### PR TITLE
fix: remove const qualifier from ptr_at_mut

### DIFF
--- a/src/ntt/matrix.rs
+++ b/src/ntt/matrix.rs
@@ -150,7 +150,7 @@ impl<'a, T> MatrixMut<'a, T> {
     }
 
     /// returns a mutable pointer to the element at (`row`, `col`). This performs no bounds checking and provining indices out-of-bounds is UB.
-    pub(crate) const unsafe fn ptr_at_mut(&mut self, row: usize, col: usize) -> *mut T {
+    pub(crate) unsafe fn ptr_at_mut(&mut self, row: usize, col: usize) -> *mut T {
         // Safe to call under the following assertion (checked by caller)
         //
         // assert!(row < self.rows);


### PR DESCRIPTION
### Changes
- Removes `const` qualifier from `MatrixMut::ptr_at_mut`

### Why this is needed
Fixes E0658 compile error: mutable references in const functions are unstable