### PR TITLE
Add support for `FoldType::ProverHelps` optimization

### DIFF
--- a/src/stir_ldt/committer.rs
+++ b/src/stir_ldt/committer.rs
@@ -53,7 +53,7 @@ where
         // NOTE: This a prover helps, the following ones need to be Naive
         let folded_evals = restructure_evaluations(
             folded_evals,
-            FoldType::Naive, // This will eventually change to `FoldType::ProverHelps`.
+            self.0.fold_optimization,
             base_domain.group_gen(),
             base_domain.group_gen_inv(),
             self.0.folding_factor,

--- a/src/stir_ldt/committer.rs
+++ b/src/stir_ldt/committer.rs
@@ -1,7 +1,5 @@
 use super::parameters::StirConfig;
-use crate::{
-    ntt::expand_from_coeff, parameters::FoldType, poly_utils::fold::restructure_evaluations, utils,
-};
+use crate::{ntt::expand_from_coeff, poly_utils::fold::restructure_evaluations, utils};
 use ark_crypto_primitives::merkle_tree::{Config, MerkleTree};
 use ark_ff::{FftField, Field};
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Polynomial};

--- a/src/stir_ldt/mod.rs
+++ b/src/stir_ldt/mod.rs
@@ -1,5 +1,6 @@
 use ark_crypto_primitives::merkle_tree::{Config, MultiPath};
 use ark_ff::Field;
+use ark_poly::univariate::DensePolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 pub mod committer;
@@ -16,6 +17,7 @@ where
     MerkleConfig: Config<Leaf = [F]>,
 {
     merkle_proofs: Vec<(MultiPath<MerkleConfig>, Vec<Vec<F>>)>,
+    first_round_coeffs: Option<Vec<DensePolynomial<F>>>,
 }
 
 pub fn stir_proof_size<MerkleConfig, F>(

--- a/src/stir_ldt/mod.rs
+++ b/src/stir_ldt/mod.rs
@@ -1,6 +1,5 @@
 use ark_crypto_primitives::merkle_tree::{Config, MultiPath};
 use ark_ff::Field;
-use ark_poly::univariate::DensePolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 pub mod committer;
@@ -17,7 +16,6 @@ where
     MerkleConfig: Config<Leaf = [F]>,
 {
     merkle_proofs: Vec<(MultiPath<MerkleConfig>, Vec<Vec<F>>)>,
-    first_round_coeffs: Option<Vec<DensePolynomial<F>>>,
 }
 
 pub fn stir_proof_size<MerkleConfig, F>(

--- a/src/stir_ldt/parameters.rs
+++ b/src/stir_ldt/parameters.rs
@@ -7,7 +7,7 @@ use ark_ff::FftField;
 use crate::{
     crypto::fields::FieldWithSize,
     domain::Domain,
-    parameters::{ProtocolParameters, SoundnessType, UnivariateParameters},
+    parameters::{FoldType, ProtocolParameters, SoundnessType, UnivariateParameters},
 };
 
 #[derive(Clone)]
@@ -26,8 +26,8 @@ where
     pub(crate) starting_folding_pow_bits: f64,
 
     pub(crate) folding_factor: usize,
+    pub(crate) fold_optimization: FoldType,
     pub(crate) round_parameters: Vec<RoundConfig>,
-    // pub(crate) fold_optimisation: FoldType, Just doing prover helps
     pub(crate) final_queries: usize,
     pub(crate) final_pow_bits: f64,
     pub(crate) final_log_inv_rate: usize,
@@ -162,6 +162,7 @@ where
             starting_log_inv_rate: stir_parameters.starting_log_inv_rate,
             starting_folding_pow_bits,
             folding_factor: stir_parameters.folding_factor,
+            fold_optimization: stir_parameters.fold_optimisation,
             round_parameters,
             final_queries,
             final_pow_bits,

--- a/src/stir_ldt/prover.rs
+++ b/src/stir_ldt/prover.rs
@@ -5,8 +5,7 @@ use super::{
 };
 use crate::{
     domain::Domain,
-    parameters::FoldType,
-    poly_utils::{self, fold::restructure_evaluations, univariate::naive_interpolation},
+    poly_utils::{self},
     utils::{self, expand_randomness},
 };
 use ark_crypto_primitives::merkle_tree::{Config, MerkleTree, MultiPath};


### PR DESCRIPTION
I added the fold optimization for the first round of the prover (plus some refactoring). 

This means that if the `FoldType` is set to `ProverHelps`, then the prover interpolates over the coset, as opposed to sending the evaluations of the polynomial. This alleviates the work of the verifier, who can now simply evaluate the polynomial at the random point.

Feedback is appreciated on whether the Verifier needs to perform some extra check in this scenario.