### PR TITLE
Generic type bounds for FS types

### DIFF
--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -5,7 +5,7 @@ pub trait OODIOPattern<F: Field> {
     fn add_ood(self, num_samples: usize) -> Self;
 }
 
-impl<F> OODIOPattern<F> for IOPattern
+impl<F, IOPattern> OODIOPattern<F> for IOPattern
 where
     F: Field,
     IOPattern: FieldIOPattern<F>,
@@ -24,7 +24,7 @@ pub trait WhirPoWIOPattern {
     fn pow(self, bits: f64) -> Self;
 }
 
-impl WhirPoWIOPattern for IOPattern
+impl <IOPattern> WhirPoWIOPattern for IOPattern
 where
     IOPattern: PoWIOPattern,
 {

--- a/src/sumcheck/prover_not_skipping.rs
+++ b/src/sumcheck/prover_not_skipping.rs
@@ -13,7 +13,7 @@ pub trait SumcheckNotSkippingIOPattern<F: Field> {
     fn add_sumcheck(self, folding_factor: usize, pow_bits: f64) -> Self;
 }
 
-impl<F> SumcheckNotSkippingIOPattern<F> for IOPattern
+impl<F, IOPattern> SumcheckNotSkippingIOPattern<F> for IOPattern
 where
     F: Field,
     IOPattern: FieldIOPattern<F> + WhirPoWIOPattern,
@@ -101,10 +101,7 @@ where
 #[cfg(test)]
 mod tests {
     use ark_ff::Field;
-    use nimue::{
-        plugins::ark::{FieldChallenges, FieldIOPattern, FieldReader},
-        IOPattern, ProofResult,
-    };
+    use nimue::{plugins::ark::{FieldChallenges, FieldIOPattern, FieldReader}, IOPattern, Merlin, ProofResult};
     use nimue_pow::blake3::Blake3PoW;
 
     use crate::{
@@ -155,7 +152,7 @@ mod tests {
         );
 
         let folding_randomness_1 =
-            prover.compute_sumcheck_polynomials::<Blake3PoW>(&mut merlin, folding_factor, 0.)?;
+            prover.compute_sumcheck_polynomials::<Blake3PoW, Merlin>(&mut merlin, folding_factor, 0.)?;
 
         // Compute the answers
         let folded_poly_1 = polynomial.fold(&folding_randomness_1);
@@ -241,14 +238,14 @@ mod tests {
         );
 
         let folding_randomness_1 =
-            prover.compute_sumcheck_polynomials::<Blake3PoW>(&mut merlin, folding_factor, 0.)?;
+            prover.compute_sumcheck_polynomials::<Blake3PoW, Merlin>(&mut merlin, folding_factor, 0.)?;
 
         let folded_poly_1 = polynomial.fold(&folding_randomness_1);
         let fold_eval = folded_poly_1.evaluate_at_extension(&fold_point);
         prover.add_new_equality(&[fold_point.clone()], &combination_randomness, &[fold_eval]);
 
         let folding_randomness_2 =
-            prover.compute_sumcheck_polynomials::<Blake3PoW>(&mut merlin, folding_factor, 0.)?;
+            prover.compute_sumcheck_polynomials::<Blake3PoW, Merlin>(&mut merlin, folding_factor, 0.)?;
 
         // Compute the answers
         let folded_poly_1 = polynomial.fold(&folding_randomness_1);

--- a/src/sumcheck/prover_not_skipping.rs
+++ b/src/sumcheck/prover_not_skipping.rs
@@ -1,8 +1,5 @@
 use ark_ff::Field;
-use nimue::{
-    plugins::ark::{FieldChallenges, FieldIOPattern, FieldWriter},
-    IOPattern, Merlin, ProofResult,
-};
+use nimue::{plugins::ark::{FieldChallenges, FieldIOPattern, FieldWriter}, IOPattern, ProofResult};
 use nimue_pow::{PoWChallenge, PowStrategy};
 
 use crate::{
@@ -59,7 +56,7 @@ where
         }
     }
 
-    pub fn compute_sumcheck_polynomials<S>(
+    pub fn compute_sumcheck_polynomials<S, Merlin>(
         &mut self,
         merlin: &mut Merlin,
         folding_factor: usize,
@@ -67,6 +64,7 @@ where
     ) -> ProofResult<MultilinearPoint<F>>
     where
         S: PowStrategy,
+        Merlin: FieldChallenges<F> + FieldWriter<F> + PoWChallenge,
     {
         let mut res = Vec::with_capacity(folding_factor);
 

--- a/src/whir/committer.rs
+++ b/src/whir/committer.rs
@@ -41,13 +41,13 @@ where
         Self(config)
     }
 
-    pub fn commit(
+    pub fn commit<Merlin>(
         &self,
         merlin: &mut Merlin,
         polynomial: CoefficientList<F::BasePrimeField>,
     ) -> ProofResult<Witness<F, MerkleConfig>>
     where
-        Merlin: FieldChallenges<F> + ByteWriter,
+        Merlin: FieldWriter<F> + FieldChallenges<F> + ByteWriter,
     {
         let base_domain = self.0.starting_domain.base_domain.unwrap();
         let expansion = base_domain.size() / polynomial.num_coeffs();

--- a/src/whir/iopattern.rs
+++ b/src/whir/iopattern.rs
@@ -20,7 +20,7 @@ pub trait WhirIOPattern<F: FftField> {
     ) -> Self;
 }
 
-impl<F> WhirIOPattern<F> for IOPattern
+impl<F, IOPattern> WhirIOPattern<F> for IOPattern
 where
     F: FftField,
     IOPattern: ByteIOPattern


### PR DESCRIPTION
Changes the type bounds on `prove` and `verify` to not hardcode keccak for challenges. This is required to allow these methods to work with algebraic hashes.