### PR TITLE
Generalize the type of merkle roots

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -9,7 +9,7 @@ use ark_crypto_primitives::{
 };
 use ark_ff::{FftField, Field};
 use ark_serialize::CanonicalSerialize;
-use nimue::{DefaultHash, IOPattern};
+use nimue::{Arthur, DefaultHash, IOPattern, Merlin};
 use nimue_pow::blake3::Blake3PoW;
 use whir::{
     cmdline_utils::{AvailableFields, AvailableMerkle},
@@ -25,6 +25,8 @@ use whir::{
 use serde::Serialize;
 
 use clap::Parser;
+use whir::whir::fs_utils::{DigestReader, DigestWriter};
+use whir::whir::iopattern::DigestIOPattern;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -211,6 +213,9 @@ fn run_whir<F, MerkleConfig>(
     F: FftField + CanonicalSerialize,
     MerkleConfig: Config<Leaf = [F]> + Clone,
     MerkleConfig::InnerDigest: AsRef<[u8]> + From<[u8; 32]>,
+    IOPattern: DigestIOPattern<MerkleConfig>,
+    Merlin: DigestWriter<MerkleConfig>,
+    for<'a> Arthur<'a>: DigestReader<MerkleConfig>,
 {
     let security_level = args.security_level;
     let pow_bits = args.pow_bits.unwrap();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,7 +6,7 @@ use ark_crypto_primitives::{
 };
 use ark_ff::FftField;
 use ark_serialize::CanonicalSerialize;
-use nimue::{DefaultHash, IOPattern};
+use nimue::{Arthur, DefaultHash, IOPattern, Merlin};
 use whir::{
     cmdline_utils::{AvailableFields, AvailableMerkle, WhirType},
     crypto::{
@@ -21,6 +21,8 @@ use whir::{
 use nimue_pow::blake3::Blake3PoW;
 
 use clap::Parser;
+use whir::whir::fs_utils::{DigestReader, DigestWriter};
+use whir::whir::iopattern::DigestIOPattern;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -182,6 +184,9 @@ fn run_whir<F, MerkleConfig>(
     F: FftField + CanonicalSerialize,
     MerkleConfig: Config<Leaf = [F]> + Clone,
     MerkleConfig::InnerDigest: AsRef<[u8]> + From<[u8; 32]>,
+    IOPattern: DigestIOPattern<MerkleConfig>,
+    Merlin: DigestWriter<MerkleConfig>,
+    for<'a> Arthur<'a>: DigestReader<MerkleConfig>,
 {
     match args.protocol_type {
         WhirType::PCS => run_whir_pcs::<F, MerkleConfig>(args, leaf_hash_params, two_to_one_params),
@@ -199,6 +204,9 @@ fn run_whir_as_ldt<F, MerkleConfig>(
     F: FftField + CanonicalSerialize,
     MerkleConfig: Config<Leaf = [F]> + Clone,
     MerkleConfig::InnerDigest: AsRef<[u8]> + From<[u8; 32]>,
+    IOPattern: DigestIOPattern<MerkleConfig>,
+    Merlin: DigestWriter<MerkleConfig>,
+    for<'a> Arthur<'a>: DigestReader<MerkleConfig>,
 {
     use whir::whir::{
         committer::Committer, iopattern::WhirIOPattern, parameters::WhirConfig, prover::Prover,
@@ -303,6 +311,9 @@ fn run_whir_pcs<F, MerkleConfig>(
     F: FftField + CanonicalSerialize,
     MerkleConfig: Config<Leaf = [F]> + Clone,
     MerkleConfig::InnerDigest: AsRef<[u8]> + From<[u8; 32]>,
+    IOPattern: DigestIOPattern<MerkleConfig>,
+    Merlin: DigestWriter<MerkleConfig>,
+    for<'a> Arthur<'a>: DigestReader<MerkleConfig>,
 {
     use whir::whir::{
         committer::Committer, iopattern::WhirIOPattern, parameters::WhirConfig, prover::Prover,

--- a/src/crypto/merkle_tree/keccak.rs
+++ b/src/crypto/merkle_tree/keccak.rs
@@ -6,9 +6,13 @@ use ark_crypto_primitives::{
     merkle_tree::Config,
     sponge::Absorb,
 };
+use ark_ff::Field;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use nimue::{Arthur, ByteIOPattern, ByteReader, ByteWriter, IOPattern, Merlin, ProofError, ProofResult};
 use rand::RngCore;
 use sha3::Digest;
+use crate::whir::fs_utils::{DigestReader, DigestWriter};
+use crate::whir::iopattern::DigestIOPattern;
 
 #[derive(
     Debug, Default, Clone, Copy, Eq, PartialEq, Hash, CanonicalSerialize, CanonicalDeserialize,
@@ -127,4 +131,24 @@ pub fn default_config<F: CanonicalSerialize + Send>(
     <CompressH as TwoToOneCRHScheme>::setup(rng).unwrap();
 
     ((), ())
+}
+
+impl <F: Field> DigestIOPattern<MerkleTreeParams<F>> for IOPattern {
+    fn add_digest(self, label: &str) -> Self {
+        self.add_bytes(32, label)
+    }
+}
+
+impl <F: Field> DigestWriter<MerkleTreeParams<F>> for Merlin {
+    fn add_digest(&mut self, digest: KeccakDigest) -> ProofResult<()> {
+        self.add_bytes(&digest.0).map_err(ProofError::InvalidIO)
+    }
+}
+
+impl <'a, F: Field> DigestReader<MerkleTreeParams<F>> for Arthur<'a> {
+    fn read_digest(&mut self) -> ProofResult<KeccakDigest> {
+        let mut digest = [0; 32];
+        self.fill_next_bytes(&mut digest)?;
+        Ok(KeccakDigest(digest))
+    }
 }

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -1,5 +1,5 @@
 use ark_ff::Field;
-use nimue::{plugins::ark::FieldIOPattern, IOPattern};
+use nimue::plugins::ark::FieldIOPattern;
 use nimue_pow::PoWIOPattern;
 pub trait OODIOPattern<F: Field> {
     fn add_ood(self, num_samples: usize) -> Self;

--- a/src/sumcheck/prover_not_skipping.rs
+++ b/src/sumcheck/prover_not_skipping.rs
@@ -1,5 +1,5 @@
 use ark_ff::Field;
-use nimue::{plugins::ark::{FieldChallenges, FieldIOPattern, FieldWriter}, IOPattern, ProofResult};
+use nimue::{plugins::ark::{FieldChallenges, FieldIOPattern, FieldWriter}, ProofResult};
 use nimue_pow::{PoWChallenge, PowStrategy};
 
 use crate::{

--- a/src/whir/committer.rs
+++ b/src/whir/committer.rs
@@ -9,9 +9,10 @@ use ark_ff::FftField;
 use ark_poly::EvaluationDomain;
 use nimue::{
     plugins::ark::{FieldChallenges, FieldWriter},
-    ByteWriter, Merlin, ProofResult,
+    ByteWriter, ProofResult,
 };
 
+use crate::whir::fs_utils::DigestWriter;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -34,8 +35,7 @@ where
 impl<F, MerkleConfig, PowStrategy> Committer<F, MerkleConfig, PowStrategy>
 where
     F: FftField,
-    MerkleConfig: Config<Leaf = [F]>,
-    MerkleConfig::InnerDigest: AsRef<[u8]>,
+    MerkleConfig: Config<Leaf = [F]>
 {
     pub fn new(config: WhirConfig<F, MerkleConfig, PowStrategy>) -> Self {
         Self(config)
@@ -47,7 +47,7 @@ where
         polynomial: CoefficientList<F::BasePrimeField>,
     ) -> ProofResult<Witness<F, MerkleConfig>>
     where
-        Merlin: FieldWriter<F> + FieldChallenges<F> + ByteWriter,
+        Merlin: FieldWriter<F> + FieldChallenges<F> + ByteWriter + DigestWriter<MerkleConfig>,
     {
         let base_domain = self.0.starting_domain.base_domain.unwrap();
         let expansion = base_domain.size() / polynomial.num_coeffs();
@@ -88,7 +88,7 @@ where
 
         let root = merkle_tree.root();
 
-        merlin.add_bytes(root.as_ref())?;
+        merlin.add_digest(root)?;
 
         let mut ood_points = vec![F::ZERO; self.0.committment_ood_samples];
         let mut ood_answers = Vec::with_capacity(self.0.committment_ood_samples);

--- a/src/whir/fs_utils.rs
+++ b/src/whir/fs_utils.rs
@@ -1,3 +1,4 @@
+use ark_crypto_primitives::merkle_tree::Config;
 use crate::utils::dedup;
 use nimue::{ByteChallenges, ProofResult};
 
@@ -23,4 +24,12 @@ where
         result % folded_domain_size
     });
     Ok(dedup(indices))
+}
+
+pub trait DigestWriter<MerkleConfig: Config> {
+    fn add_digest(&mut self, digest: MerkleConfig::InnerDigest) -> ProofResult<()>;
+}
+
+pub trait DigestReader<MerkleConfig: Config> {
+    fn read_digest(&mut self) -> ProofResult<MerkleConfig::InnerDigest>;
 }

--- a/src/whir/iopattern.rs
+++ b/src/whir/iopattern.rs
@@ -9,32 +9,36 @@ use crate::{
 
 use super::parameters::WhirConfig;
 
-pub trait WhirIOPattern<F: FftField> {
-    fn commit_statement<MerkleConfig: Config, PowStrategy>(
-        self,
-        params: &WhirConfig<F, MerkleConfig, PowStrategy>,
-    ) -> Self;
-    fn add_whir_proof<MerkleConfig: Config, PowStrategy>(
-        self,
-        params: &WhirConfig<F, MerkleConfig, PowStrategy>,
-    ) -> Self;
+pub trait DigestIOPattern<MerkleConfig: Config> {
+    fn add_digest(self, label: &str) -> Self;
 }
 
-impl<F, IOPattern> WhirIOPattern<F> for IOPattern
+pub trait WhirIOPattern<F: FftField, MerkleConfig: Config> {
+    fn commit_statement<PowStrategy>(
+        self,
+        params: &WhirConfig<F, MerkleConfig, PowStrategy>,
+    ) -> Self;
+    fn add_whir_proof<PowStrategy>(self, params: &WhirConfig<F, MerkleConfig, PowStrategy>)
+        -> Self;
+}
+
+impl<F, MerkleConfig, IOPattern> WhirIOPattern<F, MerkleConfig> for IOPattern
 where
     F: FftField,
+    MerkleConfig: Config,
     IOPattern: ByteIOPattern
         + FieldIOPattern<F>
         + SumcheckNotSkippingIOPattern<F>
         + WhirPoWIOPattern
-        + OODIOPattern<F>,
+        + OODIOPattern<F>
+        + DigestIOPattern<MerkleConfig>,
 {
-    fn commit_statement<MerkleConfig: Config, PowStrategy>(
+    fn commit_statement<PowStrategy>(
         self,
         params: &WhirConfig<F, MerkleConfig, PowStrategy>,
     ) -> Self {
         // TODO: Add params
-        let mut this = self.add_bytes(32, "merkle_digest");
+        let mut this = self.add_digest("merkle_digest");
         if params.committment_ood_samples > 0 {
             assert!(params.initial_statement);
             this = this.add_ood(params.committment_ood_samples);
@@ -42,7 +46,7 @@ where
         this
     }
 
-    fn add_whir_proof<MerkleConfig: Config, PowStrategy>(
+    fn add_whir_proof<PowStrategy>(
         mut self,
         params: &WhirConfig<F, MerkleConfig, PowStrategy>,
     ) -> Self {
@@ -62,7 +66,7 @@ where
         for r in &params.round_parameters {
             let domain_size_bytes = ((folded_domain_size * 2 - 1).ilog2() as usize + 7) / 8;
             self = self
-                .add_bytes(32, "merkle_digest")
+                .add_digest("merkle_digest")
                 .add_ood(r.ood_samples)
                 .challenge_bytes(r.num_queries * domain_size_bytes, "stir_queries")
                 .pow(r.pow_bits)

--- a/src/whir/mod.rs
+++ b/src/whir/mod.rs
@@ -8,7 +8,7 @@ pub mod iopattern;
 pub mod parameters;
 pub mod prover;
 pub mod verifier;
-mod fs_utils;
+pub mod fs_utils;
 
 #[derive(Debug, Clone, Default)]
 pub struct Statement<F> {

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -10,7 +10,7 @@ use nimue::{
 use nimue_pow::{self, PoWChallenge};
 
 use super::{parameters::WhirConfig, Statement, WhirProof};
-use crate::whir::fs_utils::get_challenge_stir_queries;
+use crate::whir::fs_utils::{get_challenge_stir_queries, DigestReader};
 use crate::{
     parameters::FoldType,
     poly_utils::{coeffs::CoefficientList, eq_poly_outside, fold::compute_fold, MultilinearPoint},
@@ -66,7 +66,6 @@ impl<F, MerkleConfig, PowStrategy> Verifier<F, MerkleConfig, PowStrategy>
 where
     F: FftField,
     MerkleConfig: Config<Leaf = [F]>,
-    MerkleConfig::InnerDigest: AsRef<[u8]> + From<[u8; 32]>,
     PowStrategy: nimue_pow::PowStrategy,
 {
     pub fn new(params: WhirConfig<F, MerkleConfig, PowStrategy>) -> Self {
@@ -81,9 +80,9 @@ where
         arthur: &mut Arthur,
     ) -> ProofResult<ParsedCommitment<F, MerkleConfig::InnerDigest>>
     where
-        Arthur: ByteReader + FieldReader<F> + FieldChallenges<F>,
+        Arthur: ByteReader + FieldReader<F> + FieldChallenges<F> + DigestReader<MerkleConfig>,
     {
-        let root: [u8; 32] = arthur.next_bytes()?;
+        let root = arthur.read_digest()?;
 
         let mut ood_points = vec![F::ZERO; self.params.committment_ood_samples];
         let mut ood_answers = vec![F::ZERO; self.params.committment_ood_samples];
@@ -93,7 +92,7 @@ where
         }
 
         Ok(ParsedCommitment {
-            root: root.into(),
+            root,
             ood_points,
             ood_answers,
         })
@@ -107,7 +106,7 @@ where
         whir_proof: &WhirProof<MerkleConfig, F>,
     ) -> ProofResult<ParsedProof<F>>
     where
-        Arthur: FieldReader<F> + FieldChallenges<F> + PoWChallenge + ByteReader + ByteChallenges,
+        Arthur: FieldReader<F> + FieldChallenges<F> + PoWChallenge + ByteReader + ByteChallenges + DigestReader<MerkleConfig>,
     {
         let mut sumcheck_rounds = Vec::new();
         let mut folding_randomness: MultilinearPoint<F>;
@@ -162,7 +161,7 @@ where
             let (merkle_proof, answers) = &whir_proof.0[r];
             let round_params = &self.params.round_parameters[r];
 
-            let new_root: [u8; 32] = arthur.next_bytes()?;
+            let new_root = arthur.read_digest()?;
 
             let mut ood_points = vec![F::ZERO; round_params.ood_samples];
             let mut ood_answers = vec![F::ZERO; round_params.ood_samples];
@@ -214,6 +213,7 @@ where
                 sumcheck_rounds.push((sumcheck_poly, folding_randomness_single));
 
                 if round_params.folding_pow_bits > 0. {
+                    println!("pow");
                     arthur.challenge_pow::<PowStrategy>(round_params.folding_pow_bits)?;
                 }
             }
@@ -235,7 +235,7 @@ where
 
             folding_randomness = new_folding_randomness;
 
-            prev_root = new_root.into();
+            prev_root = new_root.clone();
             exp_domain_gen = exp_domain_gen * exp_domain_gen;
             domain_gen_inv = domain_gen_inv * domain_gen_inv;
             domain_size /= 2;
@@ -470,7 +470,7 @@ where
         whir_proof: &WhirProof<MerkleConfig, F>,
     ) -> ProofResult<()>
     where
-        Arthur: FieldChallenges<F> + FieldReader<F> + ByteChallenges + ByteReader + PoWChallenge,
+        Arthur: FieldChallenges<F> + FieldReader<F> + ByteChallenges + ByteReader + PoWChallenge + DigestReader<MerkleConfig>,
     {
         // We first do a pass in which we rederive all the FS challenges
         // Then we will check the algebraic part (so to optimise inversions)


### PR DESCRIPTION
Another (final, I think!) step towards algebraic hash support – it lifts the requirement of merkle roots to be bytes, making them fully configurable by the clients.