### PR TITLE
Interleaved RS Code for ProverHelps optimization. 

### DIFF
--- a/benches/expand_from_coeff.rs
+++ b/benches/expand_from_coeff.rs
@@ -4,10 +4,14 @@ use whir::{crypto::fields::Field64, ntt};
 #[global_allocator]
 static ALLOC: AllocProfiler = AllocProfiler::system();
 
-// Test cases with polynomial sizes defined as exponents of 2 and expansion factors
+//
+// Test cases with tuple entries:
+//      - polynomial sizes defined as exponents of 2,
+//      - RS code expansion factors, and
+//      - interleaved bloc size exponent of 2
+//
 const TEST_CASES: &[(u32, usize, usize)] = &[
     (16, 2, 2),
-    (18, 2, 2),
     (18, 2, 2),
     (20, 2, 3),
     (16, 4, 3),
@@ -17,7 +21,7 @@ const TEST_CASES: &[(u32, usize, usize)] = &[
 ];
 
 #[divan::bench(args = TEST_CASES)]
-fn rs_encode_coset_poly(bencher: Bencher, case: &(u32, usize, usize)) {
+fn interleaved_rs_encode(bencher: Bencher, case: &(u32, usize, usize)) {
     bencher
         .with_inputs(|| {
             let (exp, expansion, coset_sz) = *case;
@@ -27,7 +31,7 @@ fn rs_encode_coset_poly(bencher: Bencher, case: &(u32, usize, usize)) {
             (coeffs, expansion, coset_sz)
         })
         .bench_values(|(coeffs, expansion, coset_sz)| {
-            black_box(ntt::rs_encode_coset_poly(&coeffs, expansion, coset_sz))
+            black_box(ntt::interleaved_rs_encode(&coeffs, expansion, coset_sz))
         });
 }
 

--- a/benches/expand_from_coeff.rs
+++ b/benches/expand_from_coeff.rs
@@ -5,27 +5,30 @@ use whir::{crypto::fields::Field64, ntt};
 static ALLOC: AllocProfiler = AllocProfiler::system();
 
 // Test cases with polynomial sizes defined as exponents of 2 and expansion factors
-const TEST_CASES: &[(u32, usize)] = &[
-    (16, 2),
-    (18, 2),
-    (20, 2),
-    (16, 4),
-    (18, 4),
-    (20, 4),
-    (22, 4),
+const TEST_CASES: &[(u32, usize, usize)] = &[
+    (16, 2, 2),
+    (18, 2, 2),
+    (18, 2, 2),
+    (20, 2, 3),
+    (16, 4, 3),
+    (18, 4, 3),
+    (20, 4, 4),
+    (22, 4, 4),
 ];
 
 #[divan::bench(args = TEST_CASES)]
-fn expand_from_coeff(bencher: Bencher, case: &(u32, usize)) {
+fn rs_encode_coset_poly(bencher: Bencher, case: &(u32, usize, usize)) {
     bencher
         .with_inputs(|| {
-            let (exp, expansion) = *case;
+            let (exp, expansion, coset_sz) = *case;
 
             let size = 1 << exp;
             let coeffs: Vec<_> = (0..size).map(Field64::from).collect();
-            (coeffs, expansion)
+            (coeffs, expansion, coset_sz)
         })
-        .bench_values(|(coeffs, expansion)| black_box(ntt::expand_from_coeff(&coeffs, expansion)));
+        .bench_values(|(coeffs, expansion, coset_sz)| {
+            black_box(ntt::rs_encode_coset_poly(&coeffs, expansion, coset_sz))
+        });
 }
 
 fn main() {

--- a/src/ntt/mod.rs
+++ b/src/ntt/mod.rs
@@ -42,9 +42,8 @@ pub fn rs_encode_coset_poly<F: FftField>(
     fold_factor: usize,
 ) -> Vec<F> {
     let fold_factor = u32::try_from(fold_factor).unwrap();
+    debug_assert!(expansion > 0);
     debug_assert!(poly.len().is_power_of_two());
-    debug_assert!(fold_factor < F::TWO_ADICITY);
-    debug_assert!(fold_factor < usize::BITS);
 
     let fold_factor_exp = 2usize.pow(fold_factor);
     let expanded_size = poly.len() * expansion;
@@ -59,13 +58,13 @@ pub fn rs_encode_coset_poly<F: FftField>(
     let columns = fold_factor_exp;
 
     // 2. Create fold-factor-exp number of h(X^k) polynomial. (This is
-    //    equivalent to striding the collecting the coefficients of
-    //    `poly` in multiples of k-th degree). This is essentially
+    //    equivalent to collecting the coefficients of `poly` in
+    //    multiples of `k = fold_factor_exp`). This is essentially
     //    equivalent to transposing the matrix.
     transpose(&mut result, rows, columns);
 
     // 3. Compute NTT for each hₜ(X), which will naturally be evaluated
-    // at ω = ζ^k roots of unity.
+    //    at ω = ζ^k roots of unity.
     ntt_batch(&mut result, rows);
 
     // 4. Arrange cosets consecutively.

--- a/src/ntt/mod.rs
+++ b/src/ntt/mod.rs
@@ -258,7 +258,7 @@ mod tests {
 
         let eval_domain = GeneralEvaluationDomain::<Field64>::new(count * expansion).unwrap();
 
-        let poly = Vec::from_iter((0..count).into_iter().map(|_| Field64::rand(&mut rng)));
+        let poly: Vec<_> = (0..count).map(|_| Field64::rand(&mut rng)).collect();
 
         // Compute things the old way
         let mut expected = test_utils::expand_from_coeff(&poly, expansion);

--- a/src/ntt/mod.rs
+++ b/src/ntt/mod.rs
@@ -2,6 +2,10 @@
 
 mod cooley_tukey;
 mod matrix;
+
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 mod transpose;
 mod utils;
 mod wavelet;
@@ -18,56 +22,47 @@ pub use self::{
 };
 
 ///
-/// RS encode a polynomial `poly` of degree `d-1` at the rate
-/// 1/`expansion` (i.e., the RS block length `N = d*expansion`).
+/// RS encode interleaved data `interleaved_coeffs` at the rate
+/// 1/`expansion`, where 2^`fold_factor` elements are interleaved
+/// together.
 ///
-/// Suppose the Merkle tree leaves are grouped as cosets of size  k =
-/// 2^`fold_factor`. Given a polynomial f(x) of degree `d-1`, it can be
-/// extended by zero-padding to a polynomial of degree `N-1` and written
-/// in the following form:
-///
-/// f(X) = h₀(X^k) + X·h₁(X^k) + ⋯ + X^{k-1}·h_{k-1}(X^k)
-///
-/// where each hₜ(X) is polynomial of maximum degree `N/k - 1`.
-///
-/// If ζ is the N-th root of unity, then [rs_encode_coset_poly] computes
-/// the Reed-Solomon code for each hₜ(x) using `ω = ζ^k` as the root of
-/// unity, and for each index i, places [h₀(ω^i), h₁(ω^i), ⋯
-/// ,h_{k-1}(ω^i)] consecutively in the output buffer.
+/// This function computes the RS-code for each interleaved message and
+/// outputs the interleaved alphabets in the same order as the input.
 ///
 #[cfg_attr(feature = "tracing", instrument(skip(poly), fields(size = poly.len())))]
-pub fn rs_encode_coset_poly<F: FftField>(
-    poly: &[F],
+pub fn interleaved_rs_encode<F: FftField>(
+    interleaved_coeffs: &[F],
     expansion: usize,
     fold_factor: usize,
 ) -> Vec<F> {
     let fold_factor = u32::try_from(fold_factor).unwrap();
     debug_assert!(expansion > 0);
-    debug_assert!(poly.len().is_power_of_two());
+    debug_assert!(interleaved_coeffs.len().is_power_of_two());
 
     let fold_factor_exp = 2usize.pow(fold_factor);
-    let expanded_size = poly.len() * expansion;
+    let expanded_size = interleaved_coeffs.len() * expansion;
 
     debug_assert_eq!(expanded_size % fold_factor_exp, 0);
 
-    // 1. Create zero-padded polynomial of appropriate size
+    // 1. Create zero-padded message of appropriate size
     let mut result = vec![F::zero(); expanded_size];
-    result[..poly.len()].copy_from_slice(poly);
+    result[..interleaved_coeffs.len()].copy_from_slice(interleaved_coeffs);
 
     let rows = expanded_size / fold_factor_exp;
     let columns = fold_factor_exp;
 
-    // 2. Create fold-factor-exp number of h(X^k) polynomial. (This is
-    //    equivalent to collecting the coefficients of `poly` in
-    //    multiples of `k = fold_factor_exp`). This is essentially
-    //    equivalent to transposing the matrix.
+    //
+    // 2. Convert from column-major (interleaved form) to row-major
+    //    representation.
+    //
+
+    // TODO: Might be useful to keep the transposed data for future use.
     transpose(&mut result, rows, columns);
 
-    // 3. Compute NTT for each hₜ(X), which will naturally be evaluated
-    //    at ω = ζ^k roots of unity.
+    // 3. Compute NTT on row-major representation
     ntt_batch(&mut result, rows);
 
-    // 4. Arrange cosets consecutively.
+    // 4. Convert back to column-major (interleaved) representation
     transpose(&mut result, columns, rows);
     result
 }
@@ -75,52 +70,9 @@ pub fn rs_encode_coset_poly<F: FftField>(
 #[cfg(test)]
 mod tests {
     use ark_ff::Field;
-    #[cfg(feature = "parallel")]
-    use rayon::prelude::*;
 
     use super::*;
     use crate::{crypto::fields::Field64, ntt::cooley_tukey::NttEngine};
-
-    fn expand_from_coeff<F: FftField>(coeffs: &[F], expansion: usize) -> Vec<F> {
-        let engine = cooley_tukey::NttEngine::<F>::new_from_cache();
-        let expanded_size = coeffs.len() * expansion;
-        let mut result = Vec::with_capacity(expanded_size);
-        // Note: We can also zero-extend the coefficients and do a larger NTT.
-        // But this is more efficient.
-
-        // Do coset NTT.
-        let root = engine.root(expanded_size);
-        result.extend_from_slice(coeffs);
-        #[cfg(not(feature = "parallel"))]
-        for i in 1..expansion {
-            let root = root.pow([i as u64]);
-            let mut offset = F::ONE;
-            result.extend(coeffs.iter().map(|x| {
-                let val = *x * offset;
-                offset *= root;
-                val
-            }));
-        }
-        #[cfg(feature = "parallel")]
-        result.par_extend((1..expansion).into_par_iter().flat_map(|i| {
-            let root_i = root.pow([i as u64]);
-            coeffs
-                .par_iter()
-                .enumerate()
-                .map_with(F::ZERO, move |root_j, (j, coeff)| {
-                    if root_j.is_zero() {
-                        *root_j = root_i.pow([j as u64]);
-                    } else {
-                        *root_j *= root_i;
-                    }
-                    *coeff * *root_j
-                })
-        }));
-
-        ntt_batch(&mut result, coeffs.len());
-        transpose(&mut result, expansion, coeffs.len());
-        result
-    }
 
     #[test]
     fn test_expand_from_coeff_size_2() {
@@ -174,7 +126,7 @@ mod tests {
         // The expected NTT result should be in transposed order:
         let expected_values_transposed = vec![expected_f0, expected_f2, expected_f1, expected_f3];
 
-        let computed_values = expand_from_coeff(&coeffs, expansion);
+        let computed_values = test_utils::expand_from_coeff(&coeffs, expansion);
         assert_eq!(computed_values, expected_values_transposed);
     }
 
@@ -290,16 +242,15 @@ mod tests {
             expected_f15,
         ];
 
-        let computed_values = expand_from_coeff(&coeffs, expansion);
+        let computed_values = test_utils::expand_from_coeff(&coeffs, expansion);
         assert_eq!(computed_values, expected_values_transposed);
     }
 
     #[test]
-    fn test_rs_encode_as_cosets() {
+    fn test_interleaved_rs_encode() {
         use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
         use ark_std::UniformRand;
 
-        use crate::poly_utils::fold::tests::transform_evaluations;
         let mut rng = ark_std::test_rng();
         let count = 1 << 20;
         let expansion = 4;
@@ -310,11 +261,15 @@ mod tests {
         let poly = Vec::from_iter((0..count).into_iter().map(|_| Field64::rand(&mut rng)));
 
         // Compute things the old way
-        let mut expected = expand_from_coeff(&poly, expansion);
-        transform_evaluations(&mut expected, eval_domain.group_gen_inv(), folding_factor);
+        let mut expected = test_utils::expand_from_coeff(&poly, expansion);
+        test_utils::transform_evaluations(
+            &mut expected,
+            eval_domain.group_gen_inv(),
+            folding_factor,
+        );
 
         // Compute things the new way
-        let interleaved_ntt = rs_encode_coset_poly(&poly, expansion, folding_factor);
+        let interleaved_ntt = interleaved_rs_encode(&poly, expansion, folding_factor);
         assert_eq!(expected, interleaved_ntt);
     }
 }

--- a/src/ntt/test_utils.rs
+++ b/src/ntt/test_utils.rs
@@ -1,0 +1,122 @@
+use ark_ff::FftField;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use super::*;
+
+pub(super) fn expand_from_coeff<F: FftField>(coeffs: &[F], expansion: usize) -> Vec<F> {
+    let engine = cooley_tukey::NttEngine::<F>::new_from_cache();
+    let expanded_size = coeffs.len() * expansion;
+    let mut result = Vec::with_capacity(expanded_size);
+    // Note: We can also zero-extend the coefficients and do a larger NTT.
+    // But this is more efficient.
+
+    // Do coset NTT.
+    let root = engine.root(expanded_size);
+    result.extend_from_slice(coeffs);
+    #[cfg(not(feature = "parallel"))]
+    for i in 1..expansion {
+        let root = root.pow([i as u64]);
+        let mut offset = F::ONE;
+        result.extend(coeffs.iter().map(|x| {
+            let val = *x * offset;
+            offset *= root;
+            val
+        }));
+    }
+    #[cfg(feature = "parallel")]
+    result.par_extend((1..expansion).into_par_iter().flat_map(|i| {
+        let root_i = root.pow([i as u64]);
+        coeffs
+            .par_iter()
+            .enumerate()
+            .map_with(F::ZERO, move |root_j, (j, coeff)| {
+                if root_j.is_zero() {
+                    *root_j = root_i.pow([j as u64]);
+                } else {
+                    *root_j *= root_i;
+                }
+                *coeff * *root_j
+            })
+    }));
+
+    ntt_batch(&mut result, coeffs.len());
+    transpose(&mut result, expansion, coeffs.len());
+    result
+}
+
+/// Applies a folding transformation to evaluation vectors in-place.
+///
+/// Performs reshaping, inverse NTTs, and applies coset + scaling correction.
+///
+/// The evaluations are grouped into `2^folding_factor` blocks of size `N / 2^folding_factor`.
+/// For each group, the function performs the following:
+///
+/// 1. Transpose: reshape layout to enable independent processing of each sub-coset.
+/// 2. Inverse NTT: convert each sub-coset from evaluation to coefficient form (no 1/N scaling).
+/// 3. Scale correction:
+///    Each output is multiplied by:
+///
+///    ```ignore
+///    size_inv * (domain_gen_inv^i)^j
+///    ```
+///
+///    where:
+///      - `size_inv = 1 / 2^folding_factor`
+///      - `i` is the subdomain index
+///      - `j` is the index within the block
+///
+/// # Panics
+/// Panics if the input size is not divisible by `2^folding_factor`.
+pub(crate) fn transform_evaluations<F: FftField>(
+    evals: &mut [F],
+    domain_gen_inv: F,
+    folding_factor: usize,
+) {
+    // Compute the number of sub-cosets = 2^folding_factor
+    let folding_factor_exp = 1 << folding_factor;
+
+    // Ensure input is divisible by folding factor
+    assert!(evals.len() % folding_factor_exp == 0);
+
+    // Number of rows (one per subdomain)
+    let size_of_new_domain = evals.len() / folding_factor_exp;
+
+    // Step 1: Reshape via transposition
+    transpose(evals, folding_factor_exp, size_of_new_domain);
+
+    // Step 2: Apply inverse NTTs
+    intt_batch(evals, folding_factor_exp);
+
+    // Step 3: Apply scaling to match the desired domain layout
+    // Each value is scaled by: size_inv * offset^j
+    let size_inv = F::from(folding_factor_exp as u64).inverse().unwrap();
+    #[cfg(not(feature = "parallel"))]
+    {
+        let mut coset_offset_inv = F::ONE;
+        for answers in evals.chunks_exact_mut(folding_factor_exp) {
+            let mut scale = size_inv;
+            for v in answers.iter_mut() {
+                *v *= scale;
+                scale *= coset_offset_inv;
+            }
+            coset_offset_inv *= domain_gen_inv;
+        }
+    }
+    #[cfg(feature = "parallel")]
+    evals
+        .par_chunks_exact_mut(folding_factor_exp)
+        .enumerate()
+        .for_each_with(F::ZERO, |offset, (i, answers)| {
+            if *offset == F::ZERO {
+                *offset = domain_gen_inv.pow([i as u64]);
+            } else {
+                *offset *= domain_gen_inv;
+            }
+            let mut scale = size_inv;
+            for v in answers.iter_mut() {
+                *v *= scale;
+                scale *= &*offset;
+            }
+        });
+}

--- a/src/ntt/test_utils.rs
+++ b/src/ntt/test_utils.rs
@@ -68,7 +68,7 @@ pub(super) fn expand_from_coeff<F: FftField>(coeffs: &[F], expansion: usize) -> 
 ///
 /// # Panics
 /// Panics if the input size is not divisible by `2^folding_factor`.
-pub(crate) fn transform_evaluations<F: FftField>(
+pub fn transform_evaluations<F: FftField>(
     evals: &mut [F],
     domain_gen_inv: F,
     folding_factor: usize,

--- a/src/poly_utils/fold.rs
+++ b/src/poly_utils/fold.rs
@@ -1,10 +1,6 @@
-use ark_ff::{FftField, Field};
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
+use ark_ff::Field;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
-
-use crate::ntt::{intt_batch, transpose};
 
 /// Computes the folded value of a function evaluated on a coset.
 ///
@@ -71,95 +67,96 @@ pub fn compute_fold<F: Field>(
     answers[0]
 }
 
-/// Applies a folding transformation to evaluation vectors in-place.
-///
-/// Performs reshaping, inverse NTTs, and applies coset + scaling correction.
-///
-/// The evaluations are grouped into `2^folding_factor` blocks of size `N / 2^folding_factor`.
-/// For each group, the function performs the following:
-///
-/// 1. Transpose: reshape layout to enable independent processing of each sub-coset.
-/// 2. Inverse NTT: convert each sub-coset from evaluation to coefficient form (no 1/N scaling).
-/// 3. Scale correction:
-///    Each output is multiplied by:
-///
-///    ```ignore
-///    size_inv * (domain_gen_inv^i)^j
-///    ```
-///
-///    where:
-///      - `size_inv = 1 / 2^folding_factor`
-///      - `i` is the subdomain index
-///      - `j` is the index within the block
-///
-/// # Panics
-/// Panics if the input size is not divisible by `2^folding_factor`.
-#[cfg_attr(feature = "tracing", instrument(skip_all, fields(size = evals.len(), folding_factor)))]
-pub fn transform_evaluations<F: FftField>(
-    evals: &mut [F],
-    domain_gen_inv: F,
-    folding_factor: usize,
-) {
-    // Compute the number of sub-cosets = 2^folding_factor
-    let folding_factor_exp = 1 << folding_factor;
-
-    // Ensure input is divisible by folding factor
-    assert!(evals.len() % folding_factor_exp == 0);
-
-    // Number of rows (one per subdomain)
-    let size_of_new_domain = evals.len() / folding_factor_exp;
-
-    // Step 1: Reshape via transposition
-    transpose(evals, folding_factor_exp, size_of_new_domain);
-
-    // Step 2: Apply inverse NTTs
-    intt_batch(evals, folding_factor_exp);
-
-    // Step 3: Apply scaling to match the desired domain layout
-    // Each value is scaled by: size_inv * offset^j
-    let size_inv = F::from(folding_factor_exp as u64).inverse().unwrap();
-    #[cfg(not(feature = "parallel"))]
-    {
-        let mut coset_offset_inv = F::ONE;
-        for answers in evals.chunks_exact_mut(folding_factor_exp) {
-            let mut scale = size_inv;
-            for v in answers.iter_mut() {
-                *v *= scale;
-                scale *= coset_offset_inv;
-            }
-            coset_offset_inv *= domain_gen_inv;
-        }
-    }
-    #[cfg(feature = "parallel")]
-    evals
-        .par_chunks_exact_mut(folding_factor_exp)
-        .enumerate()
-        .for_each_with(F::ZERO, |offset, (i, answers)| {
-            if *offset == F::ZERO {
-                *offset = domain_gen_inv.pow([i as u64]);
-            } else {
-                *offset *= domain_gen_inv;
-            }
-            let mut scale = size_inv;
-            for v in answers.iter_mut() {
-                *v *= scale;
-                scale *= &*offset;
-            }
-        });
-}
-
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use ark_ff::{AdditiveGroup, FftField, Field};
+    #[cfg(feature = "parallel")]
+    use rayon::prelude::*;
 
-    use super::{compute_fold, transform_evaluations};
+    use super::compute_fold;
     use crate::{
         crypto::fields::Field64,
-        ntt::transpose,
+        ntt::{intt_batch, transpose},
         poly_utils::{coeffs::CoefficientList, multilinear::MultilinearPoint},
     };
 
     type F = Field64;
+
+    /// Applies a folding transformation to evaluation vectors in-place.
+    ///
+    /// Performs reshaping, inverse NTTs, and applies coset + scaling correction.
+    ///
+    /// The evaluations are grouped into `2^folding_factor` blocks of size `N / 2^folding_factor`.
+    /// For each group, the function performs the following:
+    ///
+    /// 1. Transpose: reshape layout to enable independent processing of each sub-coset.
+    /// 2. Inverse NTT: convert each sub-coset from evaluation to coefficient form (no 1/N scaling).
+    /// 3. Scale correction:
+    ///    Each output is multiplied by:
+    ///
+    ///    ```ignore
+    ///    size_inv * (domain_gen_inv^i)^j
+    ///    ```
+    ///
+    ///    where:
+    ///      - `size_inv = 1 / 2^folding_factor`
+    ///      - `i` is the subdomain index
+    ///      - `j` is the index within the block
+    ///
+    /// # Panics
+    /// Panics if the input size is not divisible by `2^folding_factor`.
+    pub(crate) fn transform_evaluations<F: FftField>(
+        evals: &mut [F],
+        domain_gen_inv: F,
+        folding_factor: usize,
+    ) {
+        // Compute the number of sub-cosets = 2^folding_factor
+        let folding_factor_exp = 1 << folding_factor;
+
+        // Ensure input is divisible by folding factor
+        assert!(evals.len() % folding_factor_exp == 0);
+
+        // Number of rows (one per subdomain)
+        let size_of_new_domain = evals.len() / folding_factor_exp;
+
+        // Step 1: Reshape via transposition
+        transpose(evals, folding_factor_exp, size_of_new_domain);
+
+        // Step 2: Apply inverse NTTs
+        intt_batch(evals, folding_factor_exp);
+
+        // Step 3: Apply scaling to match the desired domain layout
+        // Each value is scaled by: size_inv * offset^j
+        let size_inv = F::from(folding_factor_exp as u64).inverse().unwrap();
+        #[cfg(not(feature = "parallel"))]
+        {
+            let mut coset_offset_inv = F::ONE;
+            for answers in evals.chunks_exact_mut(folding_factor_exp) {
+                let mut scale = size_inv;
+                for v in answers.iter_mut() {
+                    *v *= scale;
+                    scale *= coset_offset_inv;
+                }
+                coset_offset_inv *= domain_gen_inv;
+            }
+        }
+        #[cfg(feature = "parallel")]
+        evals
+            .par_chunks_exact_mut(folding_factor_exp)
+            .enumerate()
+            .for_each_with(F::ZERO, |offset, (i, answers)| {
+                if *offset == F::ZERO {
+                    *offset = domain_gen_inv.pow([i as u64]);
+                } else {
+                    *offset *= domain_gen_inv;
+                }
+                let mut scale = size_inv;
+                for v in answers.iter_mut() {
+                    *v *= scale;
+                    scale *= &*offset;
+                }
+            });
+    }
 
     #[test]
     fn test_folding() {

--- a/src/poly_utils/fold.rs
+++ b/src/poly_utils/fold.rs
@@ -68,95 +68,17 @@ pub fn compute_fold<F: Field>(
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use ark_ff::{AdditiveGroup, FftField, Field};
-    #[cfg(feature = "parallel")]
-    use rayon::prelude::*;
 
     use super::compute_fold;
     use crate::{
         crypto::fields::Field64,
-        ntt::{intt_batch, transpose},
+        ntt::{test_utils::transform_evaluations, transpose},
         poly_utils::{coeffs::CoefficientList, multilinear::MultilinearPoint},
     };
 
     type F = Field64;
-
-    /// Applies a folding transformation to evaluation vectors in-place.
-    ///
-    /// Performs reshaping, inverse NTTs, and applies coset + scaling correction.
-    ///
-    /// The evaluations are grouped into `2^folding_factor` blocks of size `N / 2^folding_factor`.
-    /// For each group, the function performs the following:
-    ///
-    /// 1. Transpose: reshape layout to enable independent processing of each sub-coset.
-    /// 2. Inverse NTT: convert each sub-coset from evaluation to coefficient form (no 1/N scaling).
-    /// 3. Scale correction:
-    ///    Each output is multiplied by:
-    ///
-    ///    ```ignore
-    ///    size_inv * (domain_gen_inv^i)^j
-    ///    ```
-    ///
-    ///    where:
-    ///      - `size_inv = 1 / 2^folding_factor`
-    ///      - `i` is the subdomain index
-    ///      - `j` is the index within the block
-    ///
-    /// # Panics
-    /// Panics if the input size is not divisible by `2^folding_factor`.
-    pub(crate) fn transform_evaluations<F: FftField>(
-        evals: &mut [F],
-        domain_gen_inv: F,
-        folding_factor: usize,
-    ) {
-        // Compute the number of sub-cosets = 2^folding_factor
-        let folding_factor_exp = 1 << folding_factor;
-
-        // Ensure input is divisible by folding factor
-        assert!(evals.len() % folding_factor_exp == 0);
-
-        // Number of rows (one per subdomain)
-        let size_of_new_domain = evals.len() / folding_factor_exp;
-
-        // Step 1: Reshape via transposition
-        transpose(evals, folding_factor_exp, size_of_new_domain);
-
-        // Step 2: Apply inverse NTTs
-        intt_batch(evals, folding_factor_exp);
-
-        // Step 3: Apply scaling to match the desired domain layout
-        // Each value is scaled by: size_inv * offset^j
-        let size_inv = F::from(folding_factor_exp as u64).inverse().unwrap();
-        #[cfg(not(feature = "parallel"))]
-        {
-            let mut coset_offset_inv = F::ONE;
-            for answers in evals.chunks_exact_mut(folding_factor_exp) {
-                let mut scale = size_inv;
-                for v in answers.iter_mut() {
-                    *v *= scale;
-                    scale *= coset_offset_inv;
-                }
-                coset_offset_inv *= domain_gen_inv;
-            }
-        }
-        #[cfg(feature = "parallel")]
-        evals
-            .par_chunks_exact_mut(folding_factor_exp)
-            .enumerate()
-            .for_each_with(F::ZERO, |offset, (i, answers)| {
-                if *offset == F::ZERO {
-                    *offset = domain_gen_inv.pow([i as u64]);
-                } else {
-                    *offset *= domain_gen_inv;
-                }
-                let mut scale = size_inv;
-                for v in answers.iter_mut() {
-                    *v *= scale;
-                    scale *= &*offset;
-                }
-            });
-    }
 
     #[test]
     fn test_folding() {

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -12,8 +12,8 @@ use tracing::{instrument, span, Level};
 
 use super::Witness;
 use crate::{
-    ntt::expand_from_coeff,
-    poly_utils::{coeffs::CoefficientList, fold::transform_evaluations},
+    ntt::rs_encode_coset_poly,
+    poly_utils::coeffs::CoefficientList,
     whir::{
         parameters::WhirConfig,
         utils::{sample_ood_points, DigestToUnitSerialize},
@@ -65,10 +65,9 @@ where
         let expansion = base_domain.size() / polynomial.num_coeffs();
 
         // Expand the polynomial coefficients into evaluations over the extended domain.
-        let mut evals = expand_from_coeff(polynomial.coeffs(), expansion);
-        transform_evaluations(
-            &mut evals,
-            base_domain.group_gen_inv(),
+        let evals = rs_encode_coset_poly(
+            polynomial.coeffs(),
+            expansion,
             self.0.folding_factor.at_round(0),
         );
 

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -12,7 +12,7 @@ use tracing::{instrument, span, Level};
 
 use super::Witness;
 use crate::{
-    ntt::rs_encode_coset_poly,
+    ntt::interleaved_rs_encode,
     poly_utils::coeffs::CoefficientList,
     whir::{
         parameters::WhirConfig,
@@ -65,7 +65,7 @@ where
         let expansion = base_domain.size() / polynomial.num_coeffs();
 
         // Expand the polynomial coefficients into evaluations over the extended domain.
-        let evals = rs_encode_coset_poly(
+        let evals = interleaved_rs_encode(
             polynomial.coeffs(),
             expansion,
             self.0.folding_factor.at_round(0),

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -19,10 +19,8 @@ use super::{
 };
 use crate::{
     domain::Domain,
-    ntt::expand_from_coeff,
-    poly_utils::{
-        coeffs::CoefficientList, fold::transform_evaluations, multilinear::MultilinearPoint,
-    },
+    ntt::rs_encode_coset_poly,
+    poly_utils::{coeffs::CoefficientList, multilinear::MultilinearPoint},
     sumcheck::SumcheckSingle,
     utils::expand_randomness,
     whir::{
@@ -208,12 +206,8 @@ where
         // Fold the coefficients, and compute fft of polynomial (and commit)
         let new_domain = round_state.domain.scale(2);
         let expansion = new_domain.size() / folded_coefficients.num_coeffs();
-        let mut evals = expand_from_coeff(folded_coefficients.coeffs(), expansion);
-        transform_evaluations(
-            &mut evals,
-            new_domain.backing_domain.group_gen_inv(),
-            folding_factor_next,
-        );
+        let evals =
+            rs_encode_coset_poly(folded_coefficients.coeffs(), expansion, folding_factor_next);
 
         #[cfg(not(feature = "parallel"))]
         let leafs_iter = evals.chunks_exact(1 << folding_factor_next);

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -19,7 +19,7 @@ use super::{
 };
 use crate::{
     domain::Domain,
-    ntt::rs_encode_coset_poly,
+    ntt::interleaved_rs_encode,
     poly_utils::{coeffs::CoefficientList, multilinear::MultilinearPoint},
     sumcheck::SumcheckSingle,
     utils::expand_randomness,
@@ -207,7 +207,7 @@ where
         let new_domain = round_state.domain.scale(2);
         let expansion = new_domain.size() / folded_coefficients.num_coeffs();
         let evals =
-            rs_encode_coset_poly(folded_coefficients.coeffs(), expansion, folding_factor_next);
+            interleaved_rs_encode(folded_coefficients.coeffs(), expansion, folding_factor_next);
 
         #[cfg(not(feature = "parallel"))]
         let leafs_iter = evals.chunks_exact(1 << folding_factor_next);


### PR DESCRIPTION
Add interleaved RS encoding of polynomial
- Interleaved RS encoding using `rs_encode_coset_poly`.
- Moved old functions [expand_from_coeff](https://github.com/WizardOfMenlo/whir/blob/654326d096b6dc9ca21897e5e9ad20bfa4f9cd18/src/ntt/mod.rs#L24) and [transform_evaluations](https://github.com/WizardOfMenlo/whir/blob/654326d096b6dc9ca21897e5e9ad20bfa4f9cd18/src/poly_utils/fold.rs#L98) to tests
- Updated benchmark code
- Added better documentation