### PR TITLE
add checks for unused imports in Cargo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo fmt --all --check
 
   unused_deps:
-    name: check for unused dependencies
+    name: Check for unused dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,6 @@ dependencies = [
 name = "whir"
 version = "0.1.0"
 dependencies = [
- "approx",
  "ark-ff",
  "ark-serialize",
  "ark-std",
@@ -1548,7 +1547,6 @@ dependencies = [
  "digest",
  "hex",
  "hex-literal",
- "itertools 0.14.0",
  "ordered-float",
  "proptest",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spongefish = { git = "https://github.com/arkworks-rs/spongefish", features = ["ark-ff"], rev = "fcc277f8a857fdeeadd7cca92ab08de63b1ff1a1"}
 rayon = { version = "1.10", optional = true }
-itertools = "0.14"
 tracing = { version = "0.1", features = ["attributes"], optional = true }
 hex = "0.4"
 static_assertions = "1.1.0"
@@ -55,7 +54,6 @@ hex-literal = "0.4.1"
 const-oid = "0.9.6"
 arrayvec = "0.7.6"
 derive-where = { version = "1.6.0", features = ["safe"] }
-approx = "0.5.1"
 ordered-float = { version = "5.1.0", features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Having noticed that some of the repos we work on have dangling unused imports in Cargo files.
This machete tool is cleaning them up, so I think it is pretty useful to have it as part of the CI:

Here are the results I got in the first run on this repo:
```cargo-machete installed successfully.
Run cargo-machete 
Analyzing dependencies of crates in this directory...
Done!
cargo-machete found the following unused dependencies in this directory:
whir -- ./Cargo.toml:
	approx
	itertools
``` 