### PR TITLE
rm useless `is_power_of_two` util

### DIFF
--- a/src/ntt/transpose.rs
+++ b/src/ntt/transpose.rs
@@ -1,4 +1,3 @@
-use super::super::utils::is_power_of_two;
 use super::{utils::workload_size, MatrixMut};
 use std::mem::swap;
 
@@ -13,8 +12,8 @@ use rayon::join;
 /// This algorithm assumes that both rows and cols are powers of two.
 pub fn transpose<F: Sized + Copy + Send>(matrix: &mut [F], rows: usize, cols: usize) {
     debug_assert_eq!(matrix.len() % (rows * cols), 0);
-    debug_assert!(is_power_of_two(rows));
-    debug_assert!(is_power_of_two(cols));
+    debug_assert!(rows.is_power_of_two());
+    debug_assert!(cols.is_power_of_two());
     // eprintln!(
     //     "Transpose {} x {rows} x {cols} matrix.",
     //     matrix.len() / (rows * cols)
@@ -209,7 +208,7 @@ fn transpose_square_swap_parallel<F: Sized + Send>(
     debug_assert!(a.is_square());
     debug_assert_eq!(a.rows(), b.cols());
     debug_assert_eq!(a.cols(), b.rows());
-    debug_assert!(is_power_of_two(a.rows()));
+    debug_assert!(a.rows().is_power_of_two());
     debug_assert!(workload_size::<F>() >= 2);
 
     let size = a.rows();
@@ -269,7 +268,7 @@ fn transpose_square_swap_non_parallel<F: Sized>(mut a: MatrixMut<F>, mut b: Matr
     debug_assert!(a.is_square());
     debug_assert_eq!(a.rows(), b.cols());
     debug_assert_eq!(a.cols(), b.rows());
-    debug_assert!(is_power_of_two(a.rows()));
+    debug_assert!(a.rows().is_power_of_two());
     debug_assert!(workload_size::<F>() >= 2); // otherwise, we would recurse even if size == 1.
 
     let size = a.rows();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,11 +2,6 @@ use crate::ntt::transpose;
 use ark_ff::Field;
 use std::collections::BTreeSet;
 
-// checks whether the given number n is a power of two.
-pub const fn is_power_of_two(n: usize) -> bool {
-    n != 0 && n.is_power_of_two()
-}
-
 // TODO(Gotti): n_bits is a misnomer if base > 2. Should be n_limbs or sth.
 // Also, should the behaviour for value >= base^n_bits be specified as part of the API or asserted not to happen?
 // Currently, we compute the decomposition of value % (base^n_bits).
@@ -73,7 +68,7 @@ pub fn stack_evaluations<F: Field>(mut evals: Vec<F>, folding_factor: usize) -> 
 mod tests {
     use crate::utils::base_decomposition;
 
-    use super::{is_power_of_two, stack_evaluations};
+    use super::stack_evaluations;
 
     #[test]
     fn test_evaluations_stack() {
@@ -94,15 +89,6 @@ mod tests {
                 assert_eq!(f, F::from((i + j * num / fold_size) as u64));
             }
         }
-    }
-
-    #[test]
-    fn test_is_power_of_two() {
-        assert!(!is_power_of_two(0));
-        assert!(is_power_of_two(1));
-        assert!(is_power_of_two(2));
-        assert!(!is_power_of_two(3));
-        assert!(!is_power_of_two(usize::MAX));
     }
 
     #[test]


### PR DESCRIPTION
The only difference with `is_power_of_two` from the core library was that it also checks that `n` is not zero. The only places this function was used was in matrix transposition but this seems useless since the number of rows and columns should never be zero. 

As a consequence we can directly use the core `is_power_of_two` method and remove this from the utils.