### PR TITLE
fix grinding (was done after query, instead of before)

### DIFF
--- a/src/whir/domainsep.rs
+++ b/src/whir/domainsep.rs
@@ -70,10 +70,10 @@ where
             self = self
                 .add_digest("merkle_digest")
                 .add_ood(r.ood_samples)
+                .pow(r.pow_bits)
                 .challenge_bytes(r.num_queries * domain_size_bytes, "stir_queries")
                 .hint("stir_answers")
                 .hint("merkle_proof")
-                .pow(r.pow_bits)
                 .challenge_scalars(1, "combination_randomness")
                 .add_sumcheck(
                     params.folding_factor.at_round(round + 1),
@@ -89,10 +89,10 @@ where
         let domain_size_bytes = ((folded_domain_size * 2 - 1).ilog2() as usize).div_ceil(8);
 
         self.add_scalars(1 << params.final_sumcheck_rounds, "final_coeffs")
+            .pow(params.final_pow_bits)
             .challenge_bytes(domain_size_bytes * params.final_queries, "final_queries")
             .hint("stir_answers")
             .hint("merkle_proof")
-            .pow(params.final_pow_bits)
             .add_sumcheck(params.final_sumcheck_rounds, params.final_folding_pow_bits)
             .hint("deferred_weight_evaluations")
     }

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -235,6 +235,18 @@ where
             |point| folded_coefficients.evaluate(point),
         )?;
 
+        // PoW
+        if round_params.pow_bits > 0. {
+            #[cfg(feature = "tracing")]
+            let _span = span!(
+                Level::INFO,
+                "challenge_pow",
+                pow_bits = round_params.pow_bits
+            )
+            .entered();
+            prover_state.challenge_pow::<PowStrategy>(round_params.pow_bits)?;
+        }
+
         // STIR Queries
         let (stir_challenges, stir_challenges_indexes) = self.compute_stir_queries(
             prover_state,
@@ -262,18 +274,6 @@ where
         stir_evaluations.extend(answers.iter().map(|answers| {
             CoefficientList::new(answers.clone()).evaluate(&round_state.folding_randomness)
         }));
-
-        // PoW
-        if round_params.pow_bits > 0. {
-            #[cfg(feature = "tracing")]
-            let _span = span!(
-                Level::INFO,
-                "challenge_pow",
-                pow_bits = round_params.pow_bits
-            )
-            .entered();
-            prover_state.challenge_pow::<PowStrategy>(round_params.pow_bits)?;
-        }
 
         // Randomness for combination
         let [combination_randomness_gen] = prover_state.challenge_scalars()?;
@@ -352,6 +352,18 @@ where
         // Precompute the folding factors for later use
         let folding_factor = self.0.folding_factor.at_round(round_state.round);
 
+        // PoW
+        if self.0.final_pow_bits > 0. {
+            #[cfg(feature = "tracing")]
+            let _span = span!(
+                Level::INFO,
+                "challenge_pow",
+                pow_bits = self.0.final_pow_bits
+            )
+            .entered();
+            prover_state.challenge_pow::<PowStrategy>(self.0.final_pow_bits)?;
+        }
+
         // Final verifier queries and answers. The indices are over the
         // *folded* domain.
         let final_challenge_indexes = get_challenge_stir_queries(
@@ -376,18 +388,6 @@ where
 
         prover_state.hint::<Vec<Vec<F>>>(&answers)?;
         prover_state.hint::<MultiPath<MerkleConfig>>(&merkle_proof)?;
-
-        // PoW
-        if self.0.final_pow_bits > 0. {
-            #[cfg(feature = "tracing")]
-            let _span = span!(
-                Level::INFO,
-                "challenge_pow",
-                pow_bits = self.0.final_pow_bits
-            )
-            .entered();
-            prover_state.challenge_pow::<PowStrategy>(self.0.final_pow_bits)?;
-        }
 
         // Final sumcheck
         if self.0.final_sumcheck_rounds > 0 {

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -264,6 +264,8 @@ where
         commitment: &ParsedCommitment<F, MerkleConfig::InnerDigest>,
         folding_randomness: &MultilinearPoint<F>,
     ) -> ProofResult<Vec<Constraint<F>>> {
+        self.verify_proof_of_work(verifier_state, params.pow_bits)?;
+
         let stir_challenges_indexes = get_challenge_stir_queries(
             params.domain_size,
             params.folding_factor,
@@ -273,8 +275,6 @@ where
 
         let answers =
             self.verify_merkle_proof(verifier_state, &commitment.root, &stir_challenges_indexes)?;
-
-        self.verify_proof_of_work(verifier_state, params.pow_bits)?;
 
         // Compute STIR Constraints
         let folds: Vec<F> = answers


### PR DESCRIPTION
As described in section 6.3 of the [EthStark paper](https://eprint.iacr.org/2021/582.pdf), grinding should be done "before" queries. Because a typical attack against FRI/WHIR is to get "lucky" indexes, after having sent a polynomial which does not correspond to the folding of the previously committed (via merkle root of evaluations) polynomial. So we want the grinding work to appear during each iteration of the search for these "lucky" indexes, not after, once they are found.