### PR TITLE
improve `transpose_copy_parallel` perfs

### DIFF
--- a/src/ntt/matrix.rs
+++ b/src/ntt/matrix.rs
@@ -139,7 +139,7 @@ impl<'a, T> MatrixMut<'a, T> {
     }
 
     /// returns an immutable pointer to the element at (`row`, `col`). This performs no bounds checking and provining indices out-of-bounds is UB.
-    const unsafe fn ptr_at(&self, row: usize, col: usize) -> *const T {
+    pub(crate) const unsafe fn ptr_at(&self, row: usize, col: usize) -> *const T {
         // Safe to call under the following assertion (checked by caller)
         // assert!(row < self.rows);
         // assert!(col < self.cols);
@@ -150,7 +150,7 @@ impl<'a, T> MatrixMut<'a, T> {
     }
 
     /// returns a mutable pointer to the element at (`row`, `col`). This performs no bounds checking and provining indices out-of-bounds is UB.
-    const unsafe fn ptr_at_mut(&mut self, row: usize, col: usize) -> *mut T {
+    pub(crate) const unsafe fn ptr_at_mut(&mut self, row: usize, col: usize) -> *mut T {
         // Safe to call under the following assertion (checked by caller)
         //
         // assert!(row < self.rows);

--- a/src/ntt/transpose.rs
+++ b/src/ntt/transpose.rs
@@ -52,35 +52,54 @@ fn transpose_copy<F: Sized + Copy + Send>(src: MatrixMut<F>, dst: MatrixMut<F>) 
     transpose_copy_parallel(src, dst);
 }
 
-/// Sets `dst` to the transpose of `src`. This will panic if the sizes of `src` and `dst` are not compatible.
+/// Efficient parallel matrix transposition.
+///
+/// Uses cache-friendly recursive decomposition and direct pointer manipulation for maximum
+/// performance.
 #[cfg(feature = "parallel")]
-fn transpose_copy_parallel<F: Sized + Copy + Send>(
-    src: MatrixMut<'_, F>,
-    mut dst: MatrixMut<'_, F>,
-) {
+pub fn transpose_copy_parallel<F: Copy + Send>(src: MatrixMut<'_, F>, mut dst: MatrixMut<'_, F>) {
     assert_eq!(src.rows(), dst.cols());
     assert_eq!(src.cols(), dst.rows());
-    if src.rows() * src.cols() > workload_size::<F>() {
-        // Split along longest axis and recurse.
-        // This results in a cache-oblivious algorithm.
-        let ((a, b), (x, y)) = if src.rows() > src.cols() {
-            let n = src.rows() / 2;
-            (src.split_vertical(n), dst.split_horizontal(n))
-        } else {
-            let n = src.cols() / 2;
-            (src.split_horizontal(n), dst.split_vertical(n))
-        };
-        join(
-            || transpose_copy_parallel(a, x),
-            || transpose_copy_parallel(b, y),
-        );
-    } else {
-        for i in 0..src.rows() {
-            for j in 0..src.cols() {
-                dst[(j, i)] = src[(i, j)];
+
+    let (rows, cols) = (src.rows(), src.cols());
+
+    // Direct element-wise transposition for small matrices (avoids recursion overhead)
+    if rows * cols <= 64 {
+        unsafe {
+            for i in 0..rows {
+                for j in 0..cols {
+                    *dst.ptr_at_mut(j, i) = *src.ptr_at(i, j);
+                }
             }
         }
+        return;
     }
+
+    // Determine optimal split axis
+    let (split_size, split_vertical) = if rows > cols {
+        (rows / 2, true)
+    } else {
+        (cols / 2, false)
+    };
+
+    // Split source and destination matrices accordingly
+    let ((src_a, src_b), (dst_a, dst_b)) = if split_vertical {
+        (
+            src.split_vertical(split_size),
+            dst.split_horizontal(split_size),
+        )
+    } else {
+        (
+            src.split_horizontal(split_size),
+            dst.split_vertical(split_size),
+        )
+    };
+
+    // Execute recursive transposition in parallel
+    join(
+        || transpose_copy_parallel(src_a, dst_a),
+        || transpose_copy_parallel(src_b, dst_b),
+    );
 }
 
 /// Sets `dst` to the transpose of `src`. This will panic if the sizes of `src` and `dst` are not compatible.


### PR DESCRIPTION
With this benchmark

```rust
use criterion::{Criterion, black_box, criterion_group, criterion_main};
use whir_p3::ntt::{matrix::MatrixMut, transpose::transpose_copy_parallel};

/// Creates an `M x N` matrix with elements `(row, col)` for benchmarking.
fn create_matrix(rows: usize, cols: usize) -> Vec<(usize, usize)> {
    (0..rows).flat_map(|i| (0..cols).map(move |j| (i, j))).collect()
}

/// Benchmark function for `transpose_copy_parallel`
fn benchmark_transpose_copy(c: &mut Criterion) {
    let rows = 1024;
    let cols = 512; // Rectangular matrix for non-square benchmark
    let mut src_matrix = create_matrix(rows, cols);
    let mut dst_matrix = vec![(0, 0); rows * cols]; // Empty transposed matrix

    let src_view = MatrixMut::from_mut_slice(&mut src_matrix, rows, cols);
    let dst_view = MatrixMut::from_mut_slice(&mut dst_matrix, cols, rows); // Transposed shape

    c.bench_function(&format!("transpose_copy_parallel {rows}x{cols}"), |b| {
        b.iter(|| {
            transpose_copy_parallel(black_box(src_view.clone()), black_box(dst_view.clone()));
        });
    });
}

// Register benchmark group
criterion_group!(benches, benchmark_transpose_copy);
criterion_main!(benches);
```

I obtain

```shell
   Running benches/transpose_copy.rs (target/release/deps/transpose_copy-9ac2f0f8d6ec26e9)
Gnuplot not found, using plotters backend
transpose_copy_parallel 1024x512
                        time:   [233.32 µs 241.21 µs 250.79 µs]
                        change: [-51.049% -49.121% -47.008%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
```