### PR TITLE
Optimize Boolean Hypercube Summation

### DIFF
--- a/src/sumcheck/mod.rs
+++ b/src/sumcheck/mod.rs
@@ -28,7 +28,7 @@ mod tests {
         let poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
         // First, check that is sums to the right value over the hypercube
-        assert_eq!(poly_1.sum_over_hypercube(), claimed_value);
+        assert_eq!(poly_1.sum_over_binary_hypercube(), claimed_value);
 
         let combination_randomness = F::from(100101);
         let folding_randomness = MultilinearPoint(vec![F::from(4999)]);
@@ -38,7 +38,7 @@ mod tests {
         let poly_2 = prover.compute_sumcheck_polynomial(folding_factor);
 
         assert_eq!(
-            poly_2.sum_over_hypercube(),
+            poly_2.sum_over_binary_hypercube(),
             combination_randomness * poly_1.evaluate_at_point(&folding_randomness)
         );
     }
@@ -67,7 +67,7 @@ mod tests {
         let poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
         assert_eq!(
-            poly_1.sum_over_hypercube(),
+            poly_1.sum_over_binary_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
@@ -97,7 +97,7 @@ mod tests {
         let poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
         // First, check that is sums to the right value over the hypercube
-        assert_eq!(poly_1.sum_over_hypercube(), claimed_value);
+        assert_eq!(poly_1.sum_over_binary_hypercube(), claimed_value);
 
         let combination_randomness = [F::from(293), F::from(42)];
         let folding_randomness = MultilinearPoint(vec![F::from(335), F::from(222)]);
@@ -116,7 +116,7 @@ mod tests {
         let poly_2 = prover.compute_sumcheck_polynomial(folding_factor);
 
         assert_eq!(
-            poly_2.sum_over_hypercube(),
+            poly_2.sum_over_binary_hypercube(),
             combination_randomness[0] * poly_1.evaluate_at_point(&folding_randomness)
                 + combination_randomness[1] * new_fold_eval
         );
@@ -127,7 +127,7 @@ mod tests {
         let poly_3 = prover.compute_sumcheck_polynomial(folding_factor);
 
         assert_eq!(
-            poly_3.sum_over_hypercube(),
+            poly_3.sum_over_binary_hypercube(),
             combination_randomness * poly_2.evaluate_at_point(&folding_randomness)
         );
     }
@@ -171,14 +171,14 @@ mod tests {
         let statement_answer = polynomial.evaluate(&statement_point);
 
         assert_eq!(
-            sumcheck_poly_1.sum_over_hypercube(),
+            sumcheck_poly_1.sum_over_binary_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
         let fold_answer = folded_poly_1.evaluate(&fold_point);
 
         assert_eq!(
-            sumcheck_poly_2.sum_over_hypercube(),
+            sumcheck_poly_2.sum_over_binary_hypercube(),
             combination_randomness[0] * sumcheck_poly_1.evaluate_at_point(&folding_randomness_1)
                 + combination_randomness[1] * fold_answer
         );
@@ -260,19 +260,19 @@ mod tests {
         let fold_answer_2 = folded_poly_2.evaluate(&fold_point_2);
 
         assert_eq!(
-            sumcheck_poly_1.sum_over_hypercube(),
+            sumcheck_poly_1.sum_over_binary_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
         assert_eq!(
-            sumcheck_poly_2.sum_over_hypercube(),
+            sumcheck_poly_2.sum_over_binary_hypercube(),
             combination_randomness_1[0] * sumcheck_poly_1.evaluate_at_point(&folding_randomness_1)
                 + combination_randomness_1[1] * fold_answer_11
                 + combination_randomness_1[2] * fold_answer_12
         );
 
         assert_eq!(
-            sumcheck_poly_3.sum_over_hypercube(),
+            sumcheck_poly_3.sum_over_binary_hypercube(),
             combination_randomness_2[0] * sumcheck_poly_2.evaluate_at_point(&folding_randomness_2)
                 + combination_randomness_2[1] * fold_answer_2
         );

--- a/src/sumcheck/mod.rs
+++ b/src/sumcheck/mod.rs
@@ -28,7 +28,7 @@ mod tests {
         let poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
         // First, check that is sums to the right value over the hypercube
-        assert_eq!(poly_1.sum_over_binary_hypercube(), claimed_value);
+        assert_eq!(poly_1.sum_over_boolean_hypercube(), claimed_value);
 
         let combination_randomness = F::from(100101);
         let folding_randomness = MultilinearPoint(vec![F::from(4999)]);
@@ -38,7 +38,7 @@ mod tests {
         let poly_2 = prover.compute_sumcheck_polynomial(folding_factor);
 
         assert_eq!(
-            poly_2.sum_over_binary_hypercube(),
+            poly_2.sum_over_boolean_hypercube(),
             combination_randomness * poly_1.evaluate_at_point(&folding_randomness)
         );
     }
@@ -67,7 +67,7 @@ mod tests {
         let poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
         assert_eq!(
-            poly_1.sum_over_binary_hypercube(),
+            poly_1.sum_over_boolean_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
@@ -97,7 +97,7 @@ mod tests {
         let poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
         // First, check that is sums to the right value over the hypercube
-        assert_eq!(poly_1.sum_over_binary_hypercube(), claimed_value);
+        assert_eq!(poly_1.sum_over_boolean_hypercube(), claimed_value);
 
         let combination_randomness = [F::from(293), F::from(42)];
         let folding_randomness = MultilinearPoint(vec![F::from(335), F::from(222)]);
@@ -116,7 +116,7 @@ mod tests {
         let poly_2 = prover.compute_sumcheck_polynomial(folding_factor);
 
         assert_eq!(
-            poly_2.sum_over_binary_hypercube(),
+            poly_2.sum_over_boolean_hypercube(),
             combination_randomness[0] * poly_1.evaluate_at_point(&folding_randomness)
                 + combination_randomness[1] * new_fold_eval
         );
@@ -127,7 +127,7 @@ mod tests {
         let poly_3 = prover.compute_sumcheck_polynomial(folding_factor);
 
         assert_eq!(
-            poly_3.sum_over_binary_hypercube(),
+            poly_3.sum_over_boolean_hypercube(),
             combination_randomness * poly_2.evaluate_at_point(&folding_randomness)
         );
     }
@@ -171,14 +171,14 @@ mod tests {
         let statement_answer = polynomial.evaluate(&statement_point);
 
         assert_eq!(
-            sumcheck_poly_1.sum_over_binary_hypercube(),
+            sumcheck_poly_1.sum_over_boolean_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
         let fold_answer = folded_poly_1.evaluate(&fold_point);
 
         assert_eq!(
-            sumcheck_poly_2.sum_over_binary_hypercube(),
+            sumcheck_poly_2.sum_over_boolean_hypercube(),
             combination_randomness[0] * sumcheck_poly_1.evaluate_at_point(&folding_randomness_1)
                 + combination_randomness[1] * fold_answer
         );
@@ -260,19 +260,19 @@ mod tests {
         let fold_answer_2 = folded_poly_2.evaluate(&fold_point_2);
 
         assert_eq!(
-            sumcheck_poly_1.sum_over_binary_hypercube(),
+            sumcheck_poly_1.sum_over_boolean_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
         assert_eq!(
-            sumcheck_poly_2.sum_over_binary_hypercube(),
+            sumcheck_poly_2.sum_over_boolean_hypercube(),
             combination_randomness_1[0] * sumcheck_poly_1.evaluate_at_point(&folding_randomness_1)
                 + combination_randomness_1[1] * fold_answer_11
                 + combination_randomness_1[2] * fold_answer_12
         );
 
         assert_eq!(
-            sumcheck_poly_3.sum_over_binary_hypercube(),
+            sumcheck_poly_3.sum_over_boolean_hypercube(),
             combination_randomness_2[0] * sumcheck_poly_2.evaluate_at_point(&folding_randomness_2)
                 + combination_randomness_2[1] * fold_answer_2
         );

--- a/src/sumcheck/proof.rs
+++ b/src/sumcheck/proof.rs
@@ -1,9 +1,6 @@
 use ark_ff::Field;
 
-use crate::{
-    poly_utils::{eq_poly3, MultilinearPoint},
-    utils::base_decomposition,
-};
+use crate::poly_utils::{eq_poly3, MultilinearPoint};
 
 // Stored in evaluation form
 #[derive(Debug, Clone)]

--- a/src/sumcheck/proof.rs
+++ b/src/sumcheck/proof.rs
@@ -36,28 +36,6 @@ where
         &self.evaluations
     }
 
-    // TODO(Gotti): Rename to sum_over_binary_hypercube for clarity?
-    // TODO(Gotti): Make more efficient; the base_decomposition and filtering is unneccessary.
-
-    /// Returns the sum of evaluations of f, when summed only over {0,1}^n_variables
-    ///
-    /// (and not over {0,1,2}^n_variable)
-    pub fn sum_over_hypercube(&self) -> F {
-        let num_evaluation_points = 3_usize.pow(self.n_variables as u32);
-
-        let mut sum = F::ZERO;
-        for point in 0..num_evaluation_points {
-            if base_decomposition(point, 3, self.n_variables)
-                .into_iter()
-                .all(|v| matches!(v, 0 | 1))
-            {
-                sum += self.evaluations[point];
-            }
-        }
-
-        sum
-    }
-
     /// Returns the sum of evaluations of f, when summed only over {0,1}^n_variables
     /// Avoids enumerating 3^n, instead only iterates 2^n
     pub fn sum_over_binary_hypercube(&self) -> F {
@@ -129,33 +107,5 @@ mod tests {
             let point = MultilinearPoint(decomp.into_iter().map(F::from).collect());
             assert_eq!(poly.evaluate_at_point(&point), poly.evaluations()[i]);
         }
-    }
-
-    #[test]
-    fn test_sum_over_hypercube_correctness_and_bench() {
-        let n = 6;
-        let evaluations: Vec<F> = (0..(3_usize.pow(n as u32)) as u64).map(F::from).collect();
-        let poly = SumcheckPolynomial::new(evaluations, n);
-
-        let sum_orig = poly.sum_over_hypercube();
-        let sum_improved = poly.sum_over_binary_hypercube();
-        assert_eq!(sum_orig, sum_improved);
-
-        let loop_count = 10;
-
-        let start = Instant::now();
-        for _ in 0..loop_count {
-            let _ = poly.sum_over_hypercube();
-        }
-        let dur_orig = start.elapsed();
-
-        let start = Instant::now();
-        for _ in 0..loop_count {
-            let _ = poly.sum_over_binary_hypercube();
-        }
-        let dur_improved = start.elapsed();
-
-        println!("  sum_over_hypercube (original) total time: {:?}", dur_orig);
-        println!("  sum_over_hypercube_improved     total time: {:?}", dur_improved);
     }
 }

--- a/src/sumcheck/proof.rs
+++ b/src/sumcheck/proof.rs
@@ -38,7 +38,7 @@ where
 
     /// Returns the sum of evaluations of f, when summed only over {0,1}^n_variables
     /// Avoids enumerating 3^n, instead only iterates 2^n
-    pub fn sum_over_binary_hypercube(&self) -> F {
+    pub fn sum_over_boolean_hypercube(&self) -> F {
         let binary_points = 2_usize.pow(self.n_variables as u32);
         let mut sum = F::ZERO;
 

--- a/src/sumcheck/proof.rs
+++ b/src/sumcheck/proof.rs
@@ -89,7 +89,6 @@ mod tests {
     use crate::{crypto::fields::Field64, poly_utils::MultilinearPoint, utils::base_decomposition};
 
     use super::SumcheckPolynomial;
-    use std::time::Instant;
 
     type F = Field64;
 

--- a/src/sumcheck/prover_not_skipping.rs
+++ b/src/sumcheck/prover_not_skipping.rs
@@ -179,12 +179,12 @@ mod tests {
         let [folding_randomness_12]: [F; 1] = arthur.challenge_scalars()?;
 
         assert_eq!(
-            sumcheck_poly_11.sum_over_binary_hypercube(),
+            sumcheck_poly_11.sum_over_boolean_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
         assert_eq!(
-            sumcheck_poly_12.sum_over_binary_hypercube(),
+            sumcheck_poly_12.sum_over_boolean_hypercube(),
             sumcheck_poly_11.evaluate_at_point(&folding_randomness_11.into())
         );
 
@@ -286,23 +286,23 @@ mod tests {
         let [folding_randomness_22]: [F; 1] = arthur.challenge_scalars()?;
 
         assert_eq!(
-            sumcheck_poly_11.sum_over_binary_hypercube(),
+            sumcheck_poly_11.sum_over_boolean_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
         assert_eq!(
-            sumcheck_poly_12.sum_over_binary_hypercube(),
+            sumcheck_poly_12.sum_over_boolean_hypercube(),
             sumcheck_poly_11.evaluate_at_point(&folding_randomness_11.into())
         );
 
         assert_eq!(
-            sumcheck_poly_21.sum_over_binary_hypercube(),
+            sumcheck_poly_21.sum_over_boolean_hypercube(),
             sumcheck_poly_12.evaluate_at_point(&folding_randomness_12.into())
                 + combination_randomness[0] * fold_answer
         );
 
         assert_eq!(
-            sumcheck_poly_22.sum_over_binary_hypercube(),
+            sumcheck_poly_22.sum_over_boolean_hypercube(),
             sumcheck_poly_21.evaluate_at_point(&folding_randomness_21.into())
         );
 

--- a/src/sumcheck/prover_not_skipping.rs
+++ b/src/sumcheck/prover_not_skipping.rs
@@ -179,12 +179,12 @@ mod tests {
         let [folding_randomness_12]: [F; 1] = arthur.challenge_scalars()?;
 
         assert_eq!(
-            sumcheck_poly_11.sum_over_hypercube(),
+            sumcheck_poly_11.sum_over_binary_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
         assert_eq!(
-            sumcheck_poly_12.sum_over_hypercube(),
+            sumcheck_poly_12.sum_over_binary_hypercube(),
             sumcheck_poly_11.evaluate_at_point(&folding_randomness_11.into())
         );
 
@@ -286,23 +286,23 @@ mod tests {
         let [folding_randomness_22]: [F; 1] = arthur.challenge_scalars()?;
 
         assert_eq!(
-            sumcheck_poly_11.sum_over_hypercube(),
+            sumcheck_poly_11.sum_over_binary_hypercube(),
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
         assert_eq!(
-            sumcheck_poly_12.sum_over_hypercube(),
+            sumcheck_poly_12.sum_over_binary_hypercube(),
             sumcheck_poly_11.evaluate_at_point(&folding_randomness_11.into())
         );
 
         assert_eq!(
-            sumcheck_poly_21.sum_over_hypercube(),
+            sumcheck_poly_21.sum_over_binary_hypercube(),
             sumcheck_poly_12.evaluate_at_point(&folding_randomness_12.into())
                 + combination_randomness[0] * fold_answer
         );
 
         assert_eq!(
-            sumcheck_poly_22.sum_over_hypercube(),
+            sumcheck_poly_22.sum_over_binary_hypercube(),
             sumcheck_poly_21.evaluate_at_point(&folding_randomness_21.into())
         );
 

--- a/src/sumcheck/prover_single.rs
+++ b/src/sumcheck/prover_single.rs
@@ -260,7 +260,7 @@ mod tests {
         let poly_1 = prover.compute_sumcheck_polynomial();
 
         // First, check that is sums to the right value over the hypercube
-        assert_eq!(poly_1.sum_over_binary_hypercube(), claimed_value);
+        assert_eq!(poly_1.sum_over_boolean_hypercube(), claimed_value);
 
         let combination_randomness = F::from(100101);
         let folding_randomness = MultilinearPoint(vec![F::from(4999)]);
@@ -270,7 +270,7 @@ mod tests {
         let poly_2 = prover.compute_sumcheck_polynomial();
 
         assert_eq!(
-            poly_2.sum_over_binary_hypercube(),
+            poly_2.sum_over_boolean_hypercube(),
             combination_randomness * poly_1.evaluate_at_point(&folding_randomness)
         );
     }

--- a/src/sumcheck/prover_single.rs
+++ b/src/sumcheck/prover_single.rs
@@ -260,7 +260,7 @@ mod tests {
         let poly_1 = prover.compute_sumcheck_polynomial();
 
         // First, check that is sums to the right value over the hypercube
-        assert_eq!(poly_1.sum_over_hypercube(), claimed_value);
+        assert_eq!(poly_1.sum_over_binary_hypercube(), claimed_value);
 
         let combination_randomness = F::from(100101);
         let folding_randomness = MultilinearPoint(vec![F::from(4999)]);
@@ -270,7 +270,7 @@ mod tests {
         let poly_2 = prover.compute_sumcheck_polynomial();
 
         assert_eq!(
-            poly_2.sum_over_hypercube(),
+            poly_2.sum_over_binary_hypercube(),
             combination_randomness * poly_1.evaluate_at_point(&folding_randomness)
         );
     }

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -494,7 +494,7 @@ where
         if let Some(round) = parsed.initial_sumcheck_rounds.first() {
             // Check the first polynomial
             let (mut prev_poly, mut randomness) = round.clone();
-            if prev_poly.sum_over_hypercube()
+            if prev_poly.sum_over_binary_hypercube()
                 != parsed_commitment
                     .ood_answers
                     .iter()
@@ -509,7 +509,7 @@ where
 
             // Check the rest of the rounds
             for (sumcheck_poly, new_randomness) in &parsed.initial_sumcheck_rounds[1..] {
-                if sumcheck_poly.sum_over_hypercube()
+                if sumcheck_poly.sum_over_binary_hypercube()
                     != prev_poly.evaluate_at_point(&randomness.into())
                 {
                     return Err(ProofError::InvalidProof);
@@ -537,7 +537,7 @@ where
                     .map(|(val, rand)| val * rand)
                     .sum::<F>();
 
-            if sumcheck_poly.sum_over_hypercube() != claimed_sum {
+            if sumcheck_poly.sum_over_binary_hypercube() != claimed_sum {
                 return Err(ProofError::InvalidProof);
             }
 
@@ -546,7 +546,7 @@ where
             // Check the rest of the round
             for (sumcheck_poly, new_randomness) in &round.sumcheck_rounds[1..] {
                 let (prev_poly, randomness) = prev.unwrap();
-                if sumcheck_poly.sum_over_hypercube()
+                if sumcheck_poly.sum_over_binary_hypercube()
                     != prev_poly.evaluate_at_point(&randomness.into())
                 {
                     return Err(ProofError::InvalidProof);
@@ -578,7 +578,7 @@ where
             let (sumcheck_poly, new_randomness) = &parsed.final_sumcheck_rounds[0].clone();
             let claimed_sum = prev_sumcheck_poly_eval;
 
-            if sumcheck_poly.sum_over_hypercube() != claimed_sum {
+            if sumcheck_poly.sum_over_binary_hypercube() != claimed_sum {
                 return Err(ProofError::InvalidProof);
             }
 
@@ -587,7 +587,7 @@ where
             // Check the rest of the round
             for (sumcheck_poly, new_randomness) in &parsed.final_sumcheck_rounds[1..] {
                 let (prev_poly, randomness) = prev.unwrap();
-                if sumcheck_poly.sum_over_hypercube()
+                if sumcheck_poly.sum_over_binary_hypercube()
                     != prev_poly.evaluate_at_point(&randomness.into())
                 {
                     return Err(ProofError::InvalidProof);

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -494,7 +494,7 @@ where
         if let Some(round) = parsed.initial_sumcheck_rounds.first() {
             // Check the first polynomial
             let (mut prev_poly, mut randomness) = round.clone();
-            if prev_poly.sum_over_binary_hypercube()
+            if prev_poly.sum_over_boolean_hypercube()
                 != parsed_commitment
                     .ood_answers
                     .iter()
@@ -509,7 +509,7 @@ where
 
             // Check the rest of the rounds
             for (sumcheck_poly, new_randomness) in &parsed.initial_sumcheck_rounds[1..] {
-                if sumcheck_poly.sum_over_binary_hypercube()
+                if sumcheck_poly.sum_over_boolean_hypercube()
                     != prev_poly.evaluate_at_point(&randomness.into())
                 {
                     return Err(ProofError::InvalidProof);
@@ -537,7 +537,7 @@ where
                     .map(|(val, rand)| val * rand)
                     .sum::<F>();
 
-            if sumcheck_poly.sum_over_binary_hypercube() != claimed_sum {
+            if sumcheck_poly.sum_over_boolean_hypercube() != claimed_sum {
                 return Err(ProofError::InvalidProof);
             }
 
@@ -546,7 +546,7 @@ where
             // Check the rest of the round
             for (sumcheck_poly, new_randomness) in &round.sumcheck_rounds[1..] {
                 let (prev_poly, randomness) = prev.unwrap();
-                if sumcheck_poly.sum_over_binary_hypercube()
+                if sumcheck_poly.sum_over_boolean_hypercube()
                     != prev_poly.evaluate_at_point(&randomness.into())
                 {
                     return Err(ProofError::InvalidProof);
@@ -578,7 +578,7 @@ where
             let (sumcheck_poly, new_randomness) = &parsed.final_sumcheck_rounds[0].clone();
             let claimed_sum = prev_sumcheck_poly_eval;
 
-            if sumcheck_poly.sum_over_binary_hypercube() != claimed_sum {
+            if sumcheck_poly.sum_over_boolean_hypercube() != claimed_sum {
                 return Err(ProofError::InvalidProof);
             }
 
@@ -587,7 +587,7 @@ where
             // Check the rest of the round
             for (sumcheck_poly, new_randomness) in &parsed.final_sumcheck_rounds[1..] {
                 let (prev_poly, randomness) = prev.unwrap();
-                if sumcheck_poly.sum_over_binary_hypercube()
+                if sumcheck_poly.sum_over_boolean_hypercube()
                     != prev_poly.evaluate_at_point(&randomness.into())
                 {
                     return Err(ProofError::InvalidProof);


### PR DESCRIPTION
## Overview
This PR optimizes the summation over the Boolean hypercube (\{0,1\}^n) by adding a more efficient method that avoids enumerating all ternary points (\{0,1,2\}^n) and filtering them afterwards.

## Changes
- Added a new method `sum_over_boolean_hypercube()` that directly iterates through 2^n indices.
- Uses a big-endian bit reading to stay consistent with the existing ternary decomposition.

## Performance Improvement
[A quick benchmark](https://github.com/yugocabrio/whir/blob/0397a3cddbba9e257b3c46c6102053eb51f1ad46/src/sumcheck/proof.rs#L134C1-L160C6) (run in a loop of 10 iterations) shows speedups:

- Original implementation(`sum_over_hypercube`): ~1.86 ms  
- Optimized implementation(`sum_over_boolean_hypercube()`): ~0.08 ms