### PR TITLE
Adding support for WHIR batching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ criterion = "0.5"
 debug = true
 
 [features]
-default = ["parallel"]
+default = ["parallel", "batching" ]
 parallel = [
     "dep:rayon",
     "ark-poly/parallel",
@@ -67,6 +67,7 @@ parallel = [
 ]
 rayon = ["dep:rayon"]
 asm = ["ark-ff/asm"]
+batching = []
 
 [[bench]]
 name = "expand_from_coeff"

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -255,6 +255,7 @@ fn run_whir<F, MerkleConfig>(
         fold_optimisation,
         _pow_parameters: Default::default(),
         starting_log_inv_rate: starting_rate,
+        enable_batching: false,
     };
 
     let polynomial = CoefficientList::new(

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -257,6 +257,7 @@ fn run_whir_as_ldt<F, MerkleConfig>(
         fold_optimisation,
         _pow_parameters: Default::default(),
         starting_log_inv_rate: starting_rate,
+        enable_batching: false,
     };
 
     let params = WhirConfig::<F, MerkleConfig, PowStrategy>::new(mv_params, whir_params);
@@ -370,6 +371,7 @@ fn run_whir_pcs<F, MerkleConfig>(
         fold_optimisation,
         _pow_parameters: Default::default(),
         starting_log_inv_rate: starting_rate,
+        enable_batching: false,
     };
 
     let params = WhirConfig::<F, MerkleConfig, PowStrategy>::new(mv_params, whir_params);

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -376,6 +376,8 @@ where
     ///
     /// These define the hashing function used when combining two child nodes into a parent node.
     pub two_to_one_params: TwoToOneParam<MerkleConfig>,
+
+    pub enable_batching: bool,
 }
 
 impl<MerkleConfig, PowStrategy> Display for WhirParameters<MerkleConfig, PowStrategy>

--- a/src/whir/batching.rs
+++ b/src/whir/batching.rs
@@ -1,0 +1,796 @@
+#![cfg(feature = "batching")]
+
+///
+/// High level idea of batching multiple polynomials is as follows:
+///
+/// - Prover commits to multiple Merkle roots of evaluations of each polynomial
+///
+/// - Verifier samples a batching_randomness field element. For soundness
+///   reasons, Fiat-Shamir batching randomness must be sampled after the Merkle
+///   roots have been committed.
+///
+/// - Prover computes the weighted sum of each individual polynomial based on
+///   batching_randomness to compute a single polynomial to proceed during
+///   Sumcheck rounds and any other future round.
+///
+/// - In the first round of the proof, Prover includes the STIR queries from
+///   each individual oracle. (The STIR query indexes should be the same for all
+///   oracles.)
+///
+/// - During proof verification, for the first round, the Verifier validates
+///   each individual STIR query in the proof against individual Merkle root.
+///   Once these Merkle paths are validated, the Verifier re-derives
+///   batching_randomness and combines the STIR responses using powers of
+///   batching_randomness.
+///
+/// - After the first round, rest of the protocol proceeds as usual.
+///
+use ark_crypto_primitives::merkle_tree::{
+    Config as MTConfig, LeafParam, MerkleTree, MultiPath, TwoToOneParam,
+};
+use ark_ff::{FftField, Field};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+#[cfg(any(feature = "parallel", feature = "rayon"))]
+use rayon::prelude::*;
+use spongefish::{
+    codecs::arkworks_algebra::{
+        ByteDomainSeparator, ByteReader, ByteWriter, DeserializeField, FieldDomainSeparator,
+        FieldToUnit, UnitToField,
+    },
+    ProofError, ProofResult, UnitToBytes,
+};
+use spongefish_pow::PoWChallenge;
+
+use crate::{
+    fs_utils::{OODDomainSeparator, WhirPoWDomainSeparator},
+    poly_utils::coeffs::CoefficientList,
+    sumcheck::SumcheckSingleDomainSeparator,
+    whir::{
+        committer::{Committer, Witness},
+        domainsep::{DigestDomainSeparator, WhirDomainSeparator},
+        fs_utils::{DigestReader, DigestWriter},
+        parameters::WhirConfig,
+        prover::Prover,
+        statement::{Statement, StatementVerifier},
+        verifier::Verifier,
+        RoundZeroProofValidator, WhirCommitmentData, WhirProof, WhirProofRoundData,
+    },
+};
+
+fn fma_stir_queries<F: Field>(
+    scale_factor: F,
+    stir_queries: &[Vec<F>],
+    folded_queries: &mut [Vec<F>],
+) {
+    for (folded_vec, stir_vec) in folded_queries.iter_mut().zip(stir_queries.iter()) {
+        for (i, value) in stir_vec.iter().enumerate() {
+            folded_vec[i] += scale_factor * value
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+fn validate_stir_queries<F, MerkleConfig>(
+    batching_randomness: &F,
+    expected_stir_value: &[Vec<F>],
+    stir_list: &[(MultiPath<MerkleConfig>, Vec<Vec<F>>)],
+) -> bool
+where
+    F: Field,
+    MerkleConfig: MTConfig<Leaf = [F]>,
+{
+    if stir_list.is_empty() {
+        return true;
+    }
+
+    let (basic_indexes, mut computed_stir) = stir_list[0].clone();
+    let mut multiplier = *batching_randomness;
+
+    for (multi_path, stir_queries) in &stir_list[1..] {
+        if !multi_path
+            .leaf_indexes
+            .iter()
+            .zip(basic_indexes.leaf_indexes.iter())
+            .all(|(lhs, rhs)| lhs == rhs)
+        {
+            return false;
+        }
+
+        fma_stir_queries(multiplier, stir_queries.as_slice(), &mut computed_stir);
+        multiplier *= batching_randomness;
+    }
+
+    let result = expected_stir_value == computed_stir;
+    result
+}
+
+#[cfg(not(debug_assertions))]
+fn validate_stir_queries<F, MerkleConfig>(
+    _batching_randomness: &F,
+    _expected_stir_value: &[Vec<F>],
+    _stir_list: &[(MultiPath<MerkleConfig>, Vec<Vec<F>>)],
+) -> bool
+where
+    F: Field,
+    MerkleConfig: MTConfig<Leaf = [F]>,
+{
+    true
+}
+
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct BatchedWhirProof<MerkleConfig, F>
+where
+    MerkleConfig: MTConfig<Leaf = [F]>,
+    F: Sized + Clone + CanonicalSerialize + CanonicalDeserialize,
+{
+    ///
+    /// List of Merkle paths and the PCP slot value for each individual Merkle
+    /// tree in the batch. The order of MultiPath must match the order of roots
+    /// in the commitment.
+    ///
+    pub first_round_paths: Vec<(MultiPath<MerkleConfig>, Vec<Vec<F>>)>,
+
+    /// List of Merkle Paths after first batched round
+    pub merkle_paths: Vec<(MultiPath<MerkleConfig>, Vec<Vec<F>>)>,
+
+    /// Statement value at a random point.
+    pub statement_values_at_random_point: Vec<F>,
+}
+
+///
+/// This is the list of [Witness] structs as if each polynomial will be folded
+/// independently. The witnesses are individually committed to the FS-transcript.
+///
+pub struct BatchedWitness<F, MerkleConfig: MTConfig> {
+    pub(crate) witness_list: Vec<Witness<F, MerkleConfig>>,
+    pub(crate) batching_randomness: F,
+}
+
+impl<F, MerkleConfig> BatchedWitness<F, MerkleConfig>
+where
+    MerkleConfig: MTConfig,
+    F: Field,
+{
+    ///
+    /// Combines all polynomials and leaf nodes weighted by powers of
+    /// batching_randomness and returns the pair (batched_polynomial,
+    /// batched_oracle). This function is expensive O(2^num_variables).
+    ///
+    pub fn batch_witnesses(&self) -> (CoefficientList<F>, Vec<F>) {
+        assert!(
+            self.witness_list.len() > 1,
+            "Batched witness list should have at least 2 elements"
+        );
+
+        assert!(self.witness_list.iter().all(|wit| wit
+            .polynomial
+            .coeffs()
+            .len()
+            .is_power_of_two()
+            && wit.merkle_leaves.len().is_power_of_two()
+            && wit.polynomial.num_variables() == self.witness_list[0].polynomial.num_variables()
+            && wit.merkle_leaves.len() == self.witness_list[0].merkle_leaves.len()),);
+
+        let poly_dim = self.witness_list[0].polynomial.coeffs().len();
+        let oracle_len = self.witness_list[0].merkle_leaves.len();
+        assert!(oracle_len % poly_dim == 0);
+        let rate_factor = oracle_len / poly_dim;
+
+        let mut batched_poly: Vec<F> = self.witness_list[0].polynomial.coeffs().to_vec();
+        let mut batched_oracle: Vec<F> = self.witness_list[0].merkle_leaves.clone();
+
+        let mut multiplier = self.batching_randomness;
+
+        // This could potentially be parallelized.
+        for wit in &self.witness_list[1..] {
+            for (i, coefficient) in wit.polynomial.coeffs().iter().enumerate() {
+                batched_poly[i] += multiplier * coefficient;
+
+                for j in 0..rate_factor {
+                    let ndx = i + j * poly_dim;
+                    batched_oracle[ndx] += multiplier * wit.merkle_leaves[ndx];
+                }
+            }
+
+            multiplier *= self.batching_randomness;
+        }
+        (CoefficientList::new(batched_poly), batched_oracle)
+    }
+
+    pub fn roots(&self) -> Vec<MerkleConfig::InnerDigest> {
+        self.witness_list
+            .iter()
+            .map(|w| w.merkle_tree.root())
+            .collect()
+    }
+}
+
+pub trait BatchedDomainSeparator<F, MerkleConfig>: WhirDomainSeparator<F, MerkleConfig>
+where
+    F: FftField,
+    MerkleConfig: MTConfig,
+{
+    #[must_use]
+    fn batch_commit_statement<PowStrategy>(
+        self,
+        batch_size: u32,
+        params: &WhirConfig<F, MerkleConfig, PowStrategy>,
+    ) -> Self;
+}
+
+impl<F, MerkleConfig, DomainSeparator> BatchedDomainSeparator<F, MerkleConfig> for DomainSeparator
+where
+    F: FftField,
+    MerkleConfig: MTConfig,
+    DomainSeparator: ByteDomainSeparator
+        + FieldDomainSeparator<F>
+        + SumcheckSingleDomainSeparator<F>
+        + WhirPoWDomainSeparator
+        + OODDomainSeparator<F>
+        + DigestDomainSeparator<MerkleConfig>,
+{
+    ///
+    ///  FS Batch Commitment:
+    ///  P -> V
+    ///     32-bit (4-bytes): Number of entries in the batch
+    ///     For each batch entry:
+    ///         Merkle Root of prover-id.
+    ///
+    ///  V -> P
+    ///     Sample single scalar element
+    ///
+    fn batch_commit_statement<PowStrategy>(
+        self,
+        batch_size: u32,
+        _params: &WhirConfig<F, MerkleConfig, PowStrategy>,
+    ) -> Self {
+        // Add the number of elements that have been batched
+        let mut this = self.add_bytes(4, "batch_size");
+
+        for i in 0..batch_size {
+            let label = format!("commitment-root-{}", &i);
+
+            // Add the root of each Merkle tree
+            this = this.add_digest(&label);
+
+            // TODO: Add the OOD samples if present
+            // if params.committment_ood_samples > 0 {
+            //     assert!(params.initial_statement);
+            //     this = this.add_ood(params.committment_ood_samples);
+            // }
+        }
+
+        // Sample the batching combination randomness
+        this.challenge_scalars(1, "batching_randomness")
+    }
+}
+
+impl<F, MerkleConfig, PowStrategy> Committer<F, MerkleConfig, PowStrategy>
+where
+    F: FftField,
+    MerkleConfig: MTConfig<Leaf = [F]>,
+{
+    pub fn batch_commit<ProverFSState>(
+        &self,
+        prover_state: &mut ProverFSState,
+        polynomial_list: &[CoefficientList<F::BasePrimeField>],
+    ) -> ProofResult<BatchedWitness<F, MerkleConfig>>
+    where
+        ProverFSState: FieldToUnit<F> + UnitToField<F> + ByteWriter + DigestWriter<MerkleConfig>,
+    {
+        assert!(
+            polynomial_list.len() > 1,
+            "Batched evaluation requires more than one polynomial"
+        );
+
+        assert!(
+            polynomial_list.iter().all(|poly| {
+                poly.num_variables() == polynomial_list[0].num_variables()
+                    && poly.num_coeffs() == polynomial_list[0].num_coeffs()
+            }),
+            "Each polynomial must have same number of variables and same number of coefficients"
+        );
+
+        let batch_size = u32::try_from(polynomial_list.len()).unwrap().to_le_bytes();
+        prover_state.add_bytes(&batch_size)?;
+
+        let mut witness_list = Vec::new();
+
+        for poly in polynomial_list {
+            let individual_commitment = Committer::commit(self, prover_state, poly.clone())?;
+            witness_list.push(individual_commitment);
+        }
+
+        let [batching_randomness] = prover_state.challenge_scalars()?;
+
+        Ok(BatchedWitness {
+            witness_list,
+            batching_randomness,
+        })
+    }
+}
+
+impl<F, MerkleConfig, PowStrategy> Prover<F, MerkleConfig, PowStrategy>
+where
+    F: FftField,
+    MerkleConfig: MTConfig<Leaf = [F]>,
+    PowStrategy: spongefish_pow::PowStrategy,
+{
+    fn to_multiroot_proof(
+        &self,
+        batched_proof: WhirProof<MerkleConfig, F>,
+        commitment: BatchedWitness<F, MerkleConfig>,
+    ) -> ProofResult<BatchedWhirProof<MerkleConfig, F>> {
+        assert!(
+            batched_proof.merkle_paths.len() > 0,
+            "There must be at least one merkle path"
+        );
+
+        let fold_sz = 1 << self.0.folding_factor.at_round(0);
+        let mut first_round_paths: Vec<(MultiPath<MerkleConfig>, Vec<Vec<F>>)> =
+            Vec::with_capacity(commitment.witness_list.len());
+
+        let ((batched_mt, batched_stir), rest) =
+            batched_proof.merkle_paths.as_slice().split_first().unwrap();
+        let stir_indexes = batched_mt.leaf_indexes.clone();
+
+        for merkle_tree in commitment.witness_list {
+            let paths = merkle_tree
+                .merkle_tree
+                .generate_multi_proof(stir_indexes.clone())
+                .map_err(|_| ProofError::InvalidProof)?;
+
+            let answers: Vec<_> = stir_indexes
+                .iter()
+                .map(|i| merkle_tree.merkle_leaves[i * fold_sz..(i + 1) * fold_sz].to_vec())
+                .collect();
+
+            first_round_paths.push((paths, answers));
+        }
+
+        assert!(
+            validate_stir_queries(
+                &commitment.batching_randomness,
+                &batched_stir,
+                &first_round_paths,
+            ),
+            "The computed value of STIR queries must match the value in the leaf nodes"
+        );
+
+        Ok(BatchedWhirProof {
+            first_round_paths,
+            merkle_paths: rest.into(),
+            statement_values_at_random_point: batched_proof.statement_values_at_random_point,
+        })
+    }
+
+    pub fn batch_prove<ProverState>(
+        &self,
+        prover_state: &mut ProverState,
+        statement: Statement<F>,
+        witnesses: BatchedWitness<F, MerkleConfig>,
+    ) -> ProofResult<BatchedWhirProof<MerkleConfig, F>>
+    where
+        ProverState: UnitToField<F>
+            + FieldToUnit<F>
+            + UnitToBytes
+            + spongefish_pow::PoWChallenge
+            + DigestWriter<MerkleConfig>,
+    {
+        assert!(self.validate_parameters() && self.validate_statement(&statement));
+
+        assert!(
+            witnesses.witness_list.len() > 1
+                && witnesses
+                    .witness_list
+                    .iter()
+                    .all(|w| self.validate_witness(w))
+        );
+
+        let fold_size = 1 << self.0.folding_factor.at_round(0);
+        let (batched_poly, batched_oracle) = witnesses.batch_witnesses();
+
+        // Chunk evaluations into leaves for Merkle tree construction.
+        #[cfg(not(feature = "parallel"))]
+        let leafs_iter = batched_oracle.chunks_exact(fold_size);
+        #[cfg(feature = "parallel")]
+        let leafs_iter = batched_oracle.par_chunks_exact(fold_size);
+
+        // Construct the a fake Merkle tree. This is strictly not necessary
+        let batched_tree = MerkleTree::<MerkleConfig>::new(
+            &self.0.leaf_hash_params,
+            &self.0.two_to_one_params,
+            leafs_iter,
+        )
+        .unwrap();
+
+        let batched_witness = Witness {
+            polynomial: batched_poly,
+            merkle_leaves: batched_oracle,
+            merkle_tree: batched_tree,
+            ood_points: vec![],
+            ood_answers: vec![],
+        };
+
+        let proof = self.prove(prover_state, statement, batched_witness)?;
+        self.to_multiroot_proof(proof, witnesses)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(crate) struct ParsedBatchCommitment<F, D> {
+    root: Vec<D>,
+    batching_randomness: F,
+    ood_points: Vec<F>,
+    ood_answers: Vec<F>,
+}
+
+impl<F, M: MTConfig> WhirCommitmentData<F, M> for ParsedBatchCommitment<F, M::InnerDigest>
+where
+    F: Clone,
+{
+    ///
+    /// The committed root returned is the root of the first tree. This is just
+    /// a dummy value.
+    ///
+    fn committed_root(&self) -> &<M as MTConfig>::InnerDigest {
+        &self.root[0]
+    }
+
+    fn ood_data(&self) -> (&[F], &[F]) {
+        (&self.ood_points, &self.ood_answers)
+    }
+
+    fn batching_randomness(&self) -> Option<F> {
+        Some(self.batching_randomness.clone())
+    }
+}
+
+impl<F, MerkleConfig> RoundZeroProofValidator<ParsedBatchCommitment<F, MerkleConfig::InnerDigest>>
+    for BatchedWhirProof<MerkleConfig, F>
+where
+    MerkleConfig: MTConfig<Leaf = [F]>,
+    F: Sized + Clone + ark_serialize::CanonicalSerialize + ark_serialize::CanonicalDeserialize,
+{
+    type MerkleConfig = MerkleConfig;
+    fn validate_first_round(
+        &self,
+        commitment: &ParsedBatchCommitment<F, MerkleConfig::InnerDigest>,
+        stir_challenges_indexes: &[usize],
+        leaf_hash: &LeafParam<MerkleConfig>,
+        inner_node_hash: &TwoToOneParam<MerkleConfig>,
+    ) -> bool {
+        commitment.root.len() == self.first_round_paths.len()
+            && self
+                .first_round_paths
+                .iter()
+                .zip(commitment.root.iter())
+                .all(|((path, answers), root_hash)| {
+                    path.verify(
+                        leaf_hash,
+                        inner_node_hash,
+                        root_hash,
+                        answers.iter().map(|a| a.as_ref()),
+                    )
+                    .unwrap()
+                        && path.leaf_indexes == *stir_challenges_indexes
+                })
+    }
+}
+
+impl<F, MerkleConfig> WhirProofRoundData<F, MerkleConfig> for BatchedWhirProof<MerkleConfig, F>
+where
+    MerkleConfig: MTConfig<Leaf = [F]>,
+    F: Sized + Clone + CanonicalSerialize + CanonicalDeserialize + Field,
+{
+    //
+    // The Merkle paths for round-0 is the path of first oracle. Use
+    // RoundZeroProofValidator trait to validate the 0-th round. The leaf
+    // node data is combined using the powers of batching randomness
+    //
+    fn round_data(
+        &self,
+        whir_round: usize,
+        batching_randomness: Option<F>,
+    ) -> (MultiPath<MerkleConfig>, Vec<Vec<F>>) {
+        assert!(whir_round <= self.merkle_paths.len());
+        if whir_round == 0 {
+            let batching_randomness = batching_randomness.unwrap();
+            let mut multiplier = batching_randomness;
+            let (merkle_paths, mut result) = self.first_round_paths[0].clone();
+
+            for (_, leaf) in &self.first_round_paths[1..] {
+                fma_stir_queries(multiplier, leaf.as_slice(), result.as_mut_slice());
+                multiplier *= batching_randomness;
+            }
+
+            (merkle_paths, result)
+        } else {
+            self.merkle_paths[whir_round - 1].clone()
+        }
+    }
+
+    fn statement_values(&self) -> &[F] {
+        &self.statement_values_at_random_point
+    }
+}
+
+impl<F, MerkleConfig, PowStrategy> Verifier<F, MerkleConfig, PowStrategy>
+where
+    F: FftField,
+    MerkleConfig: MTConfig<Leaf = [F]>,
+    PowStrategy: spongefish_pow::PowStrategy,
+{
+    #[allow(dead_code)]
+    pub(crate) fn parse_batched_commitment<VerifierState>(
+        &self,
+        expected_batch_size: usize,
+        verifier_state: &mut VerifierState,
+    ) -> ProofResult<ParsedBatchCommitment<F, MerkleConfig::InnerDigest>>
+    where
+        VerifierState: UnitToBytes
+            + DeserializeField<F>
+            + UnitToField<F>
+            + DigestReader<MerkleConfig>
+            + ByteReader,
+    {
+        let mut batch_size_le_bytes: [u8; 4] = [0, 0, 0, 0];
+        verifier_state.fill_next_bytes(&mut batch_size_le_bytes)?;
+        let batch_size = u32::from_le_bytes(batch_size_le_bytes) as usize;
+
+        if batch_size != expected_batch_size {
+            return Err(ProofError::InvalidProof);
+        }
+
+        let mut roots = Vec::<MerkleConfig::InnerDigest>::with_capacity(batch_size);
+
+        for _ in 0..batch_size {
+            // Order is important here
+            let root = verifier_state.read_digest()?;
+            roots.push(root);
+        }
+
+        // Re-derive batching randomness
+
+        let [batching_randomness] = verifier_state.challenge_scalars()?;
+
+        Ok(ParsedBatchCommitment {
+            root: roots,
+            batching_randomness,
+            ood_points: vec![],
+            ood_answers: vec![],
+        })
+    }
+
+    pub fn verify_batched<VerifierState>(
+        &self,
+        verifier_state: &mut VerifierState,
+        statement: &StatementVerifier<F>,
+        expected_batch_size: usize,
+        whir_proof: &BatchedWhirProof<MerkleConfig, F>,
+    ) -> ProofResult<()>
+    where
+        VerifierState: UnitToBytes
+            + UnitToField<F>
+            + DeserializeField<F>
+            + PoWChallenge
+            + DigestReader<MerkleConfig>
+            + ByteReader,
+    {
+        // Parse commitment
+        let parsed_commitment =
+            self.parse_batched_commitment(expected_batch_size, verifier_state)?;
+
+        // Parse proof and validate it STIR queries against the committed Merkle roots.
+        let parsed_proof = self.parse_proof(
+            verifier_state,
+            &parsed_commitment,
+            whir_proof,
+            statement.constraints.len(),
+        )?;
+
+        // Verify generically
+        self.verify_parsed(statement, &parsed_commitment, &parsed_proof)
+    }
+}
+
+#[cfg(test)]
+mod batching_tests {
+    use ark_ff::Field;
+    use ark_std::UniformRand;
+    use spongefish::DomainSeparator;
+    use spongefish_pow::blake3::Blake3PoW;
+
+    use super::*;
+    use crate::{
+        crypto::{fields::Field64, merkle_tree::blake3 as merkle_tree},
+        parameters::{
+            FoldType, FoldingFactor, MultivariateParameters, SoundnessType, WhirParameters,
+        },
+        poly_utils::{
+            coeffs::CoefficientList, evals::EvaluationsList, multilinear::MultilinearPoint,
+        },
+        whir::{
+            committer::Committer,
+            domainsep::WhirDomainSeparator,
+            parameters::WhirConfig,
+            prover::Prover,
+            statement::{Statement, StatementVerifier, Weights},
+            verifier::Verifier,
+        },
+    };
+
+    /// Merkle tree configuration type for commitment layers.
+    type MerkleConfig = merkle_tree::MerkleTreeParams<F>;
+    /// PoW strategy used for grinding challenges in Fiat-Shamir transcript.
+    type PowStrategy = Blake3PoW;
+    /// Field type used in the tests.
+    type F = Field64;
+
+    /// Run a complete WHIR STARK proof lifecycle: commit, prove, and verify.
+    ///
+    /// This function:
+    /// - builds a multilinear polynomial with a specified number of variables,
+    /// - constructs a STARK statement with constraints based on evaluations and linear relations,
+    /// - commits to the polynomial using a Merkle-based commitment scheme,
+    /// - generates a proof using the WHIR prover,
+    /// - verifies the proof using the WHIR verifier.
+    fn make_batched_whir_things(
+        num_variables: usize,
+        folding_factor: FoldingFactor,
+        num_points: usize,
+        soundness_type: SoundnessType,
+        pow_bits: usize,
+        fold_type: FoldType,
+    ) {
+        println!("Test parameters: ");
+        println!("  num_variables  : {}", num_variables);
+        println!("  folding_factor : {:?}", &folding_factor);
+        println!("  num_points     : {:?}", num_points);
+        println!("  soundness_type : {:?}", soundness_type);
+        println!("  pow_bits       : {}", pow_bits);
+        println!("  fold_type      : {}", fold_type);
+        println!("");
+
+        // Number of coefficients in the multilinear polynomial (2^num_variables)
+        let num_coeffs = 1 << num_variables;
+
+        // Randomness source
+        let mut rng = ark_std::test_rng();
+        // Generate Merkle parameters: hash function and compression function
+        let (leaf_hash_params, two_to_one_params) = merkle_tree::default_config::<F>(&mut rng);
+
+        // Configure multivariate polynomial parameters
+        let mv_params = MultivariateParameters::new(num_variables);
+
+        // Configure the WHIR protocol parameters
+        let whir_params = WhirParameters::<MerkleConfig, PowStrategy> {
+            initial_statement: true,
+            security_level: 32,
+            pow_bits,
+            folding_factor,
+            leaf_hash_params,
+            two_to_one_params,
+            soundness_type,
+            _pow_parameters: Default::default(),
+            starting_log_inv_rate: 1,
+            fold_optimisation: fold_type,
+            enable_batching: true,
+        };
+
+        // Build global configuration from multivariate + protocol parameters
+        let params = WhirConfig::new(mv_params, whir_params);
+
+        // Define the multilinear polynomial: constant 1 across all inputs
+        let poly1 = CoefficientList::new(vec![F::ONE; num_coeffs]);
+
+        // Define the multilinear polynomial: random
+        let poly2 = CoefficientList::new(vec![F::rand(&mut rng); num_coeffs]);
+
+        // Construct a coefficient vector for linear sumcheck constraint
+        let weight_poly = CoefficientList::new((0..1 << num_variables).map(F::from).collect());
+
+        // Generate `num_points` random points in the multilinear domain
+        let points: Vec<_> = (0..num_points)
+            .map(|_| MultilinearPoint::rand(&mut rng, num_variables))
+            .collect();
+
+        // Define the Fiat-Shamir IOPattern for committing and proving
+        let io = DomainSeparator::new("🌪️")
+            .batch_commit_statement(2, &params)
+            .add_whir_proof(&params);
+
+        // println!("IO Domain Separator: {:?}", str::from_utf8(io.as_bytes()));
+        // Initialize the Merlin transcript from the IOPattern
+        let mut prover_state = io.to_prover_state();
+
+        // Create a commitment to the polynomial and generate auxiliary witness data
+        let committer = Committer::new(params.clone());
+        let batched_witness = committer
+            .batch_commit(&mut prover_state, &[poly1, poly2])
+            .unwrap();
+
+        // Get the batched polynomial
+        let (batched_poly, _) = batched_witness.batch_witnesses();
+
+        // Initialize a statement with no constraints yet
+        let mut statement = Statement::new(num_variables);
+
+        // For each random point, evaluate the polynomial and create a constraint
+        for point in &points {
+            let eval = batched_poly.evaluate(point);
+            let weights = Weights::evaluation(point.clone());
+            statement.add_constraint(weights, eval);
+        }
+
+        // Define weights for linear combination
+        let linear_claim_weight = Weights::linear(weight_poly.into());
+
+        // Convert polynomial to extension field representation
+        let poly = EvaluationsList::from(batched_poly.clone().to_extension());
+
+        // Compute the weighted sum of the polynomial (for sumcheck)
+        let sum = linear_claim_weight.weighted_sum(&poly);
+
+        // Add linear constraint to the statement
+        statement.add_constraint(linear_claim_weight, sum);
+
+        // Instantiate the prover with the given parameters
+        let prover = Prover(params.clone());
+
+        // Extract verifier-side version of the statement (only public data)
+        let statement_verifier = StatementVerifier::from_statement(&statement);
+
+        // Generate a STARK proof for the given statement and witness
+        let proof = prover
+            .batch_prove(&mut prover_state, statement, batched_witness)
+            .unwrap();
+
+        // Create a verifier with matching parameters
+        let verifier = Verifier::new(params);
+
+        // Reconstruct verifier's view of the transcript using the IOPattern and prover's data
+        let mut verifier_state = io.to_verifier_state(prover_state.narg_string());
+
+        // Verify that the generated proof satisfies the statement
+        assert!(verifier
+            .verify_batched(&mut verifier_state, &statement_verifier, 2, &proof)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_whir() {
+        let folding_factors = [4, 3, 2, 1];
+        let soundness_type = [
+            SoundnessType::ConjectureList,
+            SoundnessType::ProvableList,
+            SoundnessType::UniqueDecoding,
+        ];
+        let fold_types = [FoldType::Naive, FoldType::ProverHelps];
+        let num_points = [0, 1, 2];
+        let pow_bits = [0, 5, 10];
+
+        for folding_factor in folding_factors {
+            let num_variables = folding_factor..=3 * folding_factor;
+            for num_variable in num_variables {
+                for fold_type in fold_types {
+                    for num_points in num_points {
+                        for soundness_type in soundness_type {
+                            for pow_bits in pow_bits {
+                                make_batched_whir_things(
+                                    num_variable,
+                                    FoldingFactor::Constant(folding_factor),
+                                    num_points,
+                                    soundness_type,
+                                    pow_bits,
+                                    fold_type,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/whir/committer.rs
+++ b/src/whir/committer.rs
@@ -42,7 +42,9 @@ where
 /// and constructs a Merkle tree from the resulting values.
 ///
 /// It provides a commitment that can be used for proof generation and verification.
-pub struct Committer<F, MerkleConfig, PowStrategy>(WhirConfig<F, MerkleConfig, PowStrategy>)
+pub struct Committer<F, MerkleConfig, PowStrategy>(
+    pub(crate) WhirConfig<F, MerkleConfig, PowStrategy>,
+)
 where
     F: FftField,
     MerkleConfig: Config;
@@ -119,7 +121,6 @@ where
         let root = merkle_tree.root();
         prover_state.add_digest(root)?;
 
-        // Handle OOD (Out-Of-Domain) samples
         let (ood_points, ood_answers) = sample_ood_points(
             prover_state,
             self.0.committment_ood_samples,
@@ -187,6 +188,7 @@ mod tests {
             fold_optimisation: FoldType::ProverHelps,
             _pow_parameters: std::marker::PhantomData,
             starting_log_inv_rate: starting_rate,
+            enable_batching: false,
         };
 
         // Define multivariate parameters for the polynomial.
@@ -275,6 +277,7 @@ mod tests {
                 fold_optimisation: FoldType::ProverHelps,
                 _pow_parameters: Default::default(),
                 starting_log_inv_rate: 1,
+                enable_batching: false,
             },
         );
 
@@ -314,6 +317,7 @@ mod tests {
                 fold_optimisation: FoldType::ProverHelps,
                 _pow_parameters: Default::default(),
                 starting_log_inv_rate: 1,
+                enable_batching: false,
             },
         );
 

--- a/src/whir/domainsep.rs
+++ b/src/whir/domainsep.rs
@@ -71,6 +71,7 @@ where
         for (round, r) in params.round_parameters.iter().enumerate() {
             let folded_domain_size = domain_size >> params.folding_factor.at_round(round);
             let domain_size_bytes = ((folded_domain_size * 2 - 1).ilog2() as usize).div_ceil(8);
+
             self = self
                 .add_digest("merkle_digest")
                 .add_ood(r.ood_samples)

--- a/src/whir/parameters.rs
+++ b/src/whir/parameters.rs
@@ -49,6 +49,9 @@ where
     // Merkle tree parameters
     pub leaf_hash_params: LeafParam<MerkleConfig>,
     pub two_to_one_params: TwoToOneParam<MerkleConfig>,
+
+    // Batching related flag
+    pub enable_batching: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -91,18 +94,19 @@ where
 
         let log_eta_start = Self::log_eta(whir_parameters.soundness_type, log_inv_rate);
 
-        let committment_ood_samples = if whir_parameters.initial_statement {
-            Self::ood_samples(
-                whir_parameters.security_level,
-                whir_parameters.soundness_type,
-                num_variables,
-                log_inv_rate,
-                log_eta_start,
-                field_size_bits,
-            )
-        } else {
-            0
-        };
+        let committment_ood_samples =
+            if whir_parameters.initial_statement && !whir_parameters.enable_batching {
+                Self::ood_samples(
+                    whir_parameters.security_level,
+                    whir_parameters.soundness_type,
+                    num_variables,
+                    log_inv_rate,
+                    log_eta_start,
+                    field_size_bits,
+                )
+            } else {
+                0
+            };
 
         let starting_folding_pow_bits = if whir_parameters.initial_statement {
             Self::folding_pow_bits(
@@ -140,14 +144,18 @@ where
                 log_inv_rate,
             );
 
-            let ood_samples = Self::ood_samples(
-                whir_parameters.security_level,
-                whir_parameters.soundness_type,
-                num_variables,
-                next_rate,
-                log_next_eta,
-                field_size_bits,
-            );
+            let ood_samples = if whir_parameters.enable_batching && round == 0 {
+                0
+            } else {
+                Self::ood_samples(
+                    whir_parameters.security_level,
+                    whir_parameters.soundness_type,
+                    num_variables,
+                    next_rate,
+                    log_next_eta,
+                    field_size_bits,
+                )
+            };
 
             let query_error =
                 Self::rbr_queries(whir_parameters.soundness_type, log_inv_rate, num_queries);
@@ -220,6 +228,7 @@ where
             final_log_inv_rate: log_inv_rate,
             leaf_hash_params: whir_parameters.leaf_hash_params,
             two_to_one_params: whir_parameters.two_to_one_params,
+            enable_batching: whir_parameters.enable_batching,
         }
     }
 
@@ -645,6 +654,7 @@ mod tests {
             fold_optimisation: FoldType::ProverHelps,
             _pow_parameters: Default::default(),
             starting_log_inv_rate: 1,
+            enable_batching: false,
         }
     }
 

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -41,17 +41,17 @@ where
     MerkleConfig: Config<Leaf = [F]>,
     PowStrategy: spongefish_pow::PowStrategy,
 {
-    fn validate_parameters(&self) -> bool {
+    pub(crate) fn validate_parameters(&self) -> bool {
         self.0.mv_parameters.num_variables
             == self.0.folding_factor.total_number(self.0.n_rounds()) + self.0.final_sumcheck_rounds
     }
 
-    fn validate_statement(&self, statement: &Statement<F>) -> bool {
+    pub(crate) fn validate_statement(&self, statement: &Statement<F>) -> bool {
         statement.num_variables() == self.0.mv_parameters.num_variables
             && (self.0.initial_statement || statement.constraints.is_empty())
     }
 
-    fn validate_witness(&self, witness: &Witness<F, MerkleConfig>) -> bool {
+    pub(crate) fn validate_witness(&self, witness: &Witness<F, MerkleConfig>) -> bool {
         assert_eq!(witness.ood_points.len(), witness.ood_answers.len());
         if !self.0.initial_statement {
             assert!(witness.ood_points.is_empty());
@@ -206,7 +206,7 @@ where
         let root = merkle_tree.root();
         prover_state.add_digest(root)?;
 
-        // Handle OOD (Out-Of-Domain) samples
+        // Handle OOD samples
         let (ood_points, ood_answers) = sample_ood_points(
             prover_state,
             round_params.ood_samples,

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use ark_crypto_primitives::merkle_tree::Config;
+use ark_crypto_primitives::merkle_tree::{Config, LeafParam, TwoToOneParam};
 use ark_ff::FftField;
 use ark_poly::EvaluationDomain;
 use spongefish::{
@@ -13,7 +13,7 @@ use super::{
     parameters::WhirConfig,
     parsed_proof::{ParsedProof, ParsedRound},
     statement::{StatementVerifier, VerifierWeights},
-    WhirProof,
+    RoundZeroProofValidator, WhirCommitmentData, WhirProof, WhirProofRoundData,
 };
 use crate::{
     poly_utils::{coeffs::CoefficientList, multilinear::MultilinearPoint},
@@ -31,10 +31,52 @@ where
 }
 
 #[derive(Clone)]
-struct ParsedCommitment<F, D> {
+pub struct ParsedCommitment<F, D> {
     root: D,
     ood_points: Vec<F>,
     ood_answers: Vec<F>,
+}
+
+impl<F, MerkleConfig> RoundZeroProofValidator<ParsedCommitment<F, MerkleConfig::InnerDigest>>
+    for WhirProof<MerkleConfig, F>
+where
+    MerkleConfig: Config<Leaf = [F]>,
+    F: Sized + Clone + ark_serialize::CanonicalSerialize + ark_serialize::CanonicalDeserialize,
+{
+    type MerkleConfig = MerkleConfig;
+    fn validate_first_round(
+        &self,
+        commitment: &ParsedCommitment<F, MerkleConfig::InnerDigest>,
+        stir_challenges_indexes: &[usize],
+        leaf_hash: &LeafParam<MerkleConfig>,
+        inner_node_hash: &TwoToOneParam<MerkleConfig>,
+    ) -> bool {
+        let (merkle_proof, answers) = &self.merkle_paths[0];
+
+        merkle_proof
+            .verify(
+                &leaf_hash,
+                &inner_node_hash,
+                &commitment.root,
+                answers.iter().map(|a| a.as_ref()),
+            )
+            .unwrap()
+            && merkle_proof.leaf_indexes == *stir_challenges_indexes
+    }
+}
+
+impl<F, M: Config> WhirCommitmentData<F, M> for ParsedCommitment<F, M::InnerDigest> {
+    fn committed_root(&self) -> &<M as Config>::InnerDigest {
+        &self.root
+    }
+
+    fn ood_data(&self) -> (&[F], &[F]) {
+        (&self.ood_points, &self.ood_answers)
+    }
+
+    fn batching_randomness(&self) -> Option<F> {
+        None
+    }
 }
 
 impl<F, MerkleConfig, PowStrategy> Verifier<F, MerkleConfig, PowStrategy>
@@ -72,20 +114,24 @@ where
     }
 
     #[allow(clippy::too_many_lines)]
-    fn parse_proof<VerifierState>(
+    pub(crate) fn parse_proof<VerifierState, CommitmentType, WhirProof>(
         &self,
         verifier_state: &mut VerifierState,
-        parsed_commitment: &ParsedCommitment<F, MerkleConfig::InnerDigest>,
-        statement_points_len: usize, // Will be needed later
-        whir_proof: &WhirProof<MerkleConfig, F>,
+        parsed_commitment: &CommitmentType,
+        whir_proof: &WhirProof,
+        statement_points_len: usize,
     ) -> ProofResult<ParsedProof<F>>
     where
+        CommitmentType: WhirCommitmentData<F, MerkleConfig>,
+        WhirProof: RoundZeroProofValidator<CommitmentType, MerkleConfig = MerkleConfig>
+            + WhirProofRoundData<F, MerkleConfig>,
         VerifierState: UnitToBytes
             + UnitToField<F>
             + DeserializeField<F>
             + PoWChallenge
             + DigestReader<MerkleConfig>,
     {
+        let (committed_ood_points, _) = parsed_commitment.ood_data();
         let mut sumcheck_rounds = Vec::new();
         let mut folding_randomness;
         let initial_combination_randomness;
@@ -94,7 +140,7 @@ where
             let [combination_randomness_gen] = verifier_state.challenge_scalars()?;
             initial_combination_randomness = expand_randomness(
                 combination_randomness_gen,
-                parsed_commitment.ood_points.len() + statement_points_len,
+                committed_ood_points.len() + statement_points_len,
             );
 
             // Initial sumcheck
@@ -114,7 +160,7 @@ where
             folding_randomness =
                 MultilinearPoint(sumcheck_rounds.iter().map(|&(_, r)| r).rev().collect());
         } else {
-            assert_eq!(parsed_commitment.ood_points.len(), 0);
+            assert_eq!(committed_ood_points.len(), 0);
             assert_eq!(statement_points_len, 0);
 
             initial_combination_randomness = vec![F::ONE];
@@ -130,7 +176,7 @@ where
             }
         }
 
-        let mut prev_root = parsed_commitment.root.clone();
+        let mut prev_root = parsed_commitment.committed_root().clone();
         let mut domain_gen = self.params.starting_domain.backing_domain.group_gen();
         let mut exp_domain_gen = domain_gen.pow([1 << self.params.folding_factor.at_round(0)]);
         let mut domain_gen_inv = self.params.starting_domain.backing_domain.group_gen_inv();
@@ -138,7 +184,6 @@ where
         let mut rounds = vec![];
 
         for r in 0..self.params.n_rounds() {
-            let (merkle_proof, answers) = &whir_proof.merkle_paths[r];
             let round_params = &self.params.round_parameters[r];
 
             let new_root = verifier_state.read_digest()?;
@@ -162,16 +207,28 @@ where
                 .map(|index| exp_domain_gen.pow([*index as u64]))
                 .collect();
 
-            if !merkle_proof
-                .verify(
-                    &self.params.leaf_hash_params,
-                    &self.params.two_to_one_params,
-                    &prev_root,
-                    answers.iter().map(|a| a.as_ref()),
-                )
-                .unwrap()
-                || merkle_proof.leaf_indexes != stir_challenges_indexes
-            {
+            let (merkle_proof, answers) =
+                whir_proof.round_data(r, parsed_commitment.batching_randomness());
+
+            if r > 0 {
+                if !merkle_proof
+                    .verify(
+                        &self.params.leaf_hash_params,
+                        &self.params.two_to_one_params,
+                        &prev_root,
+                        answers.iter().map(|a| a.as_ref()),
+                    )
+                    .unwrap()
+                    || merkle_proof.leaf_indexes != stir_challenges_indexes
+                {
+                    return Err(ProofError::InvalidProof);
+                }
+            } else if !whir_proof.validate_first_round(
+                parsed_commitment,
+                &stir_challenges_indexes,
+                &self.params.leaf_hash_params,
+                &self.params.two_to_one_params,
+            ) {
                 return Err(ProofError::InvalidProof);
             }
 
@@ -238,19 +295,35 @@ where
             .map(|index| exp_domain_gen.pow([*index as u64]))
             .collect();
 
-        let (final_merkle_proof, final_randomness_answers) =
-            &whir_proof.merkle_paths[whir_proof.merkle_paths.len() - 1];
-        if !final_merkle_proof
-            .verify(
+        let (final_merkle_proof, final_randomness_answers) = whir_proof.round_data(
+            self.params.n_rounds(),
+            parsed_commitment.batching_randomness(),
+        );
+
+        if self.params.n_rounds() == 0 {
+            // There's only a single round, so we need to validate against the
+            // root batched node
+            if !whir_proof.validate_first_round(
+                parsed_commitment,
+                &final_randomness_indexes,
                 &self.params.leaf_hash_params,
                 &self.params.two_to_one_params,
-                &prev_root,
-                final_randomness_answers.iter().map(|a| a.as_ref()),
-            )
-            .unwrap()
-            || final_merkle_proof.leaf_indexes != final_randomness_indexes
-        {
-            return Err(ProofError::InvalidProof);
+            ) {
+                return Err(ProofError::InvalidProof);
+            }
+        } else {
+            if !final_merkle_proof
+                .verify(
+                    &self.params.leaf_hash_params,
+                    &self.params.two_to_one_params,
+                    &prev_root,
+                    final_randomness_answers.iter().map(|a| a.as_ref()),
+                )
+                .unwrap()
+                || final_merkle_proof.leaf_indexes != final_randomness_indexes
+            {
+                return Err(ProofError::InvalidProof);
+            }
         }
 
         if self.params.final_pow_bits > 0. {
@@ -288,13 +361,14 @@ where
             final_sumcheck_rounds,
             final_sumcheck_randomness,
             final_coefficients,
-            statement_values_at_random_point: whir_proof.statement_values_at_random_point.clone(),
+            statement_values_at_random_point: whir_proof.statement_values().to_vec(),
         })
     }
 
     fn compute_w_poly(
         &self,
-        parsed_commitment: &ParsedCommitment<F, MerkleConfig::InnerDigest>,
+        ood_points: &[F],
+        ood_response: &[F],
         statement: &StatementVerifier<F>,
         proof: &ParsedProof<F>,
     ) -> F {
@@ -309,10 +383,9 @@ where
                 .collect(),
         );
 
-        let mut new_constraints: Vec<_> = parsed_commitment
-            .ood_points
+        let mut new_constraints: Vec<_> = ood_points
             .iter()
-            .zip(&parsed_commitment.ood_answers)
+            .zip(ood_response.iter())
             .map(|(&point, &eval)| {
                 let weights = VerifierWeights::evaluation(
                     MultilinearPoint::expand_from_univariate(point, num_variables),
@@ -372,46 +445,33 @@ where
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn verify<VerifierState>(
+    pub(crate) fn verify_parsed<CommitmentType>(
         &self,
-        verifier_state: &mut VerifierState,
         statement: &StatementVerifier<F>,
-        whir_proof: &WhirProof<MerkleConfig, F>,
+        parsed_commitment: &CommitmentType,
+        parsed_proof: &ParsedProof<F>,
     ) -> ProofResult<()>
     where
-        VerifierState: UnitToBytes
-            + UnitToField<F>
-            + DeserializeField<F>
-            + PoWChallenge
-            + DigestReader<MerkleConfig>,
+        CommitmentType: WhirCommitmentData<F, MerkleConfig>,
     {
-        // We first do a pass in which we rederive all the FS challenges
-        // Then we will check the algebraic part (so to optimise inversions)
-        let parsed_commitment = self.parse_commitment(verifier_state)?;
         let evaluations: Vec<_> = statement.constraints.iter().map(|c| c.1).collect();
-        let parsed = self.parse_proof(
-            verifier_state,
-            &parsed_commitment,
-            statement.constraints.len(),
-            whir_proof,
-        )?;
 
         let computed_folds = self
             .params
             .fold_optimisation
-            .stir_evaluations_verifier(&parsed, &self.params);
+            .stir_evaluations_verifier(&parsed_proof, &self.params);
 
         let mut prev_sumcheck = None;
 
+        let (ood_points, ood_answers) = parsed_commitment.ood_data();
         // Initial sumcheck verification
-        if let Some((poly, randomness)) = parsed.initial_sumcheck_rounds.first().cloned() {
+        if let Some((poly, randomness)) = parsed_proof.initial_sumcheck_rounds.first().cloned() {
             if poly.sum_over_boolean_hypercube()
-                != parsed_commitment
-                    .ood_answers
+                != ood_answers
                     .iter()
                     .copied()
                     .chain(evaluations)
-                    .zip(&parsed.initial_combination_randomness)
+                    .zip(&parsed_proof.initial_combination_randomness)
                     .map(|(ans, rand)| ans * rand)
                     .sum()
             {
@@ -422,7 +482,7 @@ where
             let mut current = (poly, randomness);
 
             // Check the rest of the rounds
-            for (next_poly, next_rand) in &parsed.initial_sumcheck_rounds[1..] {
+            for (next_poly, next_rand) in &parsed_proof.initial_sumcheck_rounds[1..] {
                 if next_poly.sum_over_boolean_hypercube()
                     != current.0.evaluate_at_point(&current.1.into())
                 {
@@ -435,7 +495,7 @@ where
         }
 
         // Sumcheck rounds
-        for (round, folds) in parsed.rounds.iter().zip(&computed_folds) {
+        for (round, folds) in parsed_proof.rounds.iter().zip(&computed_folds) {
             let (sumcheck_poly, new_randomness) = &round.sumcheck_rounds[0];
 
             let values = round
@@ -472,11 +532,12 @@ where
             }
         }
 
-        // Check the foldings computed from the proof match the evaluations of the polynomial
+        // Check the foldings computed from the proof match the evaluations of
+        // the polynomial
         let final_folds = &computed_folds.last().expect("final folds missing");
-        let final_evaluations = parsed
+        let final_evaluations = parsed_proof
             .final_coefficients
-            .evaluate_at_univariate(&parsed.final_randomness_points);
+            .evaluate_at_univariate(&parsed_proof.final_randomness_points);
         if !final_folds
             .iter()
             .zip(final_evaluations)
@@ -491,7 +552,7 @@ where
                 .as_ref()
                 .map_or(F::ZERO, |(p, r)| p.evaluate_at_point(&(*r).into()));
 
-            let (sumcheck_poly, new_randomness) = &parsed.final_sumcheck_rounds[0];
+            let (sumcheck_poly, new_randomness) = &parsed_proof.final_sumcheck_rounds[0];
 
             if sumcheck_poly.sum_over_boolean_hypercube() != claimed_sum {
                 return Err(ProofError::InvalidProof);
@@ -500,7 +561,7 @@ where
             prev_sumcheck = Some((sumcheck_poly.clone(), *new_randomness));
 
             // Check the rest of the round
-            for (sumcheck_poly, new_randomness) in &parsed.final_sumcheck_rounds[1..] {
+            for (sumcheck_poly, new_randomness) in &parsed_proof.final_sumcheck_rounds[1..] {
                 let (prev_poly, randomness) = prev_sumcheck.unwrap();
                 if sumcheck_poly.sum_over_boolean_hypercube()
                     != prev_poly.evaluate_at_point(&randomness.into())
@@ -516,15 +577,43 @@ where
             prev_sumcheck.map_or(F::ZERO, |(poly, rand)| poly.evaluate_at_point(&rand.into()));
 
         // Check the final sumcheck evaluation
-        let evaluation_of_v_poly = self.compute_w_poly(&parsed_commitment, statement, &parsed);
-        let final_value = parsed
+        let evaluation_of_v_poly =
+            self.compute_w_poly(ood_points, ood_answers, statement, parsed_proof);
+        let final_value = parsed_proof
             .final_coefficients
-            .evaluate(&parsed.final_sumcheck_randomness);
+            .evaluate(&parsed_proof.final_sumcheck_randomness);
 
         if prev_sumcheck_poly_eval != evaluation_of_v_poly * final_value {
             return Err(ProofError::InvalidProof);
         }
 
         Ok(())
+    }
+
+    pub fn verify<VerifierState>(
+        &self,
+        verifier_state: &mut VerifierState,
+        statement: &StatementVerifier<F>,
+        whir_proof: &WhirProof<MerkleConfig, F>,
+    ) -> ProofResult<()>
+    where
+        VerifierState: UnitToBytes
+            + UnitToField<F>
+            + DeserializeField<F>
+            + PoWChallenge
+            + DigestReader<MerkleConfig>,
+    {
+        // We first do a pass in which we rederive all the FS challenges Then we
+        // will check the algebraic part (so to optimise inversions)
+        let _evaluations: Vec<_> = statement.constraints.iter().map(|c| c.1).collect();
+        let parsed_commitment = self.parse_commitment(verifier_state)?;
+        let parsed_proof = self.parse_proof(
+            verifier_state,
+            &parsed_commitment,
+            whir_proof,
+            statement.constraints.len(),
+        )?;
+
+        self.verify_parsed(statement, &parsed_commitment, &parsed_proof)
     }
 }


### PR DESCRIPTION
Changes:

1. New set of API: DomainSeparator::batch_commit_statement Committer::batch_commit Prover::batch_prove Verifier::verify_batched
2. New cargo feature flag "batching" to enable disable this API
3. New traits to make the verifier generic