### PR TITLE
statement: enable parallelization for statement evaluate

### DIFF
--- a/src/whir/statement.rs
+++ b/src/whir/statement.rs
@@ -77,12 +77,25 @@ impl<F: Field> Weights<F> {
             Self::Evaluation { point } => poly.evaluate(point),
             Self::Linear { weight } => {
                 let poly: EvaluationsList<F> = poly.clone().into();
-                weight
-                    .evals()
-                    .iter()
-                    .zip(poly.evals())
-                    .map(|(&w, &p)| w * p)
-                    .sum()
+                #[cfg(not(feature = "parallel"))]
+                {
+                    weight
+                        .evals()
+                        .iter()
+                        .zip(poly.evals())
+                        .map(|(&w, &p)| w * p)
+                        .sum()
+                }
+
+                #[cfg(feature = "parallel")]
+                {
+                    weight
+                        .evals()
+                        .par_iter()
+                        .zip(poly.evals())
+                        .map(|(&w, &p)| w * p)
+                        .sum()
+                }
             }
         }
     }

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -210,7 +210,7 @@ where
             round_folding_randomness.last().unwrap(),
         )?;
 
-        // Verify stir constraints direclty on final polynomial
+        // Verify stir constraints directly on final polynomial
         if !stir_constraints
             .iter()
             .all(|c| c.verify(&final_coefficients))


### PR DESCRIPTION
Similarly to what is done for the `weighted_sum` function

https://github.com/WizardOfMenlo/whir/blob/bd6b47818cfe197565d816ba1249060e22c5af32/src/whir/statement.rs#L149-L172

we can enable parallelization for looping over the weights.