### PR TITLE
Fix batch_size underflow in matrix_commit for small cache sizes

### DIFF
--- a/src/protocols/matrix_commit.rs
+++ b/src/protocols/matrix_commit.rs
@@ -351,8 +351,9 @@ fn hash_rows_serial<T: Encodable + Send + Sync>(
     if encoder.is_buffered() {
         // Buffered encoder, find some optimal size.
         let target = workload_size::<u8>() / 8;
-        let batch_size = (target / message_size).next_multiple_of(engine.preferred_batch_size());
-        assert!(batch_size >= 1);
+        let batch_size = (target / message_size)
+            .max(1)
+            .next_multiple_of(engine.preferred_batch_size());
         for (matrix, out) in
             zip_strict(matrix.chunks(batch_size * cols), out.chunks_mut(batch_size))
         {

--- a/src/protocols/whir/config.rs
+++ b/src/protocols/whir/config.rs
@@ -462,7 +462,7 @@ where
     F: FftField,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "  commit   {}", self.irs_committer,)?;
+        writeln!(f, "  commit   {}", self.irs_committer)?;
         writeln!(f, "  pow      {:.2} bits", self.pow.difficulty())?;
         writeln!(f, "  sumcheck {}", self.sumcheck)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,15 +22,21 @@ pub const fn workload_size<T: Sized>() -> usize {
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     const CACHE_SIZE: usize = 1 << 17; // 128KB for Apple Silicon
 
-    #[cfg(all(target_arch = "aarch64", any(target_os = "ios", target_os = "android")))]
-    const CACHE_SIZE: usize = 1 << 16; // 64KB for mobile ARM
+    #[cfg(all(
+        target_arch = "aarch64",
+        any(target_os = "ios", target_os = "android", target_os = "linux")
+    ))]
+    const CACHE_SIZE: usize = 1 << 16; // 64KB for mobile/server ARM
 
     #[cfg(target_arch = "x86_64")]
     const CACHE_SIZE: usize = 1 << 15; // 32KB for x86-64
 
     #[cfg(not(any(
         all(target_arch = "aarch64", target_os = "macos"),
-        all(target_arch = "aarch64", any(target_os = "ios", target_os = "android")),
+        all(
+            target_arch = "aarch64",
+            any(target_os = "ios", target_os = "android", target_os = "linux")
+        ),
         target_arch = "x86_64"
     )))]
     const CACHE_SIZE: usize = 1 << 15; // 32KB default


### PR DESCRIPTION
## Summary

- Fix integer underflow in `hash_rows_serial` where `batch_size` becomes 0 when `message_size > target`, causing `assert!(batch_size >= 1)` to panic
- Add Linux aarch64 to the 64KB cache size tier (was falling through to 32KB default)

## Problem

On Linux aarch64 (e.g. GitHub Actions `ubuntu-24.04-arm` with Graviton/Ampere), `workload_size` returns 32KB (the default fallback). With `starting_log_inv_rate = 2` (4x codeword expansion), the per-row `message_size` can exceed `target = workload_size / 8 = 4096`, making `target / message_size = 0`. Then `0.next_multiple_of(preferred_batch_size)` returns 0, tripping the assertion.

This doesn't reproduce on macOS aarch64 (128KB cache) because the larger target prevents the underflow.

## Fix

1. **`matrix_commit.rs`**: `.max(1)` before `next_multiple_of` ensures batch_size >= 1
2. **`utils.rs`**: Linux aarch64 gets 64KB cache size (Graviton3/4 and Ampere Altra have 64KB L1d)