### PR TITLE
rm `DefaultHash` when useless

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -9,7 +9,7 @@ use ark_crypto_primitives::{
 };
 use ark_ff::{FftField, Field};
 use ark_serialize::CanonicalSerialize;
-use nimue::{Arthur, DefaultHash, IOPattern, Merlin};
+use nimue::{Arthur, IOPattern, Merlin};
 use nimue_pow::blake3::Blake3PoW;
 use std::io::Write;
 use whir::{
@@ -284,7 +284,7 @@ fn run_whir<F, MerkleConfig>(
             println!("WARN: more PoW bits required than what specified.");
         }
 
-        let io = IOPattern::<DefaultHash>::new("🌪️")
+        let io = IOPattern::new("🌪️")
             .commit_statement(&params)
             .add_whir_proof(&params);
 
@@ -350,7 +350,7 @@ fn run_whir<F, MerkleConfig>(
             println!("WARN: more PoW bits required than what specified.");
         }
 
-        let io = IOPattern::<DefaultHash>::new("🌪️")
+        let io = IOPattern::new("🌪️")
             .commit_statement(&params)
             .add_whir_proof(&params);
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,7 +7,7 @@ use ark_crypto_primitives::{
 use ark_ff::FftField;
 use ark_ff::Field;
 use ark_serialize::CanonicalSerialize;
-use nimue::{Arthur, DefaultHash, IOPattern, Merlin};
+use nimue::{Arthur, IOPattern, Merlin};
 use whir::{
     cmdline_utils::{AvailableFields, AvailableMerkle, WhirType},
     crypto::{
@@ -262,7 +262,7 @@ fn run_whir_as_ldt<F, MerkleConfig>(
 
     let params = WhirConfig::<F, MerkleConfig, PowStrategy>::new(mv_params, whir_params);
 
-    let io = IOPattern::<DefaultHash>::new("🌪️")
+    let io = IOPattern::new("🌪️")
         .commit_statement(&params)
         .add_whir_proof(&params);
 
@@ -374,7 +374,7 @@ fn run_whir_pcs<F, MerkleConfig>(
 
     let params = WhirConfig::<F, MerkleConfig, PowStrategy>::new(mv_params, whir_params);
 
-    let io = IOPattern::<DefaultHash>::new("🌪️")
+    let io = IOPattern::new("🌪️")
         .commit_statement(&params)
         .add_whir_proof(&params);
 

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -60,11 +60,11 @@ where
 mod tests {
     use super::*;
     use crate::crypto::fields::Field64;
-    use nimue::{DefaultHash, IOPattern};
+    use nimue::IOPattern;
 
     #[test]
     fn test_add_ood() {
-        let iop = IOPattern::<DefaultHash>::new("test_protocol");
+        let iop = IOPattern::new("test_protocol");
 
         // Apply OOD query addition
         let updated_iop = <IOPattern as OODIOPattern<Field64>>::add_ood(iop.clone(), 3);
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn test_pow() {
-        let iop = IOPattern::<DefaultHash>::new("test_protocol");
+        let iop = IOPattern::new("test_protocol");
 
         // Apply PoW challenge
         let updated_iop = iop.clone().pow(10.0);

--- a/src/whir/committer.rs
+++ b/src/whir/committer.rs
@@ -157,7 +157,7 @@ mod tests {
     };
     use crate::whir::iopattern::WhirIOPattern;
     use ark_ff::UniformRand;
-    use nimue::{DefaultHash, IOPattern};
+    use nimue::IOPattern;
     use nimue_pow::blake3::Blake3PoW;
 
     #[test]
@@ -203,7 +203,7 @@ mod tests {
         let polynomial = CoefficientList::new(vec![F::rand(&mut rng); 32]);
 
         // Set up the IOPattern and initialize a Merlin transcript.
-        let io = IOPattern::<DefaultHash>::new("🌪️")
+        let io = IOPattern::new("🌪️")
             .commit_statement(&params)
             .add_whir_proof(&params);
         let mut merlin = io.to_merlin();
@@ -283,7 +283,7 @@ mod tests {
         );
 
         let polynomial = CoefficientList::new(vec![F::rand(&mut rng); 1024]); // Large polynomial
-        let io = IOPattern::<DefaultHash>::new("🌪️").commit_statement(&params);
+        let io = IOPattern::new("🌪️").commit_statement(&params);
         let mut merlin = io.to_merlin();
 
         let committer = Committer::new(params);
@@ -324,7 +324,7 @@ mod tests {
         params.committment_ood_samples = 0; // No OOD samples
 
         let polynomial = CoefficientList::new(vec![F::rand(&mut rng); 32]);
-        let io = IOPattern::<DefaultHash>::new("🌪️").commit_statement(&params);
+        let io = IOPattern::new("🌪️").commit_statement(&params);
         let mut merlin = io.to_merlin();
 
         let committer = Committer::new(params);

--- a/src/whir/mod.rs
+++ b/src/whir/mod.rs
@@ -34,7 +34,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use nimue::{DefaultHash, IOPattern};
+    use nimue::IOPattern;
     use nimue_pow::blake3::Blake3PoW;
 
     use crate::crypto::fields::Field64;
@@ -109,7 +109,7 @@ mod tests {
         let sum = linear_claim_weight.weighted_sum(&poly);
         statement.add_constraint(linear_claim_weight, sum);
 
-        let io = IOPattern::<DefaultHash>::new("🌪️")
+        let io = IOPattern::new("🌪️")
             .commit_statement(&params)
             .add_whir_proof(&params);
 


### PR DESCRIPTION
For `IOPattern`, `DefaultHash` (keccak) is already the hash by default, we don't need to specify it.