### PR TITLE
Expose protocol_id and session_id fields

### DIFF
--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -48,8 +48,8 @@ where
 
 #[derive(Clone, Copy, Debug)]
 pub struct DomainSeparator<'a, I> {
-    protocol_id: [u8; 64],
-    session_id: [u8; 32],
+    pub protocol_id: [u8; 64],
+    pub session_id: [u8; 32],
     instance: &'a I,
 }
 


### PR DESCRIPTION
In ProveKit, while updating the recursive verifier, we need to access these values so that the Gnark circuit can initialize the nimue transcript with the same arguments WHIR uses.


 