### PR TITLE
sumcheck single: improve compress fn with bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,9 @@ rand = "0.8"
 clap = { version = "4.4.17", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-spongefish = { git = "https://github.com/arkworks-rs/spongefish", features = ["arkworks-algebra"] }
+spongefish = { git = "https://github.com/arkworks-rs/spongefish", features = [
+    "arkworks-algebra",
+] }
 spongefish-pow = { git = "https://github.com/arkworks-rs/spongefish" }
 rayon = { version = "1.10.0", optional = true }
 thiserror = "2.0"
@@ -68,6 +70,10 @@ parallel = [
 rayon = ["dep:rayon"]
 asm = ["ark-ff/asm"]
 
+# [[bench]]
+# name = "expand_from_coeff"
+# harness = false
+
 [[bench]]
-name = "expand_from_coeff"
+name = "compress"
 harness = false

--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -1,0 +1,47 @@
+use ark_ff::fields::Field;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use whir::{
+    crypto::fields::Field64 as F,
+    poly_utils::{coeffs::CoefficientList, multilinear::MultilinearPoint},
+    sumcheck::SumcheckSingle,
+    whir::statement::{Statement, Weights},
+};
+
+fn bench_compress(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compress");
+
+    for &size in &[4u64, 64, 1024, 1 << 14, 1 << 20] {
+        // Skip invalid cases
+        if size < 2 || !size.is_power_of_two() {
+            continue;
+        }
+
+        let num_vars = size.trailing_zeros() as usize;
+        let base_coeffs: Vec<_> = (0..size).map(F::from).collect();
+        let eval_point = MultilinearPoint(vec![F::from(1); num_vars]);
+        let combination_randomness = F::from(42);
+        let folding_randomness = MultilinearPoint(vec![F::from(4999)]);
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &_s| {
+            b.iter(|| {
+                // Reset everything on each iteration
+                let coeffs = CoefficientList::new(base_coeffs.clone());
+                let value = coeffs.evaluate(&eval_point);
+
+                let mut statement = Statement::new(num_vars);
+                let weights = Weights::evaluation(eval_point.clone());
+                statement.add_constraint(weights, value);
+
+                let mut prover = SumcheckSingle::new(coeffs, &statement, F::ONE);
+                let sumcheck_poly = prover.compute_sumcheck_polynomial();
+
+                prover.compress(combination_randomness, &folding_randomness, &sumcheck_poly);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_compress);
+criterion_main!(benches);

--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -10,7 +10,7 @@ use whir::{
 fn bench_compress(c: &mut Criterion) {
     let mut group = c.benchmark_group("compress");
 
-    for &size in &[4u64, 64, 1024, 1 << 14, 1 << 20] {
+    for &size in &[4u64, 64, 1024, 1 << 11, 1 << 12, 1 << 14, 1 << 20, 1 << 26] {
         // Skip invalid cases
         if size < 2 || !size.is_power_of_two() {
             continue;

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 use ark_ff::Field;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -244,50 +246,63 @@ where
     /// - Updates `sum` using `sumcheck_poly`.
     pub fn compress(
         &mut self,
-        combination_randomness: F, // Scale the initial point
+        combination_randomness: F,
         folding_randomness: &MultilinearPoint<F>,
         sumcheck_poly: &SumcheckPolynomial<F>,
     ) {
         assert_eq!(folding_randomness.num_variables(), 1);
         assert!(self.num_variables() >= 1);
 
-        let randomness = folding_randomness.0[0];
+        let r = folding_randomness.0[0];
+        let evals_p = self.evaluation_of_p.evals();
+        let evals_w = self.weights.evals();
+        let half = evals_p.len() / 2;
+
+        // SAFETY: we'll fully initialize every element exactly once
+        let mut new_p: Vec<MaybeUninit<F>> = Vec::with_capacity(half);
+        let mut new_w: Vec<MaybeUninit<F>> = Vec::with_capacity(half);
+
+        unsafe {
+            new_p.set_len(half);
+            new_w.set_len(half);
+        }
 
         #[cfg(feature = "parallel")]
-        let (evaluations_of_p, evaluations_of_eq) = rayon::join(
-            || {
-                self.evaluation_of_p
-                    .evals()
-                    .par_chunks_exact(2)
-                    .map(|at| (at[1] - at[0]) * randomness + at[0])
-                    .collect()
-            },
-            || {
-                self.weights
-                    .evals()
-                    .par_chunks_exact(2)
-                    .map(|at| (at[1] - at[0]) * randomness + at[0])
-                    .collect()
-            },
-        );
+        rayon::scope(|s| {
+            s.spawn(|_| {
+                new_p.par_iter_mut().enumerate().for_each(|(i, out)| {
+                    let a = evals_p[2 * i];
+                    let b = evals_p[2 * i + 1];
+                    *out = MaybeUninit::new((b - a) * r + a);
+                });
+            });
+            s.spawn(|_| {
+                new_w.par_iter_mut().enumerate().for_each(|(i, out)| {
+                    let a = evals_w[2 * i];
+                    let b = evals_w[2 * i + 1];
+                    *out = MaybeUninit::new((b - a) * r + a);
+                });
+            });
+        });
 
         #[cfg(not(feature = "parallel"))]
-        let (evaluations_of_p, evaluations_of_eq) = (
-            self.evaluation_of_p
-                .evals()
-                .chunks_exact(2)
-                .map(|at| (at[1] - at[0]) * randomness + at[0])
-                .collect(),
-            self.weights
-                .evals()
-                .chunks_exact(2)
-                .map(|at| (at[1] - at[0]) * randomness + at[0])
-                .collect(),
-        );
+        for i in 0..half {
+            let a = evals_p[2 * i];
+            let b = evals_p[2 * i + 1];
+            new_p[i] = MaybeUninit::new((b - a) * r + a);
+
+            let c = evals_w[2 * i];
+            let d = evals_w[2 * i + 1];
+            new_w[i] = MaybeUninit::new((d - c) * r + c);
+        }
+
+        // SAFETY: all elements were fully initialized above
+        let new_p = unsafe { std::mem::transmute::<Vec<MaybeUninit<F>>, Vec<F>>(new_p) };
+        let new_w = unsafe { std::mem::transmute::<Vec<MaybeUninit<F>>, Vec<F>>(new_w) };
 
         // Update
-        self.evaluation_of_p = EvaluationsList::new(evaluations_of_p);
-        self.weights = EvaluationsList::new(evaluations_of_eq);
+        self.evaluation_of_p = EvaluationsList::new(new_p);
+        self.weights = EvaluationsList::new(new_w);
         self.sum = combination_randomness * sumcheck_poly.evaluate_at_point(folding_randomness);
     }
 }


### PR DESCRIPTION
@WizardOfMenlo I noticed by profiling a full WHIR run, that the compress function of the sumcheck takes a lot of time in the process

![image](https://github.com/user-attachments/assets/b656ee2b-e63d-41fa-99dc-701007cf7d7a)


So I optimized it with some tricks and using some benchmarks, I've the following results:

```shell
     Running benches/compress.rs (target/release/deps/compress-6a5bbc53d07e5ee2)
Gnuplot not found, using plotters backend
compress/4              time:   [39.437 µs 39.798 µs 40.137 µs]
                        change: [-6.0949% -4.5054% -3.0623%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
compress/64             time:   [52.307 µs 53.149 µs 53.905 µs]
                        change: [-8.4101% -6.4306% -3.9277%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  5 (5.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
compress/1024           time:   [124.09 µs 125.34 µs 126.63 µs]
                        change: [-7.6221% -5.7180% -3.8935%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
compress/16384          time:   [460.49 µs 468.78 µs 477.53 µs]
                        change: [-5.3329% -4.1556% -2.9310%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
compress/1048576        time:   [8.1681 ms 8.2809 ms 8.4067 ms]
                        change: [-21.395% -17.997% -14.602%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

     Running benches/expand_from_coeff.rs (target/release/deps/expand_from_coeff-22ef1c5bc5c4ce96)

running 0 tests
```

I have another optimization idea for a followup PR concerning rounds where the polynomials are smaller than a certain threshold, even in the parallel config, we should fallback to a sequential loop because for small contexts, the setup of the parallel setting is even heavier than the sequential calculation. I think that the parallelization is only useful for the first rounds and probably less afterwards (we need to benchmark to check).