### PR TITLE
WhirConfig: Restore Send + Sync

### DIFF
--- a/src/ntt/mod.rs
+++ b/src/ntt/mod.rs
@@ -62,8 +62,8 @@ pub fn interleaved_rs_encode<F: FftField>(
     result
 }
 
-/// Trait for replacing the default Reed Solomon encoding ([`RSDefault`]) with an specialised Reed Solomon encoder for the FFTField and BasePrimeField
-pub trait ReedSolomon<F: FftField> {
+/// Trait for replacing the default Reed Solomon encoding ([`RSDefault`]) with an specialised Reed Solomon encoder for the FFTField and BasePrimeField.
+pub trait ReedSolomon<F: FftField>: Send + Sync {
     fn interleaved_encode(
         &self,
         interleaved_coeffs: &[F],


### PR DESCRIPTION
Send + Sync are autotraits but were lost due to the inclusion of `Arc<dyn ReedSolomon>`. Tags however are safe to send and sync across threads so it is fine to add the constraints to ReedSolomon.