### PR TITLE
refac ntt transpose test gadgets

### DIFF
--- a/src/poly_utils/sequential_lag_poly.rs
+++ b/src/poly_utils/sequential_lag_poly.rs
@@ -5,7 +5,6 @@ use ark_ff::Field;
 use super::{hypercube::BinaryHypercubePoint, MultilinearPoint};
 
 /// There is an alternative (possibly more efficient) implementation that iterates over the x in Gray code ordering.
-
 ///
 /// LagrangePolynomialIterator for a given multilinear n-dimensional `point` iterates over pairs (x, y)
 /// where x ranges over all possible {0,1}^n


### PR DESCRIPTION
`make_example_matrix` and `make_example_matrices` test gadgets are simplified to avoid dealing with matrices complexities in the setup as we only need to setup vectors for our tests. This simplifies the logic.