### PR TITLE
Reduce tracing noise from internal spans

### DIFF
--- a/src/algebra/ntt/mod.rs
+++ b/src/algebra/ntt/mod.rs
@@ -101,7 +101,7 @@ pub fn interleaved_rs_encode<F: 'static>(
 /// This function computes the RS-code for each interleaved message and
 /// outputs the interleaved alphabets in the same order as the input.
 ///
-#[cfg_attr(feature = "tracing", instrument(skip(coeffs), fields(size = coeffs.len())))]
+#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(coeffs), fields(size = coeffs.len())))]
 fn ark_ntt<F: FftField>(coeffs: &[F], expansion: usize, interleaving_depth: usize) -> Vec<F> {
     assert!(expansion > 0);
     assert!(coeffs.len().is_multiple_of(interleaving_depth));

--- a/src/algebra/polynomials/coeffs.rs
+++ b/src/algebra/polynomials/coeffs.rs
@@ -116,7 +116,7 @@ impl<F: Field> CoefficientList<F> {
     /// - The number of variables decreases: `m = n - k`
     /// - Uses multivariate evaluation over chunks of coefficients.
     #[must_use]
-    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(size = self.coeffs.len())))]
+    #[cfg_attr(feature = "tracing", instrument(level = "debug", skip_all, fields(size = self.coeffs.len())))]
     pub fn fold(&self, folding_randomness: &MultilinearPoint<F>) -> Self {
         let folding_factor = folding_randomness.num_variables();
         #[cfg(not(feature = "parallel"))]

--- a/src/algebra/polynomials/fold.rs
+++ b/src/algebra/polynomials/fold.rs
@@ -25,7 +25,7 @@ use tracing::instrument;
 /// - \( o^{-1} \) is the inverse coset offset
 /// - \( g^{-i} \) is the inverse generator raised to index \( i \)
 /// - The function is recursively applied until the vector reduces to size 1.
-#[cfg_attr(feature = "tracing", instrument(skip_all))]
+#[cfg_attr(feature = "tracing", instrument(level = "debug", skip_all))]
 pub fn compute_fold<F: Field>(
     answers: &[F],
     folding_randomness: &[F],

--- a/src/algebra/weights.rs
+++ b/src/algebra/weights.rs
@@ -125,7 +125,7 @@ impl<F: Field> Weights<F> {
     ///
     /// **Precondition:**
     /// `accumulator.num_variables()` must match `self.num_variables()`.
-    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(num_variables = self.num_variables())))]
+    #[cfg_attr(feature = "tracing", instrument(level = "debug", skip_all, fields(num_variables = self.num_variables())))]
     pub fn accumulate(&self, accumulator: &mut EvaluationsList<F>, factor: F) {
         use crate::utils::eval_eq;
 

--- a/src/protocols/merkle_tree.rs
+++ b/src/protocols/merkle_tree.rs
@@ -106,7 +106,7 @@ impl Config {
                 .expect("Hash Engine not found");
             #[cfg(feature = "tracing")]
             let _span = span!(
-                Level::INFO,
+                Level::DEBUG,
                 "layer",
                 engine = engine.name().as_ref(),
                 count = current.len()
@@ -141,7 +141,7 @@ impl Config {
     /// Opens the commitment at the provided indices.
     ///
     /// Indices can be in any order and may contain duplicates.
-    #[cfg_attr(feature = "tracing", instrument(skip(prover_state, witness, indices), fields( num_indices = indices.len())))]
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(num_indices = indices.len())))]
     pub fn open<H, R>(
         &self,
         prover_state: &mut ProverState<H, R>,

--- a/src/protocols/proof_of_work.rs
+++ b/src/protocols/proof_of_work.rs
@@ -57,7 +57,7 @@ impl Config {
         difficulty(self.threshold)
     }
 
-    #[cfg_attr(feature = "tracing", instrument(skip(prover_state), fields(engine)))]
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(engine)))]
     pub fn prove<H, R>(&self, prover_state: &mut ProverState<H, R>)
     where
         H: DuplexSpongeInterface,

--- a/src/protocols/sumcheck.rs
+++ b/src/protocols/sumcheck.rs
@@ -63,7 +63,7 @@ impl<F: Field> Config<F> {
     /// - Samples random values to progressively reduce the polynomial.
     /// - Applies proof-of-work grinding if required.
     /// - Returns the sampled folding randomness values used in each reduction step.
-    #[cfg_attr(feature = "tracing", instrument(skip(self, prover_state)))]
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn prove<H, R>(
         &self,
         prover_state: &mut ProverState<H, R>,
@@ -108,7 +108,7 @@ impl<F: Field> Config<F> {
         MultilinearPoint(res)
     }
 
-    #[cfg_attr(feature = "tracing", instrument(skip(verifier_state)))]
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn verify<H>(
         &self,
         verifier_state: &mut VerifierState<H>,


### PR DESCRIPTION
## Summary

- Demote internal implementation spans (`merkle_tree::layer`, `ntt::ark_ntt`, `coeffs::fold`, `weights::accumulate`, `fold::compute_fold`) to `debug` level so they don't show up in default INFO-level output.
- Switch noisy `instrument` attributes to `skip_all` on `sumcheck::prove`, `sumcheck::verify`, `proof_of_work::prove`, and `merkle_tree::open` to avoid dumping large field element arrays and full `Config` structs into span fields.

Tested against ProveKit's `complete_age_check` circuit — prove output dropped from 1261 to 274 lines with no change in behavior.