### PR TITLE
Add tracing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1435,6 +1447,7 @@ dependencies = [
  "spongefish",
  "spongefish-pow",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ spongefish-pow = { git = "https://github.com/arkworks-rs/spongefish" }
 rayon = { version = "1.10.0", optional = true }
 thiserror = "2.0"
 itertools = "0.14"
+tracing = { version = "0.1.41", optional = true }
 
 [dev-dependencies]
 proptest = "1.0"
@@ -69,6 +70,7 @@ parallel = [
 ]
 rayon = ["dep:rayon"]
 asm = ["ark-ff/asm"]
+tracing = ["dep:tracing"]
 
 [[bench]]
 name = "expand_from_coeff"

--- a/src/ntt/mod.rs
+++ b/src/ntt/mod.rs
@@ -9,6 +9,8 @@ mod wavelet;
 use ark_ff::FftField;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use self::matrix::MatrixMut;
 pub use self::{
@@ -18,6 +20,7 @@ pub use self::{
 };
 
 /// RS encode at a rate 1/`expansion`.
+#[cfg_attr(feature = "tracing", instrument(skip(coeffs), fields(size = coeffs.len())))]
 pub fn expand_from_coeff<F: FftField>(coeffs: &[F], expansion: usize) -> Vec<F> {
     let engine = cooley_tukey::NttEngine::<F>::new_from_cache();
     let expanded_size = coeffs.len() * expansion;

--- a/src/poly_utils/coeffs.rs
+++ b/src/poly_utils/coeffs.rs
@@ -1,4 +1,6 @@
 use ark_ff::Field;
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 #[cfg(feature = "parallel")]
 use {
     rayon::{join, prelude::*},
@@ -111,6 +113,7 @@ where
     /// - The number of variables decreases: `m = n - k`
     /// - Uses multivariate evaluation over chunks of coefficients.
     #[must_use]
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(size = self.coeffs.len())))]
     pub fn fold(&self, folding_randomness: &MultilinearPoint<F>) -> Self {
         let folding_factor = folding_randomness.num_variables();
         #[cfg(not(feature = "parallel"))]
@@ -161,6 +164,7 @@ impl<F> CoefficientList<F> {
     /// Map the polynomial `self` from F[X_1,...,X_n] to E[X_1,...,X_n], where E is a field extension of F.
     ///
     /// Note that this is currently restricted to the case where F is a prime field.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(size = self.coeffs.len())))]
     pub fn to_extension<E: Field<BasePrimeField = F>>(self) -> CoefficientList<E> {
         CoefficientList::new(
             self.coeffs

--- a/src/poly_utils/fold.rs
+++ b/src/poly_utils/fold.rs
@@ -1,6 +1,8 @@
 use ark_ff::{FftField, Field};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use crate::{
     ntt::{intt_batch, transpose},
@@ -30,6 +32,7 @@ use crate::{
 /// - \( o^{-1} \) is the inverse coset offset
 /// - \( g^{-i} \) is the inverse generator raised to index \( i \)
 /// - The function is recursively applied until the vector reduces to size 1.
+#[cfg_attr(feature = "tracing", instrument(skip_all))]
 pub fn compute_fold<F: Field>(
     answers: &[F],
     folding_randomness: &[F],
@@ -98,6 +101,7 @@ pub fn compute_fold<F: Field>(
 ///
 /// # Panics
 /// Panics if the input size is not divisible by `2^folding_factor`.
+#[cfg_attr(feature = "tracing", instrument(skip_all))]
 pub fn transform_evaluations<F: FftField>(
     evals: &mut [F],
     fold_type: FoldType,

--- a/src/poly_utils/fold.rs
+++ b/src/poly_utils/fold.rs
@@ -101,7 +101,7 @@ pub fn compute_fold<F: Field>(
 ///
 /// # Panics
 /// Panics if the input size is not divisible by `2^folding_factor`.
-#[cfg_attr(feature = "tracing", instrument(skip_all))]
+#[cfg_attr(feature = "tracing", instrument(skip_all, fields(size = evals.len(), folding_factor)))]
 pub fn transform_evaluations<F: FftField>(
     evals: &mut [F],
     fold_type: FoldType,

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -33,7 +33,7 @@ use crate::{
 /// - The result `h(X)` is a quadratic polynomial in `X`.
 ///
 /// The sumcheck protocol ensures that the claimed sum is correct.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SumcheckSingle<F> {
     /// Evaluations of the polynomial `p(X)`.
     evaluation_of_p: EvaluationsList<F>,

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -6,6 +6,8 @@ use spongefish::{
     ProofResult,
 };
 use spongefish_pow::{PoWChallenge, PowStrategy};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use super::SumcheckPolynomial;
 use crate::{
@@ -155,6 +157,7 @@ where
     /// - Samples random values to progressively reduce the polynomial.
     /// - Applies proof-of-work grinding if required.
     /// - Returns the sampled folding randomness values used in each reduction step.
+    #[cfg_attr(feature = "tracing", instrument(skip(self, prover_state)))]
     pub fn compute_sumcheck_polynomials<S, ProverState>(
         &mut self,
         prover_state: &mut ProverState,

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -7,7 +7,7 @@ use spongefish::{
 };
 use spongefish_pow::{PoWChallenge, PowStrategy};
 #[cfg(feature = "tracing")]
-use tracing::instrument;
+use tracing::{instrument, span, Level};
 
 use super::SumcheckPolynomial;
 use crate::{
@@ -87,6 +87,7 @@ where
     /// - `b` represents points in `{0,1,2}^1`.
     /// - `w(b, X)` are the generic weights applied to `p(b, X)`.
     /// - `h(X)` is a quadratic polynomial.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(size = self.evaluation_of_p.num_evals())))]
     pub fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
         assert!(self.num_variables() >= 1);
 
@@ -178,6 +179,8 @@ where
 
             // Do PoW if needed
             if pow_bits > 0. {
+                #[cfg(feature = "tracing")]
+                let _span = span!(Level::INFO, "challenge_pow", pow_bits).entered();
                 prover_state.challenge_pow::<S>(pow_bits)?;
             }
 
@@ -205,6 +208,7 @@ where
     /// \end{equation}
     ///
     /// where `w_{z_i}(X)` represents the constraint encoding at point `z_i`.
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn add_new_equality(
         &mut self,
         points: &[MultilinearPoint<F>],
@@ -245,6 +249,7 @@ where
     /// - Shrinks `p(X)` and `w(X)` by half.
     /// - Fixes `X_1 = r`, reducing the dimensionality.
     /// - Updates `sum` using `sumcheck_poly`.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(size = self.evaluation_of_p.num_evals())))]
     pub fn compress(
         &mut self,
         combination_randomness: F,

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -7,6 +7,8 @@ use spongefish::{
     codecs::arkworks_algebra::{FieldToUnitSerialize, UnitToField},
     ProofResult,
 };
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use super::Witness;
 use crate::{
@@ -47,6 +49,7 @@ where
     /// - Constructs a Merkle tree from the evaluations.
     /// - Computes out-of-domain (OOD) challenge points and their evaluations.
     /// - Returns a `Witness` containing the commitment data.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(size = polynomial.num_coeffs())))]
     pub fn commit<ProverState>(
         &self,
         prover_state: &mut ProverState,

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -8,7 +8,7 @@ use spongefish::{
     ProofResult,
 };
 #[cfg(feature = "tracing")]
-use tracing::instrument;
+use tracing::{instrument, span, Level};
 
 use super::Witness;
 use crate::{
@@ -78,10 +78,14 @@ where
         // This is not necessary for the commit, but in further rounds
         // we will need the extension field. For symplicity we do it here too.
         // TODO: Commit to base field directly.
-        let folded_evals = evals
-            .into_iter()
-            .map(F::from_base_prime_field)
-            .collect::<Vec<_>>();
+        let folded_evals = {
+            #[cfg(feature = "tracing")]
+            let _span = span!(Level::INFO, "evals_to_extension", size = evals.len());
+            evals
+                .into_iter()
+                .map(F::from_base_prime_field)
+                .collect::<Vec<_>>()
+        };
 
         // Determine leaf size based on folding factor.
         let fold_size = 1 << self.0.folding_factor.at_round(0);
@@ -93,12 +97,16 @@ where
         let leafs_iter = folded_evals.par_chunks_exact(fold_size);
 
         // Construct the Merkle tree with given hash parameters.
-        let merkle_tree = MerkleTree::<MerkleConfig>::new(
-            &self.0.leaf_hash_params,
-            &self.0.two_to_one_params,
-            leafs_iter,
-        )
-        .unwrap();
+        let merkle_tree = {
+            #[cfg(feature = "tracing")]
+            let _span = span!(Level::INFO, "MerkleTree::new", size = leafs_iter.len()).entered();
+            MerkleTree::<MerkleConfig>::new(
+                &self.0.leaf_hash_params,
+                &self.0.two_to_one_params,
+                leafs_iter,
+            )
+            .unwrap()
+        };
 
         // Retrieve the Merkle tree root and add it to the narg_string.
         let root = merkle_tree.root();

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -247,7 +247,7 @@ where
         // STIR Queries
         let (stir_challenges, stir_challenges_indexes) = self.compute_stir_queries(
             prover_state,
-            &round_state,
+            round_state,
             num_variables,
             round_params,
             ood_points,
@@ -265,7 +265,7 @@ where
         // Evaluate answers in the folding randomness.
         let mut stir_evaluations = ood_answers;
         self.0.fold_optimisation.stir_evaluations_prover(
-            &round_state,
+            round_state,
             &stir_challenges_indexes,
             &answers,
             self.0.folding_factor,
@@ -400,8 +400,7 @@ where
         if self.0.final_sumcheck_rounds > 0 {
             let final_folding_randomness = round_state
                 .sumcheck_prover
-                .as_ref()
-                .cloned()
+                .clone()
                 .unwrap_or_else(|| {
                     SumcheckSingle::new(folded_coefficients.clone(), &round_state.statement, F::ONE)
                 })

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -275,6 +275,13 @@ where
 
         // PoW
         if round_params.pow_bits > 0. {
+            #[cfg(feature = "tracing")]
+            let _span = span!(
+                Level::INFO,
+                "challenge_pow",
+                pow_bits = round_params.pow_bits
+            )
+            .entered();
             prover_state.challenge_pow::<PowStrategy>(round_params.pow_bits)?;
         }
 
@@ -378,6 +385,13 @@ where
 
         // PoW
         if self.0.final_pow_bits > 0. {
+            #[cfg(feature = "tracing")]
+            let _span = span!(
+                Level::INFO,
+                "challenge_pow",
+                pow_bits = self.0.final_pow_bits
+            )
+            .entered();
             prover_state.challenge_pow::<PowStrategy>(self.0.final_pow_bits)?;
         }
 

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -341,7 +341,7 @@ where
         round_state.coefficients = folded_coefficients;
         round_state.prev_merkle = merkle_tree;
         round_state.prev_merkle_answers = evals;
-      
+
         Ok(())
     }
 

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -8,6 +8,8 @@ use spongefish::{
     ProofResult, UnitToBytes,
 };
 use spongefish_pow::{self, PoWChallenge};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use super::{
     committer::Witness,
@@ -58,6 +60,7 @@ where
         witness.polynomial.num_variables() == self.0.mv_parameters.num_variables
     }
 
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn prove<ProverState>(
         &self,
         prover_state: &mut ProverState,
@@ -146,6 +149,7 @@ where
     }
 
     #[allow(clippy::too_many_lines)]
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     fn round<ProverState>(
         &self,
         prover_state: &mut ProverState,
@@ -311,6 +315,7 @@ where
         self.round(prover_state, round_state)
     }
 
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     fn final_round<ProverState>(
         &self,
         prover_state: &mut ProverState,

--- a/src/whir/statement.rs
+++ b/src/whir/statement.rs
@@ -3,6 +3,8 @@ use std::{fmt::Debug, ops::Index};
 use ark_ff::Field;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use crate::poly_utils::{evals::EvaluationsList, multilinear::MultilinearPoint};
 
@@ -71,6 +73,7 @@ impl<F: Field> Weights<F> {
     ///
     /// **Precondition:**
     /// `accumulator.num_variables()` must match `self.num_variables()`.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(num_variables = self.num_variables())))]
     pub fn accumulate(&self, accumulator: &mut EvaluationsList<F>, factor: F) {
         use crate::utils::eval_eq;
 
@@ -113,6 +116,7 @@ impl<F: Field> Weights<F> {
     ///
     /// **Precondition:**
     /// If `self` is in linear mode, `poly.num_variables()` must match `weight.num_variables()`.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(num_variables = self.num_variables())))]
     pub fn weighted_sum(&self, poly: &EvaluationsList<F>) -> F {
         match self {
             Self::Linear { weight } => {
@@ -220,6 +224,7 @@ impl<F: Field> Statement<F> {
     /// **Returns:**
     /// - `EvaluationsList<F>`: The combined polynomial `W(X)`.
     /// - `F`: The combined sum `S`.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(num_variables = self.num_variables(), num_constraints = self.constraints.len())))]
     pub fn combine(&self, challenge: F) -> (EvaluationsList<F>, F) {
         let evaluations_vec = vec![F::ZERO; 1 << self.num_variables];
         let mut combined_evals = EvaluationsList::new(evaluations_vec);

--- a/src/whir/utils.rs
+++ b/src/whir/utils.rs
@@ -5,12 +5,15 @@ use spongefish::{
     codecs::arkworks_algebra::{FieldToUnitSerialize, UnitToField},
     ProofResult, UnitToBytes,
 };
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use crate::poly_utils::multilinear::MultilinearPoint;
 
 /// A utility function to sample Out-of-Domain (OOD) points and evaluate them
 ///
 /// This operates on the prover side.
+#[cfg_attr(feature = "tracing", instrument(skip(prover_state, evaluate_fn)))]
 pub(crate) fn sample_ood_points<F, ProverState, E>(
     prover_state: &mut ProverState,
     num_samples: usize,


### PR DESCRIPTION
Add tracing support. Besides production grade logging, this allows collecting performance information from the field. 

I did change the main WHIR loop from recursive to iterative, to avoid deeply nested spans.

Otherwise it's feature gated and has no effect when turned off. When enabled, it should have negligible impact.


Here's an example of what can be collected:

```
├─╮ whir::whir::committer::writer::commit size=524288
│ ├─╮ whir::ntt::expand_from_coeff expansion=2 size=524288
│ ├─╯ 39.2 ms duration, 457 MB peak memory, 83.9 MB local, 22.4k allocations
│ ├─╮ whir::poly_utils::fold::transform_evaluations size=1048576
│ ├─╯ 11.8 ms duration, 457 MB peak memory, 33.6 MB local, 5.00 allocations
│ ├─╮ whir::whir::committer::writer::evals_to_extension size=1048576
│ ├─╯ 3.29 μs duration, 424 MB peak memory, 348 B local, 4.00 allocations
│ ├─╮ whir::whir::committer::writer::MerkleTree::new size=65536
│ ├─╯ 2.07 s duration, 428 MB peak memory, 4.65 MB local, 8.40M allocations
│ ├─╮ whir::whir::utils::sample_ood_points num_samples=1 num_variables=19
│ ├─╯ 3.23 ms duration, 428 MB peak memory, 928 B local, 17.0 allocations
│ ├─╮ whir::poly_utils::coeffs::to_extension size=524288
│ ├─╯ 3.08 μs duration, 428 MB peak memory, 348 B local, 4.00 allocations
├─╯ commit: 2.13 s duration, 457 MB peak memory, 83.9 MB local, 8.42M allocations
```

```
├─╮ whir::whir::prover::prove
│ ├─╮ whir::whir::statement::combine num_variables=19 num_constraints=4
│ │ ├─╮ whir::whir::statement::accumulate num_variables=19
│ │ ├─╯ 1.58 ms duration, 530 MB peak memory, 488 B local, 5.00 allocations
│ │ ├─╮ whir::whir::statement::accumulate num_variables=19
│ │ ├─╯ 1.08 ms duration, 530 MB peak memory, 348 B local, 4.00 allocations
│ │ ├─╮ whir::whir::statement::accumulate num_variables=19
│ │ ├─╯ 1.02 ms duration, 530 MB peak memory, 348 B local, 4.00 allocations
│ │ ├─╮ whir::whir::statement::accumulate num_variables=19
│ │ ├─╯ 929 μs duration, 530 MB peak memory, 348 B local, 4.00 allocations
│ ├─╯ combine: 5.81 ms duration, 530 MB peak memory, 16.8 MB local, 31.0 allocations
│ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomials folding_factor=4 pow_bits=0.0
│ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=524288
│ │ ├─╯ 1.15 ms duration, 530 MB peak memory, 548 B local, 6.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=524288
│ │ ├─╯ 2.03 ms duration, 547 MB peak memory, 16.8 MB local, 6.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=262144
│ │ ├─╯ 734 μs duration, 513 MB peak memory, 548 B local, 6.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=262144
│ │ ├─╯ 2.15 ms duration, 521 MB peak memory, 8.39 MB local, 6.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=131072
│ │ ├─╯ 949 μs duration, 505 MB peak memory, 548 B local, 6.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=131072
│ │ ├─╯ 591 μs duration, 509 MB peak memory, 4.19 MB local, 6.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=65536
│ │ ├─╯ 266 μs duration, 500 MB peak memory, 548 B local, 6.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=65536
│ │ ├─╯ 590 μs duration, 502 MB peak memory, 2.10 MB local, 6.00 allocations
│ ├─╯ compute_sumcheck_polynomials: 8.57 ms duration, 547 MB peak memory, 16.8 MB local, 171 allocations
│ ├─╮ whir::whir::prover::round size=524288
│ │ ├─╮ whir::poly_utils::coeffs::fold size=524288
│ │ ├─╯ 908 μs duration, 499 MB peak memory, 1.05 MB local, 5.00 allocations
│ │ ├─╮ whir::ntt::expand_from_coeff expansion=16 size=32768
│ │ ├─╯ 17.3 ms duration, 533 MB peak memory, 33.6 MB local, 12.7k allocations
│ │ ├─╮ whir::poly_utils::fold::transform_evaluations size=524288
│ │ ├─╯ 4.35 ms duration, 533 MB peak memory, 16.8 MB local, 5.00 allocations
│ │ ├─╮ whir::whir::prover::MerkleTree::new size=32768
│ │ ├─╯ 1.05 s duration, 519 MB peak memory, 2.49 MB local, 4.21M allocations
│ │ ├─╮ whir::whir::utils::sample_ood_points num_samples=1 num_variables=15
│ │ ├─╯ 170 μs duration, 518 MB peak memory, 800 B local, 17.0 allocations
│ │ ├─╮ whir::whir::prover::challenge_pow pow_bits=17.0
│ │ ├─╯ 14.6 ms duration, 518 MB peak memory, 696 B local, 208k allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::add_new_equality
│ │ ├─╯ 22.1 ms duration, 518 MB peak memory, 1.60 kB local, 3.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomials folding_factor=4 pow_bits=0.0
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=32768
│ │ │ ├─╯ 219 μs duration, 518 MB peak memory, 688 B local, 7.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=32768
│ │ │ ├─╯ 654 μs duration, 519 MB peak memory, 1.05 MB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=16384
│ │ │ ├─╯ 257 μs duration, 517 MB peak memory, 1.77 kB local, 7.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=16384
│ │ │ ├─╯ 183 μs duration, 518 MB peak memory, 525 kB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=8192
│ │ │ ├─╯ 110 μs duration, 517 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=8192
│ │ │ ├─╯ 214 μs duration, 517 MB peak memory, 262 kB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=4096
│ │ │ ├─╯ 126 μs duration, 516 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=4096
│ │ │ ├─╯ 173 μs duration, 517 MB peak memory, 131 kB local, 6.00 allocations
│ │ ├─╯ compute_sumcheck_polynomials: 2.03 ms duration, 519 MB peak memory, 1.05 MB local, 173 allocations
│ ├─╯ round: 1.11 s duration, 533 MB peak memory, 34.6 MB local, 4.44M allocations
│ ├─╮ whir::whir::prover::round size=32768
│ │ ├─╮ whir::poly_utils::coeffs::fold size=32768
│ │ ├─╯ 256 μs duration, 462 MB peak memory, 65.8 kB local, 5.00 allocations
│ │ ├─╮ whir::ntt::expand_from_coeff expansion=128 size=2048
│ │ ├─╯ 9.44 ms duration, 479 MB peak memory, 17.2 MB local, 16.9k allocations
│ │ ├─╮ whir::poly_utils::fold::transform_evaluations size=262144
│ │ ├─╯ 3.87 ms duration, 479 MB peak memory, 8.39 MB local, 5.00 allocations
│ │ ├─╮ whir::whir::prover::MerkleTree::new size=16384
│ │ ├─╯ 529 ms duration, 472 MB peak memory, 1.33 MB local, 2.10M allocations
│ │ ├─╮ whir::whir::utils::sample_ood_points num_samples=1 num_variables=11
│ │ ├─╯ 88.8 μs duration, 471 MB peak memory, 672 B local, 17.0 allocations
│ │ ├─╮ whir::whir::prover::challenge_pow pow_bits=16.0
│ │ ├─╯ 12.1 ms duration, 471 MB peak memory, 696 B local, 174k allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::add_new_equality
│ │ ├─╯ 1.76 ms duration, 471 MB peak memory, 180 B local, 2.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomials folding_factor=4 pow_bits=0.0
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=2048
│ │ │ ├─╯ 218 μs duration, 471 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=2048
│ │ │ ├─╯ 61.4 μs duration, 471 MB peak memory, 65.8 kB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=1024
│ │ │ ├─╯ 88.2 μs duration, 471 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=1024
│ │ │ ├─╯ 31.5 μs duration, 471 MB peak memory, 33.0 kB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=512
│ │ │ ├─╯ 31.9 μs duration, 471 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=512
│ │ │ ├─╯ 18.4 μs duration, 471 MB peak memory, 16.6 kB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=256
│ │ │ ├─╯ 77.8 μs duration, 471 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=256
│ │ │ ├─╯ 15.0 μs duration, 471 MB peak memory, 8.44 kB local, 6.00 allocations
│ │ ├─╯ compute_sumcheck_polynomials: 584 μs duration, 471 MB peak memory, 66.3 kB local, 171 allocations
│ ├─╯ round: 557 ms duration, 479 MB peak memory, 17.3 MB local, 2.30M allocations
│ ├─╮ whir::whir::prover::round size=2048
│ │ ├─╮ whir::poly_utils::coeffs::fold size=2048
│ │ ├─╯ 152 μs duration, 451 MB peak memory, 4.34 kB local, 5.00 allocations
│ │ ├─╮ whir::ntt::expand_from_coeff expansion=1024 size=128
│ │ ├─╯ 17.0 ms duration, 461 MB peak memory, 9.91 MB local, 68.5k allocations
│ │ ├─╮ whir::poly_utils::fold::transform_evaluations size=131072
│ │ ├─╯ 1.76 ms duration, 460 MB peak memory, 4.19 MB local, 5.00 allocations
│ │ ├─╮ whir::whir::prover::MerkleTree::new size=8192
│ │ ├─╯ 265 ms duration, 456 MB peak memory, 882 kB local, 1.06M allocations
│ │ ├─╮ whir::whir::utils::sample_ood_points num_samples=1 num_variables=7
│ │ ├─╯ 9.83 μs duration, 456 MB peak memory, 556 B local, 17.0 allocations
│ │ ├─╮ whir::whir::prover::challenge_pow pow_bits=16.0
│ │ ├─╯ 43.4 ms duration, 456 MB peak memory, 696 B local, 597k allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::add_new_equality
│ │ ├─╯ 74.3 μs duration, 456 MB peak memory, 180 B local, 2.00 allocations
│ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomials folding_factor=4 pow_bits=0.0
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=128
│ │ │ ├─╯ 381 μs duration, 456 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=128
│ │ │ ├─╯ 12.9 μs duration, 456 MB peak memory, 4.34 kB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=64
│ │ │ ├─╯ 131 μs duration, 456 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=64
│ │ │ ├─╯ 10.5 μs duration, 456 MB peak memory, 2.30 kB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=32
│ │ │ ├─╯ 161 μs duration, 456 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=32
│ │ │ ├─╯ 7.96 μs duration, 456 MB peak memory, 1.27 kB local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=16
│ │ │ ├─╯ 20.2 μs duration, 456 MB peak memory, 548 B local, 6.00 allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=16
│ │ │ ├─╯ 6.29 μs duration, 456 MB peak memory, 760 B local, 6.00 allocations
│ │ ├─╯ compute_sumcheck_polynomials: 789 μs duration, 456 MB peak memory, 4.86 kB local, 172 allocations
│ ├─╯ round: 329 ms duration, 461 MB peak memory, 9.92 MB local, 1.72M allocations
│ ├─╮ whir::whir::prover::round size=128
│ │ ├─╮ whir::poly_utils::coeffs::fold size=128
│ │ ├─╯ 156 μs duration, 447 MB peak memory, 504 B local, 5.00 allocations
│ │ ├─╮ whir::whir::prover::final_round size=8
│ │ │ ├─╮ whir::whir::prover::challenge_pow pow_bits=8.0
│ │ │ ├─╯ 283 μs duration, 447 MB peak memory, 696 B local, 3.32k allocations
│ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomials folding_factor=3 pow_bits=0.0
│ │ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=8
│ │ │ │ ├─╯ 111 μs duration, 447 MB peak memory, 688 B local, 8.00 allocations
│ │ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=8
│ │ │ │ ├─╯ 8.17 μs duration, 447 MB peak memory, 504 B local, 6.00 allocations
│ │ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=4
│ │ │ │ ├─╯ 21.7 μs duration, 447 MB peak memory, 548 B local, 6.00 allocations
│ │ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=4
│ │ │ │ ├─╯ 18.1 μs duration, 447 MB peak memory, 376 B local, 6.00 allocations
│ │ │ │ ├─╮ whir::sumcheck::sumcheck_single::compute_sumcheck_polynomial size=2
│ │ │ │ ├─╯ 1.75 μs duration, 447 MB peak memory, 548 B local, 6.00 allocations
│ │ │ │ ├─╮ whir::sumcheck::sumcheck_single::compress size=2
│ │ │ │ ├─╯ 5.58 μs duration, 447 MB peak memory, 348 B local, 6.00 allocations
│ │ │ ├─╯ compute_sumcheck_polynomials: 209 μs duration, 447 MB peak memory, 1.26 kB local, 140 allocations
│ │ ├─╯ final_round: 654 μs duration, 447 MB peak memory, 13.0 kB local, 5.14k allocations
│ ├─╯ round: 827 μs duration, 447 MB peak memory, 13.5 kB local, 5.16k allocations
├─╯ prove: 2.03 s duration, 547 MB peak memory, 50.3 MB local, 8.47M allocations
```