### PR TITLE
zkWHIR 3.0 : Code Switch Protocol (part 1)

### DIFF
--- a/proptest-regressions/protocols/code_switch.txt
+++ b/proptest-regressions/protocols/code_switch.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc d1b11d6a89f5f0e74e62779bf54948e664f6780433d440ac3d977744776ed358 # shrinks to seed = 0, source_size = 3, src_lir = 1, tgt_lir = 1
 cc e5c94e6ed6e6d91a8725206056b46ea1c13efd83e0c206e32f20a01929ddf654 # shrinks to seed = 0, source_size = 12, src_lir = 1, tgt_lir = 1
+cc c5cdfb9b93481bf4819a4207587a6bf93c85cce8b7e2e999a9478cfc0f78cc0d # shrinks to seed = 0, source_size = 8, src_lir = 2, tgt_lir = 1

--- a/proptest-regressions/protocols/code_switch.txt
+++ b/proptest-regressions/protocols/code_switch.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d1b11d6a89f5f0e74e62779bf54948e664f6780433d440ac3d977744776ed358 # shrinks to seed = 0, source_size = 3, src_lir = 1, tgt_lir = 1
+cc e5c94e6ed6e6d91a8725206056b46ea1c13efd83e0c206e32f20a01929ddf654 # shrinks to seed = 0, source_size = 12, src_lir = 1, tgt_lir = 1

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -1,0 +1,432 @@
+//! Code-switching IOR: R_{C, sl} → R_{C', sl'}
+//!
+//! Reduces a proximity claim about oracle f (source code C) to a proximity
+//! claim about oracle g (target code C'). Non-ZK variant.
+//!
+//! Paper: Construction 9.7 (p.55), Theorem 9.6 (p.54), Lemma 9.9 (p.57)
+
+use ark_ff::Field;
+use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    algebra::{
+        dot,
+        embedding::{Embedding, Identity},
+        fields::FieldWithSize,
+        linear_form::UnivariateEvaluation,
+        mixed_dot, mixed_univariate_evaluate, univariate_evaluate,
+    },
+    bits::Bits,
+    hash::Hash,
+    protocols::{geometric_challenge::geometric_challenge, irs_commit, proof_of_work},
+    transcript::{
+        Codec, Decoding, DuplexSpongeInterface, ProverMessage, ProverState, VerificationResult,
+        VerifierMessage, VerifierState,
+    },
+    type_info::Typed,
+};
+
+/// Prover output from the code-switch interaction phase.
+/// Paper: Equation 9 (p.55)
+#[derive(Clone, Debug)]
+pub struct Witness<F: Field, G: Field = F> {
+    /// Target oracle commitment data. G_target = F since target uses Identity<F>.
+    pub target_witness: irs_commit::Witness<F>,
+    /// The message f, taken by ownership from the caller.
+    pub message: Vec<F>,
+    /// Source oracle evaluations at in-domain query points (in M::Source = G).
+    pub source_evaluations: irs_commit::Evaluations<G>,
+}
+
+/// Verifier output from the code-switch decision phase.
+/// Paper: Equation 9 (p.55) — output (x', y')
+#[derive(Clone, Debug)]
+pub struct CodeSwitchClaim<F: Field, G: Field = F> {
+    /// μ' — batched target value. Decision phase formula (p.55).
+    pub mu_prime: F,
+    /// ν_1 = batching_coeffs[0]. Caller scales original sl by this.
+    pub original_sl_coeff: F,
+    /// Target oracle commitment (g).
+    pub target_commitment: irs_commit::Commitment<F>,
+    /// RLC coefficients for constraint weights (batching_coeffs[1..]).
+    pub constraint_rlc_coeffs: Vec<F>,
+    /// OOD constraint weights — UnivariateEvaluation at each OOD point (M::Target).
+    pub ood_constraint_weights: Vec<UnivariateEvaluation<F>>,
+    /// In-domain constraint weights — UnivariateEvaluation at each source eval point (M::Source).
+    pub in_domain_constraint_weights: Vec<UnivariateEvaluation<G>>,
+    /// Source oracle evaluation data from in-domain queries.
+    pub source_evaluations: irs_commit::Evaluations<G>,
+}
+
+/// Code-switching IOR config. Non-ZK variant (n=0, no C_zk masks).
+///
+/// TODO [ZK]: Add mask oracle, private zero-evaders, mask terms in sl'.
+#[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct Config<M: Embedding> {
+    pub embedding: Typed<M>,
+    /// Source code C.
+    pub source: irs_commit::Config<M>,
+    /// Target code C'. Message length ℓ' = ℓ (same message).
+    pub target: irs_commit::Config<Identity<M::Target>>,
+    /// OOD samples tying source and target to the same message.
+    pub cs_ood_samples: usize,
+    // In-domain queries reuse source.in_domain_samples (same formula).
+    // Reintroduce cs_in_domain_queries if security budgets diverge or mask_length > 0.
+    /// Proof-of-work config (set by parent orchestrator).
+    pub pow: proof_of_work::Config,
+}
+
+/// Squeeze batching randomness from the transcript.
+/// Both prove() and verify() must call this at the same transcript position
+/// to stay in sync. Returns (ν_1, batching_coeffs) where ν_1 scales the
+/// original sl and batching_coeffs[i] scales the i-th constraint weight.
+fn batching_challenge<T, F>(transcript: &mut T, count: usize) -> (F, Vec<F>)
+where
+    T: VerifierMessage,
+    F: Field + Decoding<[T::U]>,
+{
+    let mut coeffs = geometric_challenge(transcript, count);
+    let original_sl_coeff = if coeffs.is_empty() {
+        F::ONE
+    } else {
+        coeffs.remove(0)
+    };
+    (original_sl_coeff, coeffs)
+}
+
+impl<M: Embedding> Config<M> {
+    pub fn new(
+        security_target: f64,
+        unique_decoding: bool,
+        hash_id: crate::engines::EngineId,
+        source_config: irs_commit::Config<M>,
+        target_log_inv_rate: usize,
+        target_interleaving_depth: usize,
+    ) -> Self
+    where
+        M: Default,
+        M::Target: Default,
+    {
+        let source_message_length = source_config.message_length();
+
+        // Target: ℓ' = ℓ, m' = ⌈ℓ'/ρ'⌉
+        let target_message_length = source_message_length;
+        let target_rate = 0.5_f64.powf(target_log_inv_rate as f64);
+        let target_vector_size = target_message_length * target_interleaving_depth;
+        let target_config = irs_commit::Config::<Identity<M::Target>>::new(
+            security_target,
+            unique_decoding,
+            hash_id,
+            1,
+            target_vector_size,
+            target_interleaving_depth,
+            target_rate,
+        );
+
+        // OOD: solve |Λ(C',δ')|²/2 · ((ℓ-1)/|F|)^{t_ood} ≤ 2^{-λ}
+        // Target list size, source message length (Lemma 9.9 Error 1, p.57)
+        let cs_ood_samples = irs_commit::num_ood_samples(
+            unique_decoding,
+            security_target,
+            M::Target::field_size_bits(),
+            target_config.list_size(),
+            source_message_length,
+        );
+
+        Self {
+            embedding: Typed::<M>::default(),
+            source: source_config,
+            target: target_config,
+            cs_ood_samples,
+            pow: proof_of_work::Config {
+                hash_id,
+                threshold: proof_of_work::threshold(Bits::new(0.0)),
+            },
+        }
+    }
+
+    /// Prover interaction phase — Construction 9.7 Steps 1-4 (p.55).
+    pub fn prove<H, R>(
+        &self,
+        prover_state: &mut ProverState<H, R>,
+        message: Vec<M::Target>,
+        source_randomness: &[M::Source],
+        source_witness: &irs_commit::Witness<M::Source, M::Target>,
+    ) -> Witness<M::Target, M::Source>
+    where
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Standard: Distribution<M::Target>,
+        M::Target: Codec<[H::U]>,
+        u8: Decoding<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        // Step 1: g := Enc_{C'}(f, r')
+        let target_witness = self.target.commit(prover_state, &[&message]);
+
+        // Step 2: receive OOD challenge ρ_ood
+        let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.cs_ood_samples);
+
+        // Step 3: send OOD answers y_i = f̂(ρ_i) + ρ_i^ℓ · r̂(ρ_i)
+        let msg_len = message.len();
+        for &point in &ood_points {
+            let f_eval = univariate_evaluate(&message, point);
+            let r_eval =
+                mixed_univariate_evaluate(self.source.embedding(), source_randomness, point);
+            let shift = point.pow([msg_len as u64]);
+            prover_state.prover_message(&(f_eval + shift * r_eval));
+            // TODO [ZK]: add ρ^{ℓ+r} · ŝ(ρ) term for mask oracle
+        }
+
+        // Step 4: open source oracle at in-domain queries
+        let source_evaluations = self.source.open(prover_state, &[source_witness]);
+
+        // Step 5: batching randomness (must match verify's batching_challenge call)
+        let _batching = batching_challenge::<_, M::Target>(
+            prover_state,
+            1 + ood_points.len() + source_evaluations.matrix.len(),
+        );
+
+        Witness {
+            target_witness,
+            message,
+            source_evaluations,
+        }
+    }
+
+    /// Verifier decision phase — Construction 9.7 Steps 1-4 + Decision (p.55).
+    pub fn verify<H>(
+        &self,
+        verifier_state: &mut VerifierState<H>,
+        mu: M::Target,
+        source_commitment: &irs_commit::Commitment<M::Target>,
+    ) -> VerificationResult<CodeSwitchClaim<M::Target, M::Source>>
+    where
+        H: DuplexSpongeInterface,
+        Standard: Distribution<M::Target>,
+        M::Target: Codec<[H::U]>,
+        u8: Decoding<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        // Step 1: receive target commitment
+        let target_commitment = self.target.receive_commitment(verifier_state)?;
+
+        // Step 2-3: OOD challenge + answers
+        let ood_points: Vec<M::Target> = verifier_state.verifier_message_vec(self.cs_ood_samples);
+        let ood_answers: Vec<M::Target> =
+            verifier_state.prover_messages_vec(self.cs_ood_samples)?;
+
+        // Step 4: verify source oracle openings
+        let source_evaluations = self.source.verify(verifier_state, &[source_commitment])?;
+
+        // Step 5: batching coefficients (shared helper ensures transcript sync with prover)
+        let t_ood = ood_points.len();
+        let t_times_iota = source_evaluations.matrix.len();
+        let (original_sl_coeff, constraint_rlc_coeffs) =
+            batching_challenge(verifier_state, 1 + t_ood + t_times_iota);
+
+        // Step 6: μ' = ν_1·μ + Σ ν_{1+i}·y_i + ΣΣ ν_{...}·f(x_i)_l
+        let mu_prime = original_sl_coeff * mu
+            + dot(&constraint_rlc_coeffs[..t_ood], &ood_answers)
+            + mixed_dot(
+                self.source.embedding(),
+                &constraint_rlc_coeffs[t_ood..],
+                &source_evaluations.matrix,
+            );
+
+        // Step 7: constraint weights for sl'
+        let source_msg_len = self.source.message_length();
+
+        let ood_constraint_weights: Vec<UnivariateEvaluation<M::Target>> = ood_points
+            .iter()
+            .map(|&point| UnivariateEvaluation::new(point, source_msg_len))
+            .collect();
+
+        let in_domain_constraint_weights: Vec<UnivariateEvaluation<M::Source>> =
+            source_evaluations.evaluators(source_msg_len).collect();
+
+        Ok(CodeSwitchClaim {
+            mu_prime,
+            original_sl_coeff,
+            target_commitment,
+            constraint_rlc_coeffs,
+            ood_constraint_weights,
+            in_domain_constraint_weights,
+            source_evaluations,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_std::rand::{
+        distributions::Standard, prelude::Distribution, rngs::StdRng, Rng, SeedableRng,
+    };
+    use proptest::{proptest, sample::select};
+
+    use super::*;
+    use crate::{
+        algebra::{embedding::Identity, fields, linear_form::Evaluate, ntt, random_vector},
+        transcript::{codecs::U64, DomainSeparator},
+    };
+
+    /// Run full code switch (prove + verify) and check μ' completeness.
+    /// Uses ι=1 (num_vectors=1, interleaving_depth=1) so weight count matches RLC count.
+    fn test_completeness<F: Field + FieldWithSize + Codec<[u8]> + 'static>(
+        seed: u64,
+        source_vector_size: usize,
+        source_log_inv_rate: usize,
+        target_log_inv_rate: usize,
+    ) where
+        Standard: Distribution<F>,
+        Hash: ProverMessage<[u8]>,
+    {
+        let security_target = 32.0;
+        let unique_decoding = false;
+        #[allow(clippy::cast_possible_wrap)]
+        let source_rate = 0.5_f64.powi(source_log_inv_rate as i32);
+
+        let source_config = irs_commit::Config::<Identity<F>>::new(
+            security_target,
+            unique_decoding,
+            crate::hash::BLAKE3,
+            1,
+            source_vector_size,
+            1,
+            source_rate,
+        );
+        let cs_config = Config::<Identity<F>>::new(
+            security_target,
+            unique_decoding,
+            crate::hash::BLAKE3,
+            source_config.clone(),
+            target_log_inv_rate,
+            1,
+        );
+
+        let mut rng = StdRng::seed_from_u64(seed);
+        let message: Vec<F> = random_vector(&mut rng, source_config.message_length());
+        let mu: F = rng.gen();
+
+        let instance = U64(seed);
+        let ds = DomainSeparator::protocol(&cs_config)
+            .session(&String::from("code_switch_proptest"))
+            .instance(&instance);
+
+        // Prover
+        let mut prover_state = ProverState::new_std(&ds);
+        let source_witness = source_config.commit(&mut prover_state, &[&message]);
+        let cs_witness = cs_config.prove(
+            &mut prover_state,
+            message.clone(),
+            &source_witness.masks,
+            &source_witness,
+        );
+        let proof = prover_state.proof();
+
+        // Verifier
+        let mut verifier_state = VerifierState::new_std(&ds, &proof);
+        let source_commitment = source_config
+            .receive_commitment(&mut verifier_state)
+            .unwrap();
+        let claim = cs_config
+            .verify(&mut verifier_state, mu, &source_commitment)
+            .unwrap();
+        verifier_state.check_eof().unwrap();
+
+        // Witness carries the message
+        assert_eq!(cs_witness.message, message);
+
+        // μ' completeness: Σ rlc[i] · weight[i].evaluate(f) == μ' - ν_1·μ
+        let embedding = Identity::<F>::new();
+        let t_ood = claim.ood_constraint_weights.len();
+
+        let weights_on_f: F = claim
+            .ood_constraint_weights
+            .iter()
+            .enumerate()
+            .map(|(i, w)| claim.constraint_rlc_coeffs[i] * w.evaluate(&embedding, &message))
+            .chain(
+                claim
+                    .in_domain_constraint_weights
+                    .iter()
+                    .enumerate()
+                    .map(|(j, w)| {
+                        claim.constraint_rlc_coeffs[t_ood + j] * w.evaluate(&embedding, &message)
+                    }),
+            )
+            .sum();
+
+        assert_eq!(
+            weights_on_f,
+            claim.mu_prime - claim.original_sl_coeff * mu,
+            "Constraint weights evaluated on f should equal μ' - ν_1·μ"
+        );
+        assert_eq!(
+            claim.constraint_rlc_coeffs.len(),
+            claim.ood_constraint_weights.len() + claim.in_domain_constraint_weights.len(),
+        );
+    }
+
+    fn test<F: Field + FieldWithSize + Codec<[u8]> + 'static>()
+    where
+        Standard: Distribution<F>,
+        Hash: ProverMessage<[u8]>,
+    {
+        // Valid sizes: NTT-friendly AND power-of-two (challenge_indices requires pow2 codeword)
+        let valid_sizes: Vec<usize> = (3..=8)
+            .map(|k| 1_usize << k) // 8, 16, 32, 64, 128, 256
+            .filter(|&n| ntt::next_order::<F>(n) == Some(n))
+            .collect();
+        assert!(!valid_sizes.is_empty(), "No valid NTT sizes for field");
+
+        let size = select(valid_sizes);
+        let log_inv_rates = select(vec![1_usize, 2, 3]); // rates 1/2, 1/4, 1/8
+
+        proptest!(|(
+            seed: u64,
+            source_size in size,
+            src_lir in log_inv_rates.clone(),
+            tgt_lir in log_inv_rates,
+        )| {
+            test_completeness::<F>(seed, source_size, src_lir, tgt_lir);
+        });
+    }
+
+    #[test]
+    fn test_field64() {
+        test::<fields::Field64>();
+    }
+
+    #[test]
+    #[ignore = "Somewhat expensive and redundant"]
+    fn test_field64_2() {
+        test::<fields::Field64_2>();
+    }
+
+    #[test]
+    #[ignore = "Somewhat expensive and redundant"]
+    fn test_field64_3() {
+        test::<fields::Field64_3>();
+    }
+
+    #[test]
+    #[ignore = "Somewhat expensive and redundant"]
+    fn test_field128() {
+        test::<fields::Field128>();
+    }
+
+    #[test]
+    #[ignore = "Somewhat expensive and redundant"]
+    fn test_field192() {
+        test::<fields::Field192>();
+    }
+
+    #[test]
+    #[ignore = "Somewhat expensive and redundant"]
+    fn test_field256() {
+        test::<fields::Field256>();
+    }
+}

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -1,13 +1,13 @@
-//! Code-switching IOR: R_{C, sl} → R_{C', sl'}
+//! Code-switching IOR: R_{C, C_zk, sl} → R_{C', C_zk, sl'}
 //!
 //! Reduces a proximity claim about oracle f (source code C) to a proximity
-//! claim about oracle g (target code C'). Non-ZK variant.
-//!
-//! Paper: Construction 9.7 (p.55), Theorem 9.6 (p.54), Lemma 9.9 (p.57)
+//! claim about oracle g (target code C'). Supports optional ZK via mask oracle.
 
 use ark_ff::Field;
 use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use crate::{
     algebra::{
@@ -15,7 +15,7 @@ use crate::{
         embedding::{Embedding, Identity},
         fields::FieldWithSize,
         linear_form::UnivariateEvaluation,
-        mixed_dot, mixed_univariate_evaluate, univariate_evaluate,
+        mixed_dot, mixed_univariate_evaluate, random_vector, univariate_evaluate,
     },
     bits::Bits,
     hash::Hash,
@@ -27,73 +27,69 @@ use crate::{
     type_info::Typed,
 };
 
-/// Prover output from the code-switch interaction phase.
-/// Paper: Equation 9 (p.55)
+/// Prover output. Paper: Equation 9 (p.55).
 #[derive(Clone, Debug)]
 pub struct Witness<F: Field, G: Field = F> {
-    /// Target oracle commitment data. G_target = F since target uses Identity<F>.
     pub target_witness: irs_commit::Witness<F>,
-    /// The message f, taken by ownership from the caller.
     pub message: Vec<F>,
-    /// Source oracle evaluations at in-domain query points (in M::Source = G).
     pub source_evaluations: irs_commit::Evaluations<G>,
+    pub mask_witness: Option<irs_commit::Witness<F>>,
+    pub mask_message: Option<Vec<F>>,
 }
 
-/// Verifier output from the code-switch decision phase.
-/// Paper: Equation 9 (p.55) — output (x', y')
+/// OOD and in-domain constraint weights for a single oracle (message or mask).
+#[derive(Clone, Debug)]
+pub struct ConstraintWeights<F: Field, G: Field = F> {
+    pub ood: Vec<UnivariateEvaluation<F>>,
+    pub in_domain: Vec<UnivariateEvaluation<G>>,
+}
+
+/// Verifier output. Paper: Equation 9 (p.55).
 #[derive(Clone, Debug)]
 pub struct CodeSwitchClaim<F: Field, G: Field = F> {
-    /// μ' — batched target value. Decision phase formula (p.55).
     pub mu_prime: F,
-    /// ν_1 = batching_coeffs[0]. Caller scales original sl by this.
     pub original_sl_coeff: F,
-    /// Target oracle commitment (g).
     pub target_commitment: irs_commit::Commitment<F>,
-    /// RLC coefficients for constraint weights (batching_coeffs[1..]).
+    pub mask_commitment: Option<irs_commit::Commitment<F>>,
     pub constraint_rlc_coeffs: Vec<F>,
-    /// OOD constraint weights — UnivariateEvaluation at each OOD point (M::Target).
-    pub ood_constraint_weights: Vec<UnivariateEvaluation<F>>,
-    /// In-domain constraint weights — UnivariateEvaluation at each source eval point (M::Source).
-    pub in_domain_constraint_weights: Vec<UnivariateEvaluation<G>>,
-    /// Source oracle evaluation data from in-domain queries.
+    /// Message weights: ze_ood^{←,i} and G_C^#[x,·]
+    pub source_weights: ConstraintWeights<F, G>,
+    /// Mask weights: ze_ood^{→,i} and G_C^s[x,·]. None if non-ZK.
+    pub mask_weights: Option<ConstraintWeights<F, G>>,
     pub source_evaluations: irs_commit::Evaluations<G>,
 }
 
-/// Code-switching IOR config. Non-ZK variant (n=0, no C_zk masks).
-///
-/// TODO [ZK]: Add mask oracle, private zero-evaders, mask terms in sl'.
+/// Code-switching IOR config with optional ZK.
 #[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct Config<M: Embedding> {
     pub embedding: Typed<M>,
-    /// Source code C.
     pub source: irs_commit::Config<M>,
-    /// Target code C'. Message length ℓ' = ℓ (same message).
     pub target: irs_commit::Config<Identity<M::Target>>,
-    /// OOD samples tying source and target to the same message.
     pub cs_ood_samples: usize,
-    // In-domain queries reuse source.in_domain_samples (same formula).
-    // Reintroduce cs_in_domain_queries if security budgets diverge or mask_length > 0.
-    /// Proof-of-work config (set by parent orchestrator).
     pub pow: proof_of_work::Config,
+    pub mask: Option<MaskConfig<M>>,
 }
 
-/// Squeeze batching randomness from the transcript.
-/// Both prove() and verify() must call this at the same transcript position
-/// to stay in sync. Returns (ν_1, batching_coeffs) where ν_1 scales the
-/// original sl and batching_coeffs[i] scales the i-th constraint weight.
+/// ZK mask code config (C_zk).
+#[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct MaskConfig<M: Embedding> {
+    pub commit: irs_commit::Config<Identity<M::Target>>,
+    pub num_masks: usize,
+}
+
+/// Shared transcript operation for batching randomness.
 fn batching_challenge<T, F>(transcript: &mut T, count: usize) -> (F, Vec<F>)
 where
     T: VerifierMessage,
     F: Field + Decoding<[T::U]>,
 {
-    let mut coeffs = geometric_challenge(transcript, count);
-    let original_sl_coeff = if coeffs.is_empty() {
-        F::ONE
-    } else {
-        coeffs.remove(0)
-    };
-    (original_sl_coeff, coeffs)
+    let coeffs = geometric_challenge(transcript, count);
+    match coeffs.split_first() {
+        Some((&first, rest)) => (first, rest.to_vec()),
+        None => (F::ONE, Vec::new()),
+    }
 }
 
 impl<M: Embedding> Config<M> {
@@ -104,6 +100,7 @@ impl<M: Embedding> Config<M> {
         source_config: irs_commit::Config<M>,
         target_log_inv_rate: usize,
         target_interleaving_depth: usize,
+        masked: bool,
     ) -> Self
     where
         M: Default,
@@ -111,11 +108,9 @@ impl<M: Embedding> Config<M> {
     {
         let source_message_length = source_config.message_length();
 
-        // Target: ℓ' = ℓ, m' = ⌈ℓ'/ρ'⌉
-        let target_message_length = source_message_length;
         let target_rate = 0.5_f64.powf(target_log_inv_rate as f64);
-        let target_vector_size = target_message_length * target_interleaving_depth;
-        let target_config = irs_commit::Config::<Identity<M::Target>>::new(
+        let target_vector_size = source_message_length * target_interleaving_depth;
+        let mut target_config = irs_commit::Config::<Identity<M::Target>>::new(
             security_target,
             unique_decoding,
             hash_id,
@@ -125,14 +120,45 @@ impl<M: Embedding> Config<M> {
             target_rate,
         );
 
-        // OOD: solve |Λ(C',δ')|²/2 · ((ℓ-1)/|F|)^{t_ood} ≤ 2^{-λ}
-        // Target list size, source message length (Lemma 9.9 Error 1, p.57)
+        let mask = if masked {
+            let source_randomness_len = source_config.mask_length * source_config.num_messages();
+            let mask_msg_len = source_randomness_len.max(1);
+            let mut mask_commit = irs_commit::Config::<Identity<M::Target>>::new(
+                security_target,
+                unique_decoding,
+                hash_id,
+                1,
+                mask_msg_len,
+                1,
+                source_config.rate(),
+            );
+            // ZK encoding: mask_length ≥ queries for ζ = 0 (Prop 3.19, p.30)
+            target_config.mask_length = target_config.out_domain_samples;
+            mask_commit.mask_length = mask_commit.out_domain_samples;
+            Some(MaskConfig {
+                commit: mask_commit,
+                num_masks: 1,
+            })
+        } else {
+            None
+        };
+
+        // OOD: Lemma 9.9 Error 1
+        let (ood_list_size, ood_degree) = mask.as_ref().map_or_else(
+            || (target_config.list_size(), source_message_length),
+            |m| {
+                (
+                    target_config.list_size() * m.commit.list_size(),
+                    source_message_length + m.commit.message_length(),
+                )
+            },
+        );
         let cs_ood_samples = irs_commit::num_ood_samples(
             unique_decoding,
             security_target,
             M::Target::field_size_bits(),
-            target_config.list_size(),
-            source_message_length,
+            ood_list_size,
+            ood_degree,
         );
 
         Self {
@@ -144,10 +170,11 @@ impl<M: Embedding> Config<M> {
                 hash_id,
                 threshold: proof_of_work::threshold(Bits::new(0.0)),
             },
+            mask,
         }
     }
 
-    /// Prover interaction phase — Construction 9.7 Steps 1-4 (p.55).
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn prove<H, R>(
         &self,
         prover_state: &mut ProverState<H, R>,
@@ -163,27 +190,52 @@ impl<M: Embedding> Config<M> {
         u8: Decoding<[H::U]>,
         Hash: ProverMessage<[H::U]>,
     {
-        // Step 1: g := Enc_{C'}(f, r')
+        debug_assert_eq!(message.len(), self.source.message_length());
+        debug_assert_eq!(
+            source_randomness.len(),
+            self.source.mask_length * self.source.num_messages()
+        );
+
+        // Step 1a: g := Enc_{C'}(f, r')
         let target_witness = self.target.commit(prover_state, &[&message]);
 
-        // Step 2: receive OOD challenge ρ_ood
+        // Step 1b: s := Enc_{C_zk}((r, s_leftover), r'')
+        let (mask_message, mask_witness) = self.mask.as_ref().map_or((None, None), |mask_config| {
+            let mask_msg_len = mask_config.commit.message_length();
+            let embedding = self.source.embedding();
+            let r_embedded: Vec<M::Target> = source_randomness
+                .iter()
+                .map(|&x| embedding.map(x))
+                .collect();
+            let r_len = r_embedded.len();
+            let mut mask_msg = Vec::with_capacity(mask_msg_len);
+            mask_msg.extend_from_slice(&r_embedded);
+            let s_leftover: Vec<M::Target> =
+                random_vector(prover_state.rng(), mask_msg_len - r_len);
+            mask_msg.extend_from_slice(&s_leftover);
+            let witness = mask_config.commit.commit(prover_state, &[&mask_msg]);
+            (Some(mask_msg), Some(witness))
+        });
+
+        // Step 2: OOD challenge
         let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.cs_ood_samples);
 
-        // Step 3: send OOD answers y_i = f̂(ρ_i) + ρ_i^ℓ · r̂(ρ_i)
+        // Step 3: OOD answers
         let msg_len = message.len();
         for &point in &ood_points {
             let f_eval = univariate_evaluate(&message, point);
-            let r_eval =
-                mixed_univariate_evaluate(self.source.embedding(), source_randomness, point);
+            let randomness_eval = mask_message.as_ref().map_or_else(
+                || mixed_univariate_evaluate(self.source.embedding(), source_randomness, point),
+                |mask_msg| univariate_evaluate(mask_msg, point),
+            );
             let shift = point.pow([msg_len as u64]);
-            prover_state.prover_message(&(f_eval + shift * r_eval));
-            // TODO [ZK]: add ρ^{ℓ+r} · ŝ(ρ) term for mask oracle
+            prover_state.prover_message(&(f_eval + shift * randomness_eval));
         }
 
-        // Step 4: open source oracle at in-domain queries
+        // Step 4: open source oracle
         let source_evaluations = self.source.open(prover_state, &[source_witness]);
 
-        // Step 5: batching randomness (must match verify's batching_challenge call)
+        // Step 5: batching randomness (sync with verify)
         let _batching = batching_challenge::<_, M::Target>(
             prover_state,
             1 + ood_points.len() + source_evaluations.matrix.len(),
@@ -193,10 +245,12 @@ impl<M: Embedding> Config<M> {
             target_witness,
             message,
             source_evaluations,
+            mask_witness,
+            mask_message,
         }
     }
 
-    /// Verifier decision phase — Construction 9.7 Steps 1-4 + Decision (p.55).
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn verify<H>(
         &self,
         verifier_state: &mut VerifierState<H>,
@@ -210,24 +264,34 @@ impl<M: Embedding> Config<M> {
         u8: Decoding<[H::U]>,
         Hash: ProverMessage<[H::U]>,
     {
-        // Step 1: receive target commitment
-        let target_commitment = self.target.receive_commitment(verifier_state)?;
+        debug_assert!(
+            self.mask.is_some() == (self.target.mask_length > 0),
+            "mask config and target mask_length must agree"
+        );
 
-        // Step 2-3: OOD challenge + answers
+        // Step 1
+        let target_commitment = self.target.receive_commitment(verifier_state)?;
+        let mask_commitment = self
+            .mask
+            .as_ref()
+            .map(|m| m.commit.receive_commitment(verifier_state))
+            .transpose()?;
+
+        // Step 2-3: OOD
         let ood_points: Vec<M::Target> = verifier_state.verifier_message_vec(self.cs_ood_samples);
         let ood_answers: Vec<M::Target> =
             verifier_state.prover_messages_vec(self.cs_ood_samples)?;
 
-        // Step 4: verify source oracle openings
+        // Step 4: source opening
         let source_evaluations = self.source.verify(verifier_state, &[source_commitment])?;
 
-        // Step 5: batching coefficients (shared helper ensures transcript sync with prover)
+        // Step 5: batching
         let t_ood = ood_points.len();
         let t_times_iota = source_evaluations.matrix.len();
         let (original_sl_coeff, constraint_rlc_coeffs) =
             batching_challenge(verifier_state, 1 + t_ood + t_times_iota);
 
-        // Step 6: μ' = ν_1·μ + Σ ν_{1+i}·y_i + ΣΣ ν_{...}·f(x_i)_l
+        // Step 6: μ'
         let mu_prime = original_sl_coeff * mu
             + dot(&constraint_rlc_coeffs[..t_ood], &ood_answers)
             + mixed_dot(
@@ -236,24 +300,36 @@ impl<M: Embedding> Config<M> {
                 &source_evaluations.matrix,
             );
 
-        // Step 7: constraint weights for sl'
+        // Step 7: constraint weights
         let source_msg_len = self.source.message_length();
 
-        let ood_constraint_weights: Vec<UnivariateEvaluation<M::Target>> = ood_points
-            .iter()
-            .map(|&point| UnivariateEvaluation::new(point, source_msg_len))
-            .collect();
+        let source_weights = ConstraintWeights {
+            ood: ood_points
+                .iter()
+                .map(|&point| UnivariateEvaluation::new(point, source_msg_len))
+                .collect(),
+            in_domain: source_evaluations.evaluators(source_msg_len).collect(),
+        };
 
-        let in_domain_constraint_weights: Vec<UnivariateEvaluation<M::Source>> =
-            source_evaluations.evaluators(source_msg_len).collect();
+        let mask_weights = self.mask.as_ref().map(|mask_config| {
+            let mask_msg_len = mask_config.commit.message_length();
+            ConstraintWeights {
+                ood: ood_points
+                    .iter()
+                    .map(|&point| UnivariateEvaluation::new(point, mask_msg_len))
+                    .collect(),
+                in_domain: source_evaluations.evaluators(mask_msg_len).collect(),
+            }
+        });
 
         Ok(CodeSwitchClaim {
             mu_prime,
             original_sl_coeff,
             target_commitment,
+            mask_commitment,
             constraint_rlc_coeffs,
-            ood_constraint_weights,
-            in_domain_constraint_weights,
+            source_weights,
+            mask_weights,
             source_evaluations,
         })
     }
@@ -272,8 +348,6 @@ mod tests {
         transcript::{codecs::U64, DomainSeparator},
     };
 
-    /// Run full code switch (prove + verify) and check μ' completeness.
-    /// Uses ι=1 (num_vectors=1, interleaving_depth=1) so weight count matches RLC count.
     fn test_completeness<F: Field + FieldWithSize + Codec<[u8]> + 'static>(
         seed: u64,
         source_vector_size: usize,
@@ -288,7 +362,7 @@ mod tests {
         #[allow(clippy::cast_possible_wrap)]
         let source_rate = 0.5_f64.powi(source_log_inv_rate as i32);
 
-        let source_config = irs_commit::Config::<Identity<F>>::new(
+        let mut source_config = irs_commit::Config::<Identity<F>>::new(
             security_target,
             unique_decoding,
             crate::hash::BLAKE3,
@@ -297,6 +371,10 @@ mod tests {
             1,
             source_rate,
         );
+        // Source needs mask_length > 0 for ZK (randomness r to hide in mask oracle).
+        // In production, set by the parent protocol. Here we use 1 — the minimum
+        // nontrivial value that exercises the ZK path without NTT sizing issues.
+        source_config.mask_length = 1;
         let cs_config = Config::<Identity<F>>::new(
             security_target,
             unique_decoding,
@@ -304,6 +382,7 @@ mod tests {
             source_config.clone(),
             target_log_inv_rate,
             1,
+            true, // ZK enbled
         );
 
         let mut rng = StdRng::seed_from_u64(seed);
@@ -336,37 +415,89 @@ mod tests {
             .unwrap();
         verifier_state.check_eof().unwrap();
 
-        // Witness carries the message
         assert_eq!(cs_witness.message, message);
 
-        // μ' completeness: Σ rlc[i] · weight[i].evaluate(f) == μ' - ν_1·μ
-        let embedding = Identity::<F>::new();
-        let t_ood = claim.ood_constraint_weights.len();
+        check_mu_prime_completeness(
+            &claim,
+            &message,
+            mu,
+            cs_witness.mask_message.as_deref(),
+            source_witness.masks.len(),
+        );
+    }
 
+    /// Verify μ' = ν_1·μ + ⟨f, message_weights⟩ + ⟨mask_msg, mask_weights⟩
+    fn check_mu_prime_completeness<F: Field>(
+        claim: &CodeSwitchClaim<F>,
+        message: &[F],
+        mu: F,
+        mask_msg: Option<&[F]>,
+        r_len: usize,
+    ) {
+        let embedding = Identity::<F>::new();
+        let t_ood = claim.source_weights.ood.len();
+
+        // Message part: Σ rlc[i] · weight[i].evaluate(f)
         let weights_on_f: F = claim
-            .ood_constraint_weights
+            .source_weights
+            .ood
             .iter()
             .enumerate()
-            .map(|(i, w)| claim.constraint_rlc_coeffs[i] * w.evaluate(&embedding, &message))
+            .map(|(i, w)| claim.constraint_rlc_coeffs[i] * w.evaluate(&embedding, message))
             .chain(
                 claim
-                    .in_domain_constraint_weights
+                    .source_weights
+                    .in_domain
                     .iter()
                     .enumerate()
                     .map(|(j, w)| {
-                        claim.constraint_rlc_coeffs[t_ood + j] * w.evaluate(&embedding, &message)
+                        claim.constraint_rlc_coeffs[t_ood + j] * w.evaluate(&embedding, message)
                     }),
             )
             .sum();
 
+        // Mask part (ZK only): Σ rlc[i] · mask_weight[i].evaluate(mask_msg)
+        let weights_on_mask: F =
+            mask_msg
+                .zip(claim.mask_weights.as_ref())
+                .map_or(F::ZERO, |(mask_msg, mask_w)| {
+                    let msg_len = message.len();
+                    let ood_sum: F = mask_w
+                        .ood
+                        .iter()
+                        .enumerate()
+                        .map(|(i, w)| {
+                            let shift = w.point.pow([msg_len as u64]);
+                            claim.constraint_rlc_coeffs[i]
+                                * shift
+                                * w.evaluate(&embedding, mask_msg)
+                        })
+                        .sum();
+                    let in_domain_sum: F = mask_w
+                        .in_domain
+                        .iter()
+                        .enumerate()
+                        .map(|(j, w)| {
+                            let shift = w.point.pow([msg_len as u64]);
+                            let r_eval = if r_len > 0 {
+                                w.evaluate(&embedding, &mask_msg[..r_len])
+                            } else {
+                                F::ZERO
+                            };
+                            claim.constraint_rlc_coeffs[t_ood + j] * shift * r_eval
+                        })
+                        .sum();
+                    ood_sum + in_domain_sum
+                });
+
         assert_eq!(
-            weights_on_f,
+            weights_on_f + weights_on_mask,
             claim.mu_prime - claim.original_sl_coeff * mu,
-            "Constraint weights evaluated on f should equal μ' - ν_1·μ"
+            "Message + mask weights should equal μ' - ν_1·μ"
         );
         assert_eq!(
             claim.constraint_rlc_coeffs.len(),
-            claim.ood_constraint_weights.len() + claim.in_domain_constraint_weights.len(),
+            claim.source_weights.ood.len() + claim.source_weights.in_domain.len(),
         );
     }
 
@@ -375,15 +506,14 @@ mod tests {
         Standard: Distribution<F>,
         Hash: ProverMessage<[u8]>,
     {
-        // Valid sizes: NTT-friendly AND power-of-two (challenge_indices requires pow2 codeword)
         let valid_sizes: Vec<usize> = (3..=8)
-            .map(|k| 1_usize << k) // 8, 16, 32, 64, 128, 256
+            .map(|k| 1_usize << k)
             .filter(|&n| ntt::next_order::<F>(n) == Some(n))
             .collect();
         assert!(!valid_sizes.is_empty(), "No valid NTT sizes for field");
 
         let size = select(valid_sizes);
-        let log_inv_rates = select(vec![1_usize, 2, 3]); // rates 1/2, 1/4, 1/8
+        let log_inv_rates = select(vec![1_usize, 2, 3]);
 
         proptest!(|(
             seed: u64,

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -16,7 +16,7 @@ use crate::{
         fields::FieldWithSize,
         lift,
         linear_form::UnivariateEvaluation,
-        mixed_dot, mixed_univariate_evaluate, random_vector, univariate_evaluate,
+        mixed_dot, random_vector, univariate_evaluate,
     },
     hash::Hash,
     protocols::{
@@ -55,8 +55,8 @@ pub struct ConstraintWeights<F: Field, G: Field = F> {
 #[derive(Clone, Debug)]
 pub struct MaskClaimInfo<F: Field, G: Field = F> {
     pub commitment: IrsCommitment<F>,
-    /// RLC coefficients with shift ρ^ℓ baked in.
-    pub rlc_coeffs: Vec<F>,
+    pub ood_rlc_coeffs: Vec<F>,
+    pub in_domain_rlc_coeffs: Vec<F>,
     pub weights: ConstraintWeights<F, G>,
     pub source_randomness_len: usize,
 }
@@ -68,14 +68,18 @@ impl<F: Field, G: Field> MaskClaimInfo<F, G> {
         embedding: &impl Embedding<Source = G, Target = F>,
         mask_msg: &[F],
     ) -> F {
-        let num_ood = self.weights.ood.len();
-        let ood_sum: F = self.rlc_coeffs[..num_ood]
+        // OOD: ⟨(r,s), ze^{→,i}_ood(ρ)⟩ = ρ^ℓ · (r,s)^(ρ)
+        let ood_sum: F = self
+            .ood_rlc_coeffs
             .iter()
             .zip(&self.weights.ood)
             .map(|(&c, w)| c * univariate_evaluate(mask_msg, w.point))
             .sum();
+
+        // In-domain: ⟨(r,s), (G^s_C[x,·], 0)⟩ = φ(x)^ℓ · r̂(φ(x))
         let r_slice = &mask_msg[..self.source_randomness_len];
-        let in_domain_sum: F = self.rlc_coeffs[num_ood..]
+        let in_domain_sum: F = self
+            .in_domain_rlc_coeffs
             .iter()
             .zip(&self.weights.in_domain)
             .map(|(&c, w)| c * univariate_evaluate(r_slice, embedding.map(w.point)))
@@ -91,7 +95,8 @@ pub struct CodeSwitchClaim<F: Field, G: Field = F> {
     pub mu_prime: F,
     pub original_sl_coeff: F,
     pub target_commitment: IrsCommitment<F>,
-    pub constraint_rlc_coeffs: Vec<F>,
+    pub ood_rlc_coeffs: Vec<F>,
+    pub in_domain_rlc_coeffs: Vec<F>,
     pub source_weights: ConstraintWeights<F, G>,
     pub mask_info: Option<MaskClaimInfo<F, G>>,
     pub source_evaluations: IrsEvaluations<G>,
@@ -260,17 +265,23 @@ impl<M: Embedding> Config<M> {
                     (Some(mask_msg), Some(witness))
                 });
 
-        // Step 2-3: OOD challenge + answers (y_i = f̂(ρ) + ρ^ℓ · r̂(ρ))
+        // Step 2-3: OOD challenge + answers
         let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.cs_ood_samples);
         let msg_len = message.len();
         for &point in &ood_points {
             let f_eval = univariate_evaluate(&message, point);
-            let randomness_eval = mask_message.as_ref().map_or_else(
-                || mixed_univariate_evaluate(self.source.embedding(), source_randomness, point),
-                |mask_msg| univariate_evaluate(mask_msg, point),
-            );
-            let shift = point.pow([msg_len as u64]);
-            prover_state.prover_message(&(f_eval + shift * randomness_eval));
+            if source_randomness.is_empty() {
+                // Non-ZK: codeword encodes only f, so y_i = f̂(ρ)
+                prover_state.prover_message(&f_eval);
+            } else {
+                // ZK: codeword encodes h(X) = f̂(X) + X^ℓ · r̂(X), so y_i = h(ρ)
+                let mask_msg = mask_message
+                    .as_ref()
+                    .expect("ZK code-switch requires mask_message");
+                let randomness_eval = univariate_evaluate(mask_msg, point);
+                let shift = point.pow([msg_len as u64]);
+                prover_state.prover_message(&(f_eval + shift * randomness_eval));
+            }
         }
 
         // Step 4: in-domain queries
@@ -329,15 +340,16 @@ impl<M: Embedding> Config<M> {
         // Step 5: batching
         let num_ood = ood_points.len();
         let num_in_domain = source_evaluations.matrix.len();
-        let (original_sl_coeff, constraint_rlc_coeffs) =
+        let (original_sl_coeff, all_rlc_coeffs) =
             batching_challenge(verifier_state, 1 + num_ood + num_in_domain);
+        let (ood_rlc_coeffs, in_domain_rlc_coeffs) = all_rlc_coeffs.split_at(num_ood);
 
         // Step 6: μ'
         let mu_prime = original_sl_coeff * mu
-            + dot(&constraint_rlc_coeffs[..num_ood], &ood_answers)
+            + dot(ood_rlc_coeffs, &ood_answers)
             + mixed_dot(
                 self.source.embedding(),
-                &constraint_rlc_coeffs[num_ood..],
+                in_domain_rlc_coeffs,
                 &source_evaluations.matrix,
             );
 
@@ -365,21 +377,21 @@ impl<M: Embedding> Config<M> {
                     .collect(),
             };
             let embedding = self.source.embedding();
-            let rlc_coeffs: Vec<M::Target> = constraint_rlc_coeffs[..num_ood]
+            let mask_ood_rlc_coeffs: Vec<M::Target> = ood_rlc_coeffs
                 .iter()
                 .zip(&weights.ood)
                 .map(|(&c, w)| c * w.point.pow([source_msg_len as u64]))
-                .chain(
-                    constraint_rlc_coeffs[num_ood..]
-                        .iter()
-                        .zip(&weights.in_domain)
-                        .map(|(&c, w)| c * embedding.map(w.point.pow([source_msg_len as u64]))),
-                )
+                .collect();
+            let mask_in_domain_rlc_coeffs: Vec<M::Target> = in_domain_rlc_coeffs
+                .iter()
+                .zip(&weights.in_domain)
+                .map(|(&c, w)| c * embedding.map(w.point.pow([source_msg_len as u64])))
                 .collect();
 
             MaskClaimInfo {
                 commitment: mask_commitment.expect("mask commitment must exist when masked"),
-                rlc_coeffs,
+                ood_rlc_coeffs: mask_ood_rlc_coeffs,
+                in_domain_rlc_coeffs: mask_in_domain_rlc_coeffs,
                 weights,
                 source_randomness_len,
             }
@@ -389,7 +401,8 @@ impl<M: Embedding> Config<M> {
             mu_prime,
             original_sl_coeff,
             target_commitment,
-            constraint_rlc_coeffs,
+            ood_rlc_coeffs: ood_rlc_coeffs.to_vec(),
+            in_domain_rlc_coeffs: in_domain_rlc_coeffs.to_vec(),
             source_weights,
             mask_info,
             source_evaluations,
@@ -499,15 +512,14 @@ mod tests {
     /// Completeness check (p.56): μ' = ν_1·μ + ⟨f, source_weights⟩ + ⟨mask_msg, mask_weights⟩
     fn check_completeness<F: Field>(result: &TestResult<F>, masked: bool) {
         let claim = &result.claim;
-        let num_ood = claim.source_weights.ood.len();
 
         // ⟨f, ze_ood^{←,i}⟩ + ⟨f, G_C^#[x,·]⟩ (message part of μ' decomposition)
         let msg_sum = weighted_eval(
-            &claim.constraint_rlc_coeffs[..num_ood],
+            &claim.ood_rlc_coeffs,
             &claim.source_weights.ood,
             &result.message,
         ) + weighted_eval(
-            &claim.constraint_rlc_coeffs[num_ood..],
+            &claim.in_domain_rlc_coeffs,
             &claim.source_weights.in_domain,
             &result.message,
         );
@@ -526,18 +538,19 @@ mod tests {
             msg_sum + mask_sum,
             claim.mu_prime - claim.original_sl_coeff * result.target_mu
         );
-        // Theorem 9.6 (p.54): ze has 1 + t_ood + t·ι coefficients
+        // Coefficient counts match weight counts
+        assert_eq!(claim.ood_rlc_coeffs.len(), claim.source_weights.ood.len());
         assert_eq!(
-            claim.constraint_rlc_coeffs.len(),
-            num_ood + claim.source_weights.in_domain.len()
+            claim.in_domain_rlc_coeffs.len(),
+            claim.source_weights.in_domain.len()
         );
         // ZK structure: mask_info present iff ZK mode
         assert_eq!(claim.mask_info.is_some(), masked);
         if let Some(ref info) = claim.mask_info {
-            // Mask RLC count must cover all mask weights (OOD + in-domain)
+            assert_eq!(info.ood_rlc_coeffs.len(), info.weights.ood.len());
             assert_eq!(
-                info.rlc_coeffs.len(),
-                info.weights.ood.len() + info.weights.in_domain.len()
+                info.in_domain_rlc_coeffs.len(),
+                info.weights.in_domain.len()
             );
         }
     }

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -510,7 +510,7 @@ mod tests {
 
         // Decision phase formula (p.55): μ' = ν_1·μ + message_contribution + mask_contribution
         assert_eq!(msg_sum + mask_sum, c.mu_prime - c.original_sl_coeff * r.mu);
-        // Thm 9.6 (p.54): ze has 1 + t_ood + t·ι coefficients
+        // Theorem 9.6 (p.54): ze has 1 + t_ood + t·ι coefficients
         assert_eq!(
             c.constraint_rlc_coeffs.len(),
             t + c.source_weights.in_domain.len()

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -14,12 +14,12 @@ use crate::{
         dot,
         embedding::{Embedding, Identity},
         fields::FieldWithSize,
+        lift,
         linear_form::UnivariateEvaluation,
         mixed_dot, mixed_univariate_evaluate, random_vector, univariate_evaluate,
     },
-    bits::Bits,
     hash::Hash,
-    protocols::{geometric_challenge::geometric_challenge, irs_commit, proof_of_work},
+    protocols::{geometric_challenge::geometric_challenge, irs_commit},
     transcript::{
         Codec, Decoding, DuplexSpongeInterface, ProverMessage, ProverState, VerificationResult,
         VerifierMessage, VerifierState,
@@ -27,7 +27,7 @@ use crate::{
     type_info::Typed,
 };
 
-/// Prover output. Paper: Equation 9 (p.55).
+/// Prover output from the code-switch.
 #[derive(Clone, Debug)]
 pub struct Witness<F: Field, G: Field = F> {
     pub target_witness: irs_commit::Witness<F>,
@@ -37,11 +37,46 @@ pub struct Witness<F: Field, G: Field = F> {
     pub mask_message: Option<Vec<F>>,
 }
 
-/// OOD and in-domain constraint weights for a single oracle (message or mask).
+/// OOD and in-domain constraint weights for a single oracle.
 #[derive(Clone, Debug)]
 pub struct ConstraintWeights<F: Field, G: Field = F> {
     pub ood: Vec<UnivariateEvaluation<F>>,
     pub in_domain: Vec<UnivariateEvaluation<G>>,
+}
+
+/// ZK mask oracle claim. OOD weights evaluate full mask; in-domain weights
+/// evaluate only `mask_msg[..source_randomness_len]` (paper: ⟨(r,s), (G_C^s[x,·], 0)⟩).
+#[derive(Clone, Debug)]
+pub struct MaskClaimInfo<F: Field, G: Field = F> {
+    pub commitment: irs_commit::Commitment<F>,
+    /// RLC coefficients with shift ρ^ℓ baked in.
+    pub rlc_coeffs: Vec<F>,
+    pub weights: ConstraintWeights<F, G>,
+    pub source_randomness_len: usize,
+}
+
+impl<F: Field, G: Field> MaskClaimInfo<F, G> {
+    /// Weighted mask contribution. In-domain points are lifted G → F via embedding.
+    pub fn evaluate(
+        &self,
+        embedding: &impl Embedding<Source = G, Target = F>,
+        mask_msg: &[F],
+    ) -> F {
+        let num_ood = self.weights.ood.len();
+        let ood_sum: F = self.rlc_coeffs[..num_ood]
+            .iter()
+            .zip(&self.weights.ood)
+            .map(|(&c, w)| c * univariate_evaluate(mask_msg, w.point))
+            .sum();
+        let r_slice = &mask_msg[..self.source_randomness_len];
+        let in_domain_sum: F = self.rlc_coeffs[num_ood..]
+            .iter()
+            .zip(&self.weights.in_domain)
+            .map(|(&c, w)| c * univariate_evaluate(r_slice, embedding.map(w.point)))
+            .sum();
+
+        ood_sum + in_domain_sum
+    }
 }
 
 /// Verifier output. Paper: Equation 9 (p.55).
@@ -50,13 +85,19 @@ pub struct CodeSwitchClaim<F: Field, G: Field = F> {
     pub mu_prime: F,
     pub original_sl_coeff: F,
     pub target_commitment: irs_commit::Commitment<F>,
-    pub mask_commitment: Option<irs_commit::Commitment<F>>,
     pub constraint_rlc_coeffs: Vec<F>,
-    /// Message weights: ze_ood^{←,i} and G_C^#[x,·]
     pub source_weights: ConstraintWeights<F, G>,
-    /// Mask weights: ze_ood^{→,i} and G_C^s[x,·]. None if non-ZK.
-    pub mask_weights: Option<ConstraintWeights<F, G>>,
+    pub mask_info: Option<MaskClaimInfo<F, G>>,
     pub source_evaluations: irs_commit::Evaluations<G>,
+}
+
+/// Next stage's query budgets for ZK encoding (Prop 3.19).
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+pub struct ZkQueryBudget {
+    /// Queries the next stage makes to the target oracle g.
+    pub target: usize,
+    /// Queries the next stage makes to the mask oracle s.
+    pub mask: usize,
 }
 
 /// Code-switching IOR config with optional ZK.
@@ -67,32 +108,25 @@ pub struct Config<M: Embedding> {
     pub source: irs_commit::Config<M>,
     pub target: irs_commit::Config<Identity<M::Target>>,
     pub cs_ood_samples: usize,
-    pub pow: proof_of_work::Config,
-    pub mask: Option<MaskConfig<M>>,
+    pub mask_commit: Option<irs_commit::Config<Identity<M::Target>>>,
 }
 
-/// ZK mask code config (C_zk).
-#[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
-#[serde(bound = "")]
-pub struct MaskConfig<M: Embedding> {
-    pub commit: irs_commit::Config<Identity<M::Target>>,
-    pub num_masks: usize,
-}
-
-/// Shared transcript operation for batching randomness.
+/// Split geometric challenge into (ν_1, rest). Requires count ≥ 1.
 fn batching_challenge<T, F>(transcript: &mut T, count: usize) -> (F, Vec<F>)
 where
     T: VerifierMessage,
     F: Field + Decoding<[T::U]>,
 {
+    debug_assert!(count > 0, "batching requires at least one coefficient");
     let coeffs = geometric_challenge(transcript, count);
-    match coeffs.split_first() {
-        Some((&first, rest)) => (first, rest.to_vec()),
-        None => (F::ONE, Vec::new()),
-    }
+    let (&first, rest) = coeffs
+        .split_first()
+        .expect("count > 0 guarantees non-empty coefficients");
+    (first, rest.to_vec())
 }
 
 impl<M: Embedding> Config<M> {
+    /// `zk`: `None` for non-ZK, `Some(budget)` for ZK with next stage's query budgets.
     pub fn new(
         security_target: f64,
         unique_decoding: bool,
@@ -100,16 +134,19 @@ impl<M: Embedding> Config<M> {
         source_config: irs_commit::Config<M>,
         target_log_inv_rate: usize,
         target_interleaving_depth: usize,
-        masked: bool,
+        zk: Option<ZkQueryBudget>,
     ) -> Self
     where
         M: Default,
         M::Target: Default,
     {
-        let source_message_length = source_config.message_length();
+        assert!(target_log_inv_rate > 0);
+        assert!(target_interleaving_depth > 0);
 
+        let source_message_length = source_config.message_length();
         let target_rate = 0.5_f64.powf(target_log_inv_rate as f64);
         let target_vector_size = source_message_length * target_interleaving_depth;
+
         let mut target_config = irs_commit::Config::<Identity<M::Target>>::new(
             security_target,
             unique_decoding,
@@ -120,36 +157,35 @@ impl<M: Embedding> Config<M> {
             target_rate,
         );
 
-        let mask = if masked {
-            let source_randomness_len = source_config.mask_length * source_config.num_messages();
-            let mask_msg_len = source_randomness_len.max(1);
-            let mut mask_commit = irs_commit::Config::<Identity<M::Target>>::new(
+        let mask_commit = zk.map(|budget| {
+            assert!(budget.target > 0, "ZK requires nonzero target query budget");
+            assert!(budget.mask > 0, "ZK requires nonzero mask query budget");
+            target_config.mask_length = budget.target;
+
+            let r_len = source_config.mask_length * source_config.num_messages();
+            assert!(
+                r_len > 0,
+                "ZK code-switch requires source_config.mask_length > 0"
+            );
+            let mut mc = irs_commit::Config::<Identity<M::Target>>::new(
                 security_target,
                 unique_decoding,
                 hash_id,
                 1,
-                mask_msg_len,
+                r_len,
                 1,
                 source_config.rate(),
             );
-            // ZK encoding: mask_length ≥ queries for ζ = 0 (Prop 3.19, p.30)
-            target_config.mask_length = target_config.out_domain_samples;
-            mask_commit.mask_length = mask_commit.out_domain_samples;
-            Some(MaskConfig {
-                commit: mask_commit,
-                num_masks: 1,
-            })
-        } else {
-            None
-        };
+            mc.mask_length = budget.mask;
+            mc
+        });
 
-        // OOD: Lemma 9.9 Error 1
-        let (ood_list_size, ood_degree) = mask.as_ref().map_or_else(
+        let (list_size, degree) = mask_commit.as_ref().map_or_else(
             || (target_config.list_size(), source_message_length),
             |m| {
                 (
-                    target_config.list_size() * m.commit.list_size(),
-                    source_message_length + m.commit.message_length(),
+                    target_config.list_size() * m.list_size(),
+                    source_message_length + m.message_length(),
                 )
             },
         );
@@ -157,8 +193,8 @@ impl<M: Embedding> Config<M> {
             unique_decoding,
             security_target,
             M::Target::field_size_bits(),
-            ood_list_size,
-            ood_degree,
+            list_size,
+            degree,
         );
 
         Self {
@@ -166,11 +202,7 @@ impl<M: Embedding> Config<M> {
             source: source_config,
             target: target_config,
             cs_ood_samples,
-            pow: proof_of_work::Config {
-                hash_id,
-                threshold: proof_of_work::threshold(Bits::new(0.0)),
-            },
-            mask,
+            mask_commit,
         }
     }
 
@@ -195,32 +227,33 @@ impl<M: Embedding> Config<M> {
             source_randomness.len(),
             self.source.mask_length * self.source.num_messages()
         );
+        assert!(
+            self.mask_commit.is_some() == (self.target.mask_length > 0),
+            "mask config and target mask_length must agree"
+        );
 
         // Step 1a: g := Enc_{C'}(f, r')
         let target_witness = self.target.commit(prover_state, &[&message]);
 
-        // Step 1b: s := Enc_{C_zk}((r, s_leftover), r'')
-        let (mask_message, mask_witness) = self.mask.as_ref().map_or((None, None), |mask_config| {
-            let mask_msg_len = mask_config.commit.message_length();
-            let embedding = self.source.embedding();
-            let r_embedded: Vec<M::Target> = source_randomness
-                .iter()
-                .map(|&x| embedding.map(x))
-                .collect();
-            let r_len = r_embedded.len();
-            let mut mask_msg = Vec::with_capacity(mask_msg_len);
-            mask_msg.extend_from_slice(&r_embedded);
-            let s_leftover: Vec<M::Target> =
-                random_vector(prover_state.rng(), mask_msg_len - r_len);
-            mask_msg.extend_from_slice(&s_leftover);
-            let witness = mask_config.commit.commit(prover_state, &[&mask_msg]);
-            (Some(mask_msg), Some(witness))
-        });
+        // Step 1b: s := Enc_{C_zk}((r || padding), r'')
+        let (mask_message, mask_witness) =
+            self.mask_commit
+                .as_ref()
+                .map_or((None, None), |mask_config| {
+                    let mask_msg_len = mask_config.message_length();
+                    let r_embedded = lift(self.source.embedding(), source_randomness);
+                    let r_len = r_embedded.len();
+                    let mut mask_msg = Vec::with_capacity(mask_msg_len);
+                    mask_msg.extend_from_slice(&r_embedded);
+                    let random_padding: Vec<M::Target> =
+                        random_vector(prover_state.rng(), mask_msg_len - r_len);
+                    mask_msg.extend_from_slice(&random_padding);
+                    let witness = mask_config.commit(prover_state, &[&mask_msg]);
+                    (Some(mask_msg), Some(witness))
+                });
 
-        // Step 2: OOD challenge
+        // Step 2-3: OOD challenge + answers (y_i = f̂(ρ) + ρ^ℓ · r̂(ρ))
         let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.cs_ood_samples);
-
-        // Step 3: OOD answers
         let msg_len = message.len();
         for &point in &ood_points {
             let f_eval = univariate_evaluate(&message, point);
@@ -232,11 +265,11 @@ impl<M: Embedding> Config<M> {
             prover_state.prover_message(&(f_eval + shift * randomness_eval));
         }
 
-        // Step 4: open source oracle
+        // Step 4: in-domain queries
         let source_evaluations = self.source.open(prover_state, &[source_witness]);
 
-        // Step 5: batching randomness (sync with verify)
-        let _batching = batching_challenge::<_, M::Target>(
+        // Step 5: batching (advance transcript to stay in sync with verify)
+        batching_challenge::<_, M::Target>(
             prover_state,
             1 + ood_points.len() + source_evaluations.matrix.len(),
         );
@@ -264,17 +297,17 @@ impl<M: Embedding> Config<M> {
         u8: Decoding<[H::U]>,
         Hash: ProverMessage<[H::U]>,
     {
-        debug_assert!(
-            self.mask.is_some() == (self.target.mask_length > 0),
+        assert!(
+            self.mask_commit.is_some() == (self.target.mask_length > 0),
             "mask config and target mask_length must agree"
         );
 
-        // Step 1
+        // Step 1: commitments
         let target_commitment = self.target.receive_commitment(verifier_state)?;
         let mask_commitment = self
-            .mask
+            .mask_commit
             .as_ref()
-            .map(|m| m.commit.receive_commitment(verifier_state))
+            .map(|m| m.receive_commitment(verifier_state))
             .transpose()?;
 
         // Step 2-3: OOD
@@ -286,23 +319,22 @@ impl<M: Embedding> Config<M> {
         let source_evaluations = self.source.verify(verifier_state, &[source_commitment])?;
 
         // Step 5: batching
-        let t_ood = ood_points.len();
-        let t_times_iota = source_evaluations.matrix.len();
+        let num_ood = ood_points.len();
+        let num_in_domain = source_evaluations.matrix.len();
         let (original_sl_coeff, constraint_rlc_coeffs) =
-            batching_challenge(verifier_state, 1 + t_ood + t_times_iota);
+            batching_challenge(verifier_state, 1 + num_ood + num_in_domain);
 
         // Step 6: μ'
         let mu_prime = original_sl_coeff * mu
-            + dot(&constraint_rlc_coeffs[..t_ood], &ood_answers)
+            + dot(&constraint_rlc_coeffs[..num_ood], &ood_answers)
             + mixed_dot(
                 self.source.embedding(),
-                &constraint_rlc_coeffs[t_ood..],
+                &constraint_rlc_coeffs[num_ood..],
                 &source_evaluations.matrix,
             );
 
         // Step 7: constraint weights
         let source_msg_len = self.source.message_length();
-
         let source_weights = ConstraintWeights {
             ood: ood_points
                 .iter()
@@ -311,14 +343,33 @@ impl<M: Embedding> Config<M> {
             in_domain: source_evaluations.evaluators(source_msg_len).collect(),
         };
 
-        let mask_weights = self.mask.as_ref().map(|mask_config| {
-            let mask_msg_len = mask_config.commit.message_length();
-            ConstraintWeights {
+        // Mask weights with shift ρ^ℓ baked into RLC coefficients.
+        // In-domain shift lifted G → F via embedding (ring homomorphism).
+        let mask_info = self.mask_commit.as_ref().map(|mask_config| {
+            let r_len = self.source.mask_length * self.source.num_messages();
+            let weights = ConstraintWeights {
                 ood: ood_points
                     .iter()
-                    .map(|&point| UnivariateEvaluation::new(point, mask_msg_len))
+                    .map(|&point| UnivariateEvaluation::new(point, mask_config.message_length()))
                     .collect(),
-                in_domain: source_evaluations.evaluators(mask_msg_len).collect(),
+                in_domain: source_evaluations.evaluators(r_len).collect(),
+            };
+            let embedding = self.source.embedding();
+            let mut rlc_coeffs = Vec::with_capacity(num_ood + weights.in_domain.len());
+            for (i, w) in weights.ood.iter().enumerate() {
+                let shift = w.point.pow([source_msg_len as u64]);
+                rlc_coeffs.push(constraint_rlc_coeffs[i] * shift);
+            }
+            for (j, w) in weights.in_domain.iter().enumerate() {
+                let shift = embedding.map(w.point.pow([source_msg_len as u64]));
+                rlc_coeffs.push(constraint_rlc_coeffs[num_ood + j] * shift);
+            }
+
+            MaskClaimInfo {
+                commitment: mask_commitment.expect("mask commitment must exist when masked"),
+                rlc_coeffs,
+                weights,
+                source_randomness_len: r_len,
             }
         });
 
@@ -326,10 +377,9 @@ impl<M: Embedding> Config<M> {
             mu_prime,
             original_sl_coeff,
             target_commitment,
-            mask_commitment,
             constraint_rlc_coeffs,
             source_weights,
-            mask_weights,
+            mask_info,
             source_evaluations,
         })
     }
@@ -348,215 +398,179 @@ mod tests {
         transcript::{codecs::U64, DomainSeparator},
     };
 
-    fn test_completeness<F: Field + FieldWithSize + Codec<[u8]> + 'static>(
-        seed: u64,
-        source_vector_size: usize,
-        source_log_inv_rate: usize,
-        target_log_inv_rate: usize,
-    ) where
-        Standard: Distribution<F>,
-        Hash: ProverMessage<[u8]>,
-    {
-        let security_target = 32.0;
-        let unique_decoding = false;
-        #[allow(clippy::cast_possible_wrap)]
-        let source_rate = 0.5_f64.powi(source_log_inv_rate as i32);
-
-        let mut source_config = irs_commit::Config::<Identity<F>>::new(
-            security_target,
-            unique_decoding,
-            crate::hash::BLAKE3,
-            1,
-            source_vector_size,
-            1,
-            source_rate,
-        );
-        // Source needs mask_length > 0 for ZK (randomness r to hide in mask oracle).
-        // In production, set by the parent protocol. Here we use 1 — the minimum
-        // nontrivial value that exercises the ZK path without NTT sizing issues.
-        source_config.mask_length = 1;
-        let cs_config = Config::<Identity<F>>::new(
-            security_target,
-            unique_decoding,
-            crate::hash::BLAKE3,
-            source_config.clone(),
-            target_log_inv_rate,
-            1,
-            true, // ZK enbled
-        );
-
-        let mut rng = StdRng::seed_from_u64(seed);
-        let message: Vec<F> = random_vector(&mut rng, source_config.message_length());
-        let mu: F = rng.gen();
-
-        let instance = U64(seed);
-        let ds = DomainSeparator::protocol(&cs_config)
-            .session(&String::from("code_switch_proptest"))
-            .instance(&instance);
-
-        // Prover
-        let mut prover_state = ProverState::new_std(&ds);
-        let source_witness = source_config.commit(&mut prover_state, &[&message]);
-        let cs_witness = cs_config.prove(
-            &mut prover_state,
-            message.clone(),
-            &source_witness.masks,
-            &source_witness,
-        );
-        let proof = prover_state.proof();
-
-        // Verifier
-        let mut verifier_state = VerifierState::new_std(&ds, &proof);
-        let source_commitment = source_config
-            .receive_commitment(&mut verifier_state)
-            .unwrap();
-        let claim = cs_config
-            .verify(&mut verifier_state, mu, &source_commitment)
-            .unwrap();
-        verifier_state.check_eof().unwrap();
-
-        assert_eq!(cs_witness.message, message);
-
-        check_mu_prime_completeness(
-            &claim,
-            &message,
-            mu,
-            cs_witness.mask_message.as_deref(),
-            source_witness.masks.len(),
-        );
+    /// Σ rlc[i] * weight[i].evaluate(vector)
+    fn weighted_eval<F: Field>(rlc: &[F], weights: &[UnivariateEvaluation<F>], v: &[F]) -> F {
+        let e = Identity::<F>::new();
+        rlc.iter()
+            .zip(weights)
+            .map(|(&c, w)| c * w.evaluate(&e, v))
+            .sum()
     }
 
-    /// Verify μ' = ν_1·μ + ⟨f, message_weights⟩ + ⟨mask_msg, mask_weights⟩
-    fn check_mu_prime_completeness<F: Field>(
-        claim: &CodeSwitchClaim<F>,
-        message: &[F],
+    struct TestResult<F: Field> {
+        claim: CodeSwitchClaim<F>,
+        message: Vec<F>,
         mu: F,
-        mask_msg: Option<&[F]>,
-        r_len: usize,
-    ) {
-        let embedding = Identity::<F>::new();
-        let t_ood = claim.source_weights.ood.len();
-
-        // Message part: Σ rlc[i] · weight[i].evaluate(f)
-        let weights_on_f: F = claim
-            .source_weights
-            .ood
-            .iter()
-            .enumerate()
-            .map(|(i, w)| claim.constraint_rlc_coeffs[i] * w.evaluate(&embedding, message))
-            .chain(
-                claim
-                    .source_weights
-                    .in_domain
-                    .iter()
-                    .enumerate()
-                    .map(|(j, w)| {
-                        claim.constraint_rlc_coeffs[t_ood + j] * w.evaluate(&embedding, message)
-                    }),
-            )
-            .sum();
-
-        // Mask part (ZK only): Σ rlc[i] · mask_weight[i].evaluate(mask_msg)
-        let weights_on_mask: F =
-            mask_msg
-                .zip(claim.mask_weights.as_ref())
-                .map_or(F::ZERO, |(mask_msg, mask_w)| {
-                    let msg_len = message.len();
-                    let ood_sum: F = mask_w
-                        .ood
-                        .iter()
-                        .enumerate()
-                        .map(|(i, w)| {
-                            let shift = w.point.pow([msg_len as u64]);
-                            claim.constraint_rlc_coeffs[i]
-                                * shift
-                                * w.evaluate(&embedding, mask_msg)
-                        })
-                        .sum();
-                    let in_domain_sum: F = mask_w
-                        .in_domain
-                        .iter()
-                        .enumerate()
-                        .map(|(j, w)| {
-                            let shift = w.point.pow([msg_len as u64]);
-                            let r_eval = if r_len > 0 {
-                                w.evaluate(&embedding, &mask_msg[..r_len])
-                            } else {
-                                F::ZERO
-                            };
-                            claim.constraint_rlc_coeffs[t_ood + j] * shift * r_eval
-                        })
-                        .sum();
-                    ood_sum + in_domain_sum
-                });
-
-        assert_eq!(
-            weights_on_f + weights_on_mask,
-            claim.mu_prime - claim.original_sl_coeff * mu,
-            "Message + mask weights should equal μ' - ν_1·μ"
-        );
-        assert_eq!(
-            claim.constraint_rlc_coeffs.len(),
-            claim.source_weights.ood.len() + claim.source_weights.in_domain.len(),
-        );
+        mask_message: Option<Vec<F>>,
     }
 
-    fn test<F: Field + FieldWithSize + Codec<[u8]> + 'static>()
+    fn run_code_switch<F: Field + FieldWithSize + Codec<[u8]> + 'static>(
+        seed: u64,
+        size: usize,
+        src_lir: usize,
+        tgt_lir: usize,
+        masked: bool,
+    ) -> TestResult<F>
     where
         Standard: Distribution<F>,
         Hash: ProverMessage<[u8]>,
     {
-        let valid_sizes: Vec<usize> = (3..=8)
+        #[allow(clippy::cast_possible_wrap)]
+        let rate = 0.5_f64.powi(src_lir as i32);
+        let mut src = irs_commit::Config::<Identity<F>>::new(
+            32.0,
+            false,
+            crate::hash::BLAKE3,
+            1,
+            size,
+            1,
+            rate,
+        );
+        if masked {
+            src.mask_length = 1;
+        }
+
+        let zk = if masked {
+            Some(ZkQueryBudget { target: 1, mask: 1 })
+        } else {
+            None
+        };
+        let cfg = Config::<Identity<F>>::new(
+            32.0,
+            false,
+            crate::hash::BLAKE3,
+            src.clone(),
+            tgt_lir,
+            1,
+            zk,
+        );
+
+        let mut rng = StdRng::seed_from_u64(seed);
+        let msg: Vec<F> = random_vector(&mut rng, src.message_length());
+        let mu: F = rng.gen();
+        let instance = U64(seed);
+        let ds = DomainSeparator::protocol(&cfg)
+            .session(&"cs_test")
+            .instance(&instance);
+
+        let mut ps = ProverState::new_std(&ds);
+        let sw = src.commit(&mut ps, &[&msg]);
+        let cw = cfg.prove(&mut ps, msg.clone(), &sw.masks, &sw);
+
+        let proof = ps.proof();
+        let mut vs = VerifierState::new_std(&ds, &proof);
+        let sc = src.receive_commitment(&mut vs).unwrap();
+        let claim = cfg.verify(&mut vs, mu, &sc).unwrap();
+        vs.check_eof().unwrap();
+        assert_eq!(cw.message, msg);
+
+        TestResult {
+            claim,
+            message: msg,
+            mu,
+            mask_message: cw.mask_message,
+        }
+    }
+
+    /// Completeness: μ' = ν_1·μ + ⟨f, source_weights⟩ + ⟨mask_msg, mask_weights⟩
+    /// Completeness check (p.56): μ' = ν_1·μ + ⟨f, source_weights⟩ + ⟨mask_msg, mask_weights⟩
+    fn check_completeness<F: Field>(r: &TestResult<F>, masked: bool) {
+        let c = &r.claim;
+        let t = c.source_weights.ood.len();
+
+        // ⟨f, ze_ood^{←,i}⟩ + ⟨f, G_C^#[x,·]⟩ (message part of μ' decomposition)
+        let msg_sum = weighted_eval(
+            &c.constraint_rlc_coeffs[..t],
+            &c.source_weights.ood,
+            &r.message,
+        ) + weighted_eval(
+            &c.constraint_rlc_coeffs[t..],
+            &c.source_weights.in_domain,
+            &r.message,
+        );
+
+        // ⟨(r,s), ze_ood^{→,i}⟩ + ⟨(r,s), (G_C^s[x,·], 0)⟩ (mask part, shift pre-baked)
+        let mask_sum = r
+            .mask_message
+            .as_deref()
+            .zip(c.mask_info.as_ref())
+            .map_or(F::ZERO, |(mm, info)| {
+                info.evaluate(&Identity::<F>::new(), mm)
+            });
+
+        // Decision phase formula (p.55): μ' = ν_1·μ + message_contribution + mask_contribution
+        assert_eq!(msg_sum + mask_sum, c.mu_prime - c.original_sl_coeff * r.mu);
+        // Thm 9.6 (p.54): ze has 1 + t_ood + t·ι coefficients
+        assert_eq!(
+            c.constraint_rlc_coeffs.len(),
+            t + c.source_weights.in_domain.len()
+        );
+        // ZK structure: mask_info present iff ZK mode
+        assert_eq!(c.mask_info.is_some(), masked);
+        if let Some(ref info) = c.mask_info {
+            // Mask RLC count must cover all mask weights (OOD + in-domain)
+            assert_eq!(
+                info.rlc_coeffs.len(),
+                info.weights.ood.len() + info.weights.in_domain.len()
+            );
+        }
+    }
+
+    fn valid_sizes<F: 'static>() -> Vec<usize> {
+        (3..=8)
             .map(|k| 1_usize << k)
             .filter(|&n| ntt::next_order::<F>(n) == Some(n))
-            .collect();
-        assert!(!valid_sizes.is_empty(), "No valid NTT sizes for field");
+            .collect()
+    }
 
-        let size = select(valid_sizes);
-        let log_inv_rates = select(vec![1_usize, 2, 3]);
-
-        proptest!(|(
-            seed: u64,
-            source_size in size,
-            src_lir in log_inv_rates.clone(),
-            tgt_lir in log_inv_rates,
-        )| {
-            test_completeness::<F>(seed, source_size, src_lir, tgt_lir);
+    fn proptest_completeness<F: Field + FieldWithSize + Codec<[u8]> + 'static>()
+    where
+        Standard: Distribution<F>,
+        Hash: ProverMessage<[u8]>,
+    {
+        let rates = select(vec![1_usize, 2, 3]);
+        proptest!(|(seed: u64, sz in select(valid_sizes::<F>()), s in rates.clone(), t in rates, m: bool)| {
+            check_completeness(&run_code_switch::<F>(seed, sz, s, t, m), m);
         });
     }
 
     #[test]
-    fn test_field64() {
-        test::<fields::Field64>();
+    fn completeness_field64() {
+        proptest_completeness::<fields::Field64>();
     }
-
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn test_field64_2() {
-        test::<fields::Field64_2>();
+    fn completeness_field64_2() {
+        proptest_completeness::<fields::Field64_2>();
     }
-
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn test_field64_3() {
-        test::<fields::Field64_3>();
+    fn completeness_field64_3() {
+        proptest_completeness::<fields::Field64_3>();
     }
-
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn test_field128() {
-        test::<fields::Field128>();
+    fn completeness_field128() {
+        proptest_completeness::<fields::Field128>();
     }
-
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn test_field192() {
-        test::<fields::Field192>();
+    fn completeness_field192() {
+        proptest_completeness::<fields::Field192>();
     }
-
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn test_field256() {
-        test::<fields::Field256>();
+    fn completeness_field256() {
+        proptest_completeness::<fields::Field256>();
     }
 }

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -19,7 +19,13 @@ use crate::{
         mixed_dot, mixed_univariate_evaluate, random_vector, univariate_evaluate,
     },
     hash::Hash,
-    protocols::{geometric_challenge::geometric_challenge, irs_commit},
+    protocols::{
+        geometric_challenge::geometric_challenge,
+        irs_commit::{
+            num_ood_samples, Commitment as IrsCommitment, Config as IrsConfig,
+            Evaluations as IrsEvaluations, Witness as IrsWitness,
+        },
+    },
     transcript::{
         Codec, Decoding, DuplexSpongeInterface, ProverMessage, ProverState, VerificationResult,
         VerifierMessage, VerifierState,
@@ -30,10 +36,10 @@ use crate::{
 /// Prover output from the code-switch.
 #[derive(Clone, Debug)]
 pub struct Witness<F: Field, G: Field = F> {
-    pub target_witness: irs_commit::Witness<F>,
+    pub target_witness: IrsWitness<F>,
     pub message: Vec<F>,
-    pub source_evaluations: irs_commit::Evaluations<G>,
-    pub mask_witness: Option<irs_commit::Witness<F>>,
+    pub source_evaluations: IrsEvaluations<G>,
+    pub mask_witness: Option<IrsWitness<F>>,
     pub mask_message: Option<Vec<F>>,
 }
 
@@ -48,7 +54,7 @@ pub struct ConstraintWeights<F: Field, G: Field = F> {
 /// evaluate only `mask_msg[..source_randomness_len]` (paper: ⟨(r,s), (G_C^s[x,·], 0)⟩).
 #[derive(Clone, Debug)]
 pub struct MaskClaimInfo<F: Field, G: Field = F> {
-    pub commitment: irs_commit::Commitment<F>,
+    pub commitment: IrsCommitment<F>,
     /// RLC coefficients with shift ρ^ℓ baked in.
     pub rlc_coeffs: Vec<F>,
     pub weights: ConstraintWeights<F, G>,
@@ -84,11 +90,11 @@ impl<F: Field, G: Field> MaskClaimInfo<F, G> {
 pub struct CodeSwitchClaim<F: Field, G: Field = F> {
     pub mu_prime: F,
     pub original_sl_coeff: F,
-    pub target_commitment: irs_commit::Commitment<F>,
+    pub target_commitment: IrsCommitment<F>,
     pub constraint_rlc_coeffs: Vec<F>,
     pub source_weights: ConstraintWeights<F, G>,
     pub mask_info: Option<MaskClaimInfo<F, G>>,
-    pub source_evaluations: irs_commit::Evaluations<G>,
+    pub source_evaluations: IrsEvaluations<G>,
 }
 
 /// Next stage's query budgets for ZK encoding (Prop 3.19).
@@ -105,10 +111,10 @@ pub struct ZkQueryBudget {
 #[serde(bound = "")]
 pub struct Config<M: Embedding> {
     pub embedding: Typed<M>,
-    pub source: irs_commit::Config<M>,
-    pub target: irs_commit::Config<Identity<M::Target>>,
+    pub source: IrsConfig<M>,
+    pub target: IrsConfig<Identity<M::Target>>,
     pub cs_ood_samples: usize,
-    pub mask_commit: Option<irs_commit::Config<Identity<M::Target>>>,
+    pub mask_commit: Option<IrsConfig<Identity<M::Target>>>,
 }
 
 /// Split geometric challenge into (ν_1, rest). Requires count ≥ 1.
@@ -117,7 +123,7 @@ where
     T: VerifierMessage,
     F: Field + Decoding<[T::U]>,
 {
-    debug_assert!(count > 0, "batching requires at least one coefficient");
+    assert!(count > 0, "batching requires at least one coefficient");
     let coeffs = geometric_challenge(transcript, count);
     let (&first, rest) = coeffs
         .split_first()
@@ -131,7 +137,7 @@ impl<M: Embedding> Config<M> {
         security_target: f64,
         unique_decoding: bool,
         hash_id: crate::engines::EngineId,
-        source_config: irs_commit::Config<M>,
+        source_config: IrsConfig<M>,
         target_log_inv_rate: usize,
         target_interleaving_depth: usize,
         zk: Option<ZkQueryBudget>,
@@ -147,7 +153,7 @@ impl<M: Embedding> Config<M> {
         let target_rate = 0.5_f64.powf(target_log_inv_rate as f64);
         let target_vector_size = source_message_length * target_interleaving_depth;
 
-        let mut target_config = irs_commit::Config::<Identity<M::Target>>::new(
+        let mut target_config = IrsConfig::<Identity<M::Target>>::new(
             security_target,
             unique_decoding,
             hash_id,
@@ -161,35 +167,37 @@ impl<M: Embedding> Config<M> {
             assert!(budget.target > 0, "ZK requires nonzero target query budget");
             assert!(budget.mask > 0, "ZK requires nonzero mask query budget");
             target_config.mask_length = budget.target;
+            target_config.reparameterise_security(security_target, unique_decoding);
 
-            let r_len = source_config.mask_length * source_config.num_messages();
+            let source_randomness_len = source_config.mask_length * source_config.num_messages();
             assert!(
-                r_len > 0,
+                source_randomness_len > 0,
                 "ZK code-switch requires source_config.mask_length > 0"
             );
-            let mut mc = irs_commit::Config::<Identity<M::Target>>::new(
+            let mut mask_config = IrsConfig::<Identity<M::Target>>::new(
                 security_target,
                 unique_decoding,
                 hash_id,
                 1,
-                r_len,
+                source_randomness_len,
                 1,
                 source_config.rate(),
             );
-            mc.mask_length = budget.mask;
-            mc
+            mask_config.mask_length = budget.mask;
+            mask_config.reparameterise_security(security_target, unique_decoding);
+            mask_config
         });
 
         let (list_size, degree) = mask_commit.as_ref().map_or_else(
             || (target_config.list_size(), source_message_length),
-            |m| {
+            |mask_cfg| {
                 (
-                    target_config.list_size() * m.list_size(),
-                    source_message_length + m.message_length(),
+                    target_config.list_size() * mask_cfg.list_size(),
+                    source_message_length + mask_cfg.message_length(),
                 )
             },
         );
-        let cs_ood_samples = irs_commit::num_ood_samples(
+        let cs_ood_samples = num_ood_samples(
             unique_decoding,
             security_target,
             M::Target::field_size_bits(),
@@ -212,7 +220,7 @@ impl<M: Embedding> Config<M> {
         prover_state: &mut ProverState<H, R>,
         message: Vec<M::Target>,
         source_randomness: &[M::Source],
-        source_witness: &irs_commit::Witness<M::Source, M::Target>,
+        source_witness: &IrsWitness<M::Source, M::Target>,
     ) -> Witness<M::Target, M::Source>
     where
         H: DuplexSpongeInterface,
@@ -222,8 +230,8 @@ impl<M: Embedding> Config<M> {
         u8: Decoding<[H::U]>,
         Hash: ProverMessage<[H::U]>,
     {
-        debug_assert_eq!(message.len(), self.source.message_length());
-        debug_assert_eq!(
+        assert_eq!(message.len(), self.source.message_length());
+        assert_eq!(
             source_randomness.len(),
             self.source.mask_length * self.source.num_messages()
         );
@@ -242,11 +250,11 @@ impl<M: Embedding> Config<M> {
                 .map_or((None, None), |mask_config| {
                     let mask_msg_len = mask_config.message_length();
                     let r_embedded = lift(self.source.embedding(), source_randomness);
-                    let r_len = r_embedded.len();
+                    let embedded_randomness_len = r_embedded.len();
                     let mut mask_msg = Vec::with_capacity(mask_msg_len);
                     mask_msg.extend_from_slice(&r_embedded);
                     let random_padding: Vec<M::Target> =
-                        random_vector(prover_state.rng(), mask_msg_len - r_len);
+                        random_vector(prover_state.rng(), mask_msg_len - embedded_randomness_len);
                     mask_msg.extend_from_slice(&random_padding);
                     let witness = mask_config.commit(prover_state, &[&mask_msg]);
                     (Some(mask_msg), Some(witness))
@@ -288,7 +296,7 @@ impl<M: Embedding> Config<M> {
         &self,
         verifier_state: &mut VerifierState<H>,
         mu: M::Target,
-        source_commitment: &irs_commit::Commitment<M::Target>,
+        source_commitment: &IrsCommitment<M::Target>,
     ) -> VerificationResult<CodeSwitchClaim<M::Target, M::Source>>
     where
         H: DuplexSpongeInterface,
@@ -307,7 +315,7 @@ impl<M: Embedding> Config<M> {
         let mask_commitment = self
             .mask_commit
             .as_ref()
-            .map(|m| m.receive_commitment(verifier_state))
+            .map(|mask_cfg| mask_cfg.receive_commitment(verifier_state))
             .transpose()?;
 
         // Step 2-3: OOD
@@ -346,30 +354,34 @@ impl<M: Embedding> Config<M> {
         // Mask weights with shift ρ^ℓ baked into RLC coefficients.
         // In-domain shift lifted G → F via embedding (ring homomorphism).
         let mask_info = self.mask_commit.as_ref().map(|mask_config| {
-            let r_len = self.source.mask_length * self.source.num_messages();
+            let source_randomness_len = self.source.mask_length * self.source.num_messages();
             let weights = ConstraintWeights {
                 ood: ood_points
                     .iter()
                     .map(|&point| UnivariateEvaluation::new(point, mask_config.message_length()))
                     .collect(),
-                in_domain: source_evaluations.evaluators(r_len).collect(),
+                in_domain: source_evaluations
+                    .evaluators(source_randomness_len)
+                    .collect(),
             };
             let embedding = self.source.embedding();
-            let mut rlc_coeffs = Vec::with_capacity(num_ood + weights.in_domain.len());
-            for (i, w) in weights.ood.iter().enumerate() {
-                let shift = w.point.pow([source_msg_len as u64]);
-                rlc_coeffs.push(constraint_rlc_coeffs[i] * shift);
-            }
-            for (j, w) in weights.in_domain.iter().enumerate() {
-                let shift = embedding.map(w.point.pow([source_msg_len as u64]));
-                rlc_coeffs.push(constraint_rlc_coeffs[num_ood + j] * shift);
-            }
+            let rlc_coeffs: Vec<M::Target> = constraint_rlc_coeffs[..num_ood]
+                .iter()
+                .zip(&weights.ood)
+                .map(|(&c, w)| c * w.point.pow([source_msg_len as u64]))
+                .chain(
+                    constraint_rlc_coeffs[num_ood..]
+                        .iter()
+                        .zip(&weights.in_domain)
+                        .map(|(&c, w)| c * embedding.map(w.point.pow([source_msg_len as u64]))),
+                )
+                .collect();
 
             MaskClaimInfo {
                 commitment: mask_commitment.expect("mask commitment must exist when masked"),
                 rlc_coeffs,
                 weights,
-                source_randomness_len: r_len,
+                source_randomness_len,
             }
         });
 
@@ -410,15 +422,15 @@ mod tests {
     struct TestResult<F: Field> {
         claim: CodeSwitchClaim<F>,
         message: Vec<F>,
-        mu: F,
+        target_mu: F,
         mask_message: Option<Vec<F>>,
     }
 
     fn run_code_switch<F: Field + FieldWithSize + Codec<[u8]> + 'static>(
         seed: u64,
         size: usize,
-        src_lir: usize,
-        tgt_lir: usize,
+        src_lir: usize, // source log inverse rate
+        tgt_lir: usize, // target log inverse rate
         masked: bool,
     ) -> TestResult<F>
     where
@@ -427,17 +439,10 @@ mod tests {
     {
         #[allow(clippy::cast_possible_wrap)]
         let rate = 0.5_f64.powi(src_lir as i32);
-        let mut src = irs_commit::Config::<Identity<F>>::new(
-            32.0,
-            false,
-            crate::hash::BLAKE3,
-            1,
-            size,
-            1,
-            rate,
-        );
+        let mut source_config =
+            IrsConfig::<Identity<F>>::new(32.0, false, crate::hash::BLAKE3, 1, size, 1, rate);
         if masked {
-            src.mask_length = 1;
+            source_config.mask_length = 1;
         }
 
         let zk = if masked {
@@ -445,79 +450,90 @@ mod tests {
         } else {
             None
         };
-        let cfg = Config::<Identity<F>>::new(
+        let cs_config = Config::<Identity<F>>::new(
             32.0,
             false,
             crate::hash::BLAKE3,
-            src.clone(),
+            source_config.clone(),
             tgt_lir,
             1,
             zk,
         );
 
         let mut rng = StdRng::seed_from_u64(seed);
-        let msg: Vec<F> = random_vector(&mut rng, src.message_length());
-        let mu: F = rng.gen();
+        let message: Vec<F> = random_vector(&mut rng, source_config.message_length());
+        let target_mu: F = rng.gen();
         let instance = U64(seed);
-        let ds = DomainSeparator::protocol(&cfg)
+        let domain_separator = DomainSeparator::protocol(&cs_config)
             .session(&"cs_test")
             .instance(&instance);
 
-        let mut ps = ProverState::new_std(&ds);
-        let sw = src.commit(&mut ps, &[&msg]);
-        let cw = cfg.prove(&mut ps, msg.clone(), &sw.masks, &sw);
+        let mut prover_state = ProverState::new_std(&domain_separator);
+        let source_witness = source_config.commit(&mut prover_state, &[&message]);
+        let cs_witness = cs_config.prove(
+            &mut prover_state,
+            message.clone(),
+            &source_witness.masks,
+            &source_witness,
+        );
 
-        let proof = ps.proof();
-        let mut vs = VerifierState::new_std(&ds, &proof);
-        let sc = src.receive_commitment(&mut vs).unwrap();
-        let claim = cfg.verify(&mut vs, mu, &sc).unwrap();
-        vs.check_eof().unwrap();
-        assert_eq!(cw.message, msg);
+        let proof = prover_state.proof();
+        let mut verifier_state = VerifierState::new_std(&domain_separator, &proof);
+        let source_commitment = source_config
+            .receive_commitment(&mut verifier_state)
+            .unwrap();
+        let claim = cs_config
+            .verify(&mut verifier_state, target_mu, &source_commitment)
+            .unwrap();
+        verifier_state.check_eof().unwrap();
+        assert_eq!(cs_witness.message, message);
 
         TestResult {
             claim,
-            message: msg,
-            mu,
-            mask_message: cw.mask_message,
+            message,
+            target_mu,
+            mask_message: cs_witness.mask_message,
         }
     }
 
-    /// Completeness: μ' = ν_1·μ + ⟨f, source_weights⟩ + ⟨mask_msg, mask_weights⟩
     /// Completeness check (p.56): μ' = ν_1·μ + ⟨f, source_weights⟩ + ⟨mask_msg, mask_weights⟩
-    fn check_completeness<F: Field>(r: &TestResult<F>, masked: bool) {
-        let c = &r.claim;
-        let t = c.source_weights.ood.len();
+    fn check_completeness<F: Field>(result: &TestResult<F>, masked: bool) {
+        let claim = &result.claim;
+        let num_ood = claim.source_weights.ood.len();
 
         // ⟨f, ze_ood^{←,i}⟩ + ⟨f, G_C^#[x,·]⟩ (message part of μ' decomposition)
         let msg_sum = weighted_eval(
-            &c.constraint_rlc_coeffs[..t],
-            &c.source_weights.ood,
-            &r.message,
+            &claim.constraint_rlc_coeffs[..num_ood],
+            &claim.source_weights.ood,
+            &result.message,
         ) + weighted_eval(
-            &c.constraint_rlc_coeffs[t..],
-            &c.source_weights.in_domain,
-            &r.message,
+            &claim.constraint_rlc_coeffs[num_ood..],
+            &claim.source_weights.in_domain,
+            &result.message,
         );
 
         // ⟨(r,s), ze_ood^{→,i}⟩ + ⟨(r,s), (G_C^s[x,·], 0)⟩ (mask part, shift pre-baked)
-        let mask_sum = r
+        let mask_sum = result
             .mask_message
             .as_deref()
-            .zip(c.mask_info.as_ref())
+            .zip(claim.mask_info.as_ref())
             .map_or(F::ZERO, |(mm, info)| {
                 info.evaluate(&Identity::<F>::new(), mm)
             });
 
         // Decision phase formula (p.55): μ' = ν_1·μ + message_contribution + mask_contribution
-        assert_eq!(msg_sum + mask_sum, c.mu_prime - c.original_sl_coeff * r.mu);
+        assert_eq!(
+            msg_sum + mask_sum,
+            claim.mu_prime - claim.original_sl_coeff * result.target_mu
+        );
         // Theorem 9.6 (p.54): ze has 1 + t_ood + t·ι coefficients
         assert_eq!(
-            c.constraint_rlc_coeffs.len(),
-            t + c.source_weights.in_domain.len()
+            claim.constraint_rlc_coeffs.len(),
+            num_ood + claim.source_weights.in_domain.len()
         );
         // ZK structure: mask_info present iff ZK mode
-        assert_eq!(c.mask_info.is_some(), masked);
-        if let Some(ref info) = c.mask_info {
+        assert_eq!(claim.mask_info.is_some(), masked);
+        if let Some(ref info) = claim.mask_info {
             // Mask RLC count must cover all mask weights (OOD + in-domain)
             assert_eq!(
                 info.rlc_coeffs.len(),
@@ -526,6 +542,7 @@ mod tests {
         }
     }
 
+    /// Powers of 2 in [8, 256] that are valid NTT domain sizes for field F.
     fn valid_sizes<F: 'static>() -> Vec<usize> {
         (3..=8)
             .map(|k| 1_usize << k)

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -69,10 +69,9 @@ pub struct Witness<F: Field> {
     pub mask: Option<MaskOracle<F>>,
 }
 
-/// Verifier output from the code-switch. `sum` is updated in-place to μ';
-/// this struct carries only the new oracle commitments.
+/// Verifier output from the code-switch.
 #[derive(Clone, Debug)]
-pub struct Commitments<F: Field> {
+pub struct Commitment<F: Field> {
     pub target: IrsCommitment<F>,
     pub mask: Option<IrsCommitment<F>>,
 }
@@ -168,8 +167,7 @@ impl<M: Embedding> Config<M> {
         }
     }
 
-    /// Prove the code-switch. Updates `covector` in-place with the new linear
-    /// form sl' for the next sumcheck (Completeness proof, p.55-56).
+    /// Prove the code-switch
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn prove<H, R>(
         &self,
@@ -276,14 +274,14 @@ impl<M: Embedding> Config<M> {
         }
     }
 
-    /// Verify the code-switch.
+    /// Verify the code-switch
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn verify<H>(
         &self,
         verifier_state: &mut VerifierState<H>,
         sum: &mut M::Target,
         commitment: &IrsCommitment<M::Target>,
-    ) -> VerificationResult<Commitments<M::Target>>
+    ) -> VerificationResult<Commitment<M::Target>>
     where
         H: DuplexSpongeInterface,
         Standard: Distribution<M::Target>,
@@ -328,7 +326,7 @@ impl<M: Embedding> Config<M> {
                 &source_evaluations.matrix,
             );
 
-        Ok(Commitments {
+        Ok(Commitment {
             target: target_commitment,
             mask: mask_commitment,
         })

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-use ark_ff::{AdditiveGroup, Field};
+use ark_ff::Field;
 use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "tracing")]
@@ -16,7 +16,7 @@ use crate::{
         dot,
         embedding::{Embedding, Identity},
         fields::FieldWithSize,
-        lift, mixed_dot, random_vector, univariate_evaluate,
+        geometric_accumulate, lift, mixed_dot, random_vector, scalar_mul, univariate_evaluate,
     },
     engines::EngineId,
     hash::Hash,
@@ -32,7 +32,6 @@ use crate::{
         VerifierMessage, VerifierState,
     },
     type_info::Typed,
-    utils::zip_strict,
 };
 
 /// Code-switching IOR config with optional ZK.
@@ -170,6 +169,11 @@ impl<M: Embedding> Config<M> {
         }
     }
 
+    /// Length of the covector for this code-switch.
+    pub fn covector_length(&self) -> usize {
+        self.source.masked_message_length()
+    }
+
     /// Prove the code-switch
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn prove<H, R>(
@@ -189,6 +193,7 @@ impl<M: Embedding> Config<M> {
         Hash: ProverMessage<[H::U]>,
     {
         assert_eq!(message.len(), self.source.message_length());
+        assert_eq!(covector.len(), self.covector_length());
         assert_eq!(
             self.source.num_messages(),
             1,
@@ -253,26 +258,15 @@ impl<M: Embedding> Config<M> {
         let (ood_rlc_coeffs, in_domain_rlc_coeffs) = constraint_rlc_coeffs.split_at(num_ood);
 
         // Covector update — sl' from Completeness proof (p.55-56)
-        let embedding = self.source.embedding();
-        let eval_points: Vec<_> = source_evaluations
-            .points
-            .iter()
-            .map(|&p| embedding.map(p))
-            .collect();
+        let eval_points = lift(self.source.embedding(), &source_evaluations.points);
         let all_points: Vec<_> = ood_points.iter().chain(&eval_points).copied().collect();
-        let mut pows: Vec<_> = ood_rlc_coeffs
+        let pows: Vec<_> = ood_rlc_coeffs
             .iter()
             .chain(in_domain_rlc_coeffs)
             .copied()
             .collect();
-        for c in &mut *covector {
-            let mut sum = M::Target::ZERO;
-            for (pow, &point) in zip_strict(&mut pows, &all_points) {
-                sum += *pow;
-                *pow *= point;
-            }
-            *c = *c * original_sl_coeff + sum;
-        }
+        scalar_mul(covector, original_sl_coeff);
+        geometric_accumulate(covector, pows, &all_points);
 
         Witness {
             message,
@@ -349,12 +343,13 @@ impl<M: Embedding> fmt::Display for Config<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Config(source={}, target={}, ood_samples={}, zk={})",
-            self.source,
-            self.target,
-            self.out_domain_samples,
-            self.mask_commit.is_some()
-        )
+            "Config(source={}, target={}, ood_samples={}",
+            self.source, self.target, self.out_domain_samples,
+        )?;
+        if let Some(mask) = &self.mask_commit {
+            write!(f, ", mask={mask}")?;
+        }
+        write!(f, ")")
     }
 }
 
@@ -445,7 +440,9 @@ mod tests {
         let message: Vec<F> = random_vector(&mut rng, config.source.message_length());
         let target_mu: F = rng.gen();
 
-        let mut covector: Vec<F> = random_vector(&mut rng, config.source.message_length());
+        let msg_len = config.source.message_length();
+        let mut covector: Vec<F> = random_vector(&mut rng, msg_len);
+        covector.resize(config.covector_length(), F::ZERO);
 
         let mut prover_state = ProverState::new_std(&ds);
         let source_witness = config.source.commit(&mut prover_state, &[&message]);

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-use ark_ff::Field;
+use ark_ff::{AdditiveGroup, Field};
 use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "tracing")]
@@ -245,26 +245,24 @@ impl<M: Embedding> Config<M> {
 
         // Covector update — sl' from Completeness proof (p.55-56)
         let embedding = self.source.embedding();
-        // ν_1 · sl(st): scale previous constraint
+        let eval_points: Vec<_> = source_evaluations
+            .points
+            .iter()
+            .map(|&p| embedding.map(p))
+            .collect();
+        let all_points: Vec<_> = ood_points.iter().chain(&eval_points).copied().collect();
+        let mut pows: Vec<_> = ood_rlc_coeffs
+            .iter()
+            .chain(in_domain_rlc_coeffs)
+            .copied()
+            .collect();
         for c in &mut *covector {
-            *c *= original_sl_coeff;
-        }
-        // include OOD message weights
-        for (&weight, &ood_point) in ood_rlc_coeffs.iter().zip(&ood_points) {
-            let mut point_pow = M::Target::ONE;
-            for c in &mut *covector {
-                *c += weight * point_pow;
-                point_pow *= ood_point;
+            let mut sum = M::Target::ZERO;
+            for (pow, &point) in pows.iter_mut().zip(&all_points) {
+                sum += *pow;
+                *pow *= point;
             }
-        }
-        // include In-domain message weights
-        for (&weight, &query_point) in in_domain_rlc_coeffs.iter().zip(&source_evaluations.points) {
-            let eval_point = embedding.map(query_point);
-            let mut point_pow = M::Target::ONE;
-            for c in &mut *covector {
-                *c += weight * point_pow;
-                point_pow *= eval_point;
-            }
+            *c = *c * original_sl_coeff + sum;
         }
 
         Witness {

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -267,7 +267,7 @@ impl<M: Embedding> Config<M> {
         // Step 4: in-domain queries — Construction 9.7 Step 4, p.55
         let source_evaluations = self.source.open(prover_state, &[witness]);
 
-        // Step 5: batching — Construction 9.7 Step 5, p.55
+        // Step 4.1: batching — Construction 9.7 Step 4, p.55
         let num_ood = self.out_domain_samples;
         let num_in_domain = source_evaluations.matrix.len();
         let batching_coeffs =
@@ -335,7 +335,7 @@ impl<M: Embedding> Config<M> {
         // Step 4: source opening — Construction 9.7 Step 4, p.55
         let source_evaluations = self.source.verify(verifier_state, &[commitment])?;
 
-        // Step 5-6: batching + μ' — Construction 9.7 Decision phase, p.55
+        // Step 4.1: batching + μ' — Construction 9.7 Decision phase, p.55
         let num_ood = self.out_domain_samples;
         let num_in_domain = source_evaluations.matrix.len();
         let coeffs = geometric_challenge(verifier_state, 1 + num_ood + num_in_domain);

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -32,6 +32,7 @@ use crate::{
         VerifierMessage, VerifierState,
     },
     type_info::Typed,
+    utils::zip_strict,
 };
 
 /// Code-switching IOR config with optional ZK.
@@ -122,6 +123,8 @@ impl<M: Embedding> Config<M> {
                 source_randomness_len > 0,
                 "ZK code-switch requires source_config.mask_length > 0"
             );
+            // TODO : move the mask config out for shared mask tree per iteration
+            // inputs to the new function will also change
             let mut mask_config = IrsConfig::<Identity<M::Target>>::new(
                 security_target,
                 unique_decoding,
@@ -186,6 +189,11 @@ impl<M: Embedding> Config<M> {
         Hash: ProverMessage<[H::U]>,
     {
         assert_eq!(message.len(), self.source.message_length());
+        assert_eq!(
+            self.source.num_messages(),
+            1,
+            "code-switch only supports num_messages() == 1 (single polynomial)"
+        );
         assert_eq!(
             masks.len(),
             self.source.mask_length * self.source.num_messages()
@@ -258,7 +266,7 @@ impl<M: Embedding> Config<M> {
             .collect();
         for c in &mut *covector {
             let mut sum = M::Target::ZERO;
-            for (pow, &point) in pows.iter_mut().zip(&all_points) {
+            for (pow, &point) in zip_strict(&mut pows, &all_points) {
                 sum += *pow;
                 *pow *= point;
             }
@@ -287,6 +295,11 @@ impl<M: Embedding> Config<M> {
         u8: Decoding<[H::U]>,
         Hash: ProverMessage<[H::U]>,
     {
+        assert_eq!(
+            self.source.num_messages(),
+            1,
+            "code-switch only supports num_messages() == 1 (single polynomial)"
+        );
         assert!(
             self.mask_commit.is_some() == (self.target.mask_length > 0),
             "mask config and target mask_length must agree"

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -114,6 +114,15 @@ impl<M: Embedding> Config<M> {
             // TODO : find a better way to set mask length for ZK code-switch
             // leaving right now for code switching. This will change in parameter
             // selection
+            let target_slack =
+                target_config.codeword_length - target_config.message_length();
+            assert!(
+                budget.target <= target_slack,
+                "budget.target ({}) exceeds target codeword slack ({codeword_len} - {msg_len} = {target_slack})",
+                budget.target,
+                codeword_len = target_config.codeword_length,
+                msg_len = target_config.message_length(),
+            );
             target_config.mask_length = budget.target;
             target_config.recompute_security_parameters(security_target, unique_decoding);
 
@@ -132,6 +141,15 @@ impl<M: Embedding> Config<M> {
                 source_randomness_len,
                 1,
                 source_config.rate(),
+            );
+            let mask_slack =
+                mask_config.codeword_length - mask_config.message_length();
+            assert!(
+                budget.mask <= mask_slack,
+                "budget.mask ({}) exceeds mask codeword slack ({codeword_len} - {msg_len} = {mask_slack})",
+                budget.mask,
+                codeword_len = mask_config.codeword_length,
+                msg_len = mask_config.message_length(),
             );
             mask_config.mask_length = budget.mask;
             mask_config.recompute_security_parameters(security_target, unique_decoding);

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -3,6 +3,8 @@
 //! Reduces a proximity claim about oracle f (source code C) to a proximity
 //! claim about oracle g (target code C'). Supports optional ZK via mask oracle.
 
+use std::fmt;
+
 use ark_ff::Field;
 use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -14,16 +16,15 @@ use crate::{
         dot,
         embedding::{Embedding, Identity},
         fields::FieldWithSize,
-        lift,
-        linear_form::UnivariateEvaluation,
-        mixed_dot, random_vector, univariate_evaluate,
+        lift, mixed_dot, random_vector, univariate_evaluate,
     },
+    engines::EngineId,
     hash::Hash,
     protocols::{
         geometric_challenge::geometric_challenge,
         irs_commit::{
             num_ood_samples, Commitment as IrsCommitment, Config as IrsConfig,
-            Evaluations as IrsEvaluations, Witness as IrsWitness,
+            Witness as IrsWitness,
         },
     },
     transcript::{
@@ -40,7 +41,7 @@ pub struct Config<M: Embedding> {
     pub embedding: Typed<M>,
     pub source: IrsConfig<M>,
     pub target: IrsConfig<Identity<M::Target>>,
-    pub ood_samples: usize,
+    pub out_domain_samples: usize,
     pub mask_commit: Option<IrsConfig<Identity<M::Target>>>,
 }
 
@@ -53,72 +54,27 @@ pub struct ZkQueryBudget {
     pub mask: usize,
 }
 
+/// ZK mask oracle: the message and its IRS witness.
+#[derive(Clone, Debug)]
+pub struct MaskOracle<F: Field> {
+    pub message: Vec<F>,
+    pub witness: IrsWitness<F>,
+}
+
 /// Prover output from the code-switch.
 #[derive(Clone, Debug)]
-pub struct Witness<F: Field, G: Field = F> {
-    pub target_witness: IrsWitness<F>,
+pub struct Witness<F: Field> {
     pub message: Vec<F>,
-    pub source_evaluations: IrsEvaluations<G>,
-    pub mask: Option<(Vec<F>, IrsWitness<F>)>,
+    pub target_witness: IrsWitness<F>,
+    pub mask: Option<MaskOracle<F>>,
 }
 
-/// OOD and in-domain constraint weights for a single oracle.
+/// Verifier output from the code-switch. `sum` is updated in-place to μ';
+/// this struct carries only the new oracle commitments.
 #[derive(Clone, Debug)]
-pub struct ConstraintWeights<F: Field, G: Field = F> {
-    pub ood: Vec<UnivariateEvaluation<F>>,
-    pub in_domain: Vec<UnivariateEvaluation<G>>,
-}
-
-/// ZK mask oracle claim. OOD weights evaluate full mask; in-domain weights
-/// evaluate only `mask_msg[..source_randomness_len]` (paper: ⟨(r,s), (G_C^s[x,·], 0)⟩).
-#[derive(Clone, Debug)]
-pub struct MaskClaimInfo<F: Field, G: Field = F> {
-    pub commitment: IrsCommitment<F>,
-    pub ood_rlc_coeffs: Vec<F>,
-    pub in_domain_rlc_coeffs: Vec<F>,
-    pub weights: ConstraintWeights<F, G>,
-    pub source_randomness_len: usize,
-}
-
-impl<F: Field, G: Field> MaskClaimInfo<F, G> {
-    /// Weighted mask contribution. In-domain points are lifted G → F via embedding.
-    pub fn evaluate(
-        &self,
-        embedding: &impl Embedding<Source = G, Target = F>,
-        mask_msg: &[F],
-    ) -> F {
-        // OOD: ⟨(r,s), ze^{→,i}_ood(ρ)⟩ = ρ^ℓ · (r,s)^(ρ)
-        let ood_sum: F = self
-            .ood_rlc_coeffs
-            .iter()
-            .zip(&self.weights.ood)
-            .map(|(&c, w)| c * univariate_evaluate(mask_msg, w.point))
-            .sum();
-
-        // In-domain: ⟨(r,s), (G^s_C[x,·], 0)⟩ = φ(x)^ℓ · r̂(φ(x))
-        let r_slice = &mask_msg[..self.source_randomness_len];
-        let in_domain_sum: F = self
-            .in_domain_rlc_coeffs
-            .iter()
-            .zip(&self.weights.in_domain)
-            .map(|(&c, w)| c * univariate_evaluate(r_slice, embedding.map(w.point)))
-            .sum();
-
-        ood_sum + in_domain_sum
-    }
-}
-
-/// Verifier output. Paper: Equation 9 (p.55).
-#[derive(Clone, Debug)]
-pub struct CodeSwitchClaim<F: Field, G: Field = F> {
-    pub mu_prime: F,
-    pub original_sl_coeff: F,
-    pub target_commitment: IrsCommitment<F>,
-    pub ood_rlc_coeffs: Vec<F>,
-    pub in_domain_rlc_coeffs: Vec<F>,
-    pub source_weights: ConstraintWeights<F, G>,
-    pub mask_info: Option<MaskClaimInfo<F, G>>,
-    pub source_evaluations: IrsEvaluations<G>,
+pub struct Commitments<F: Field> {
+    pub target: IrsCommitment<F>,
+    pub mask: Option<IrsCommitment<F>>,
 }
 
 impl<M: Embedding> Config<M> {
@@ -126,7 +82,7 @@ impl<M: Embedding> Config<M> {
     pub fn new(
         security_target: f64,
         unique_decoding: bool,
-        hash_id: crate::engines::EngineId,
+        hash_id: EngineId,
         source_config: IrsConfig<M>,
         target_log_inv_rate: usize,
         target_interleaving_depth: usize,
@@ -156,6 +112,9 @@ impl<M: Embedding> Config<M> {
         let mask_commit = zk.map(|budget| {
             assert!(budget.target > 0, "ZK requires nonzero target query budget");
             assert!(budget.mask > 0, "ZK requires nonzero mask query budget");
+            // TODO : find a better way to set mask length for ZK code-switch
+            // leaving right now for code switching. This will change in parameter
+            // selection
             target_config.mask_length = budget.target;
             target_config.reparameterise_security(security_target, unique_decoding);
 
@@ -178,6 +137,11 @@ impl<M: Embedding> Config<M> {
             mask_config
         });
 
+        assert!(
+            source_config.mask_length == 0 || mask_commit.is_some(),
+            "source with ZK randomness requires ZK code-switch (mask_commit)"
+        );
+
         let (list_size, degree) = mask_commit.as_ref().map_or_else(
             || (target_config.list_size(), source_message_length),
             |mask_cfg| {
@@ -187,7 +151,7 @@ impl<M: Embedding> Config<M> {
                 )
             },
         );
-        let ood_samples = num_ood_samples(
+        let out_domain_samples = num_ood_samples(
             unique_decoding,
             security_target,
             M::Target::field_size_bits(),
@@ -199,11 +163,13 @@ impl<M: Embedding> Config<M> {
             embedding: Typed::<M>::default(),
             source: source_config,
             target: target_config,
-            ood_samples,
+            out_domain_samples,
             mask_commit,
         }
     }
 
+    /// Prove the code-switch. Updates `covector` in-place with the new linear
+    /// form sl' for the next sumcheck (Completeness proof, p.55-56).
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn prove<H, R>(
         &self,
@@ -211,7 +177,8 @@ impl<M: Embedding> Config<M> {
         message: Vec<M::Target>,
         masks: &[M::Source],
         witness: &IrsWitness<M::Source, M::Target>,
-    ) -> Witness<M::Target, M::Source>
+        covector: &mut [M::Target],
+    ) -> Witness<M::Target>
     where
         H: DuplexSpongeInterface,
         R: RngCore + CryptoRng,
@@ -230,10 +197,10 @@ impl<M: Embedding> Config<M> {
             "mask config and target mask_length must agree"
         );
 
-        // Step 1a: g := Enc_{C'}(f, r')
+        // Step 1a: g := Enc_{C'}(f, r') — Construction 9.7 Step 1, p.55
         let target_witness = self.target.commit(prover_state, &[&message]);
 
-        // Step 1b: s := Enc_{C_zk}((r || padding), r'')
+        // Step 1b: s := Enc_{C_zk}((r || padding), r'') — Construction 9.7 Step 1, p.55
         #[allow(clippy::option_if_let_else)]
         let mask = if let Some(mask_config) = &self.mask_commit {
             let mask_msg_len = mask_config.message_length();
@@ -245,18 +212,21 @@ impl<M: Embedding> Config<M> {
                 random_vector(prover_state.rng(), mask_msg_len - embedded_randomness_len);
             mask_msg.extend_from_slice(&random_padding);
             let witness = mask_config.commit(prover_state, &[&mask_msg]);
-            Some((mask_msg, witness))
+            Some(MaskOracle {
+                message: mask_msg,
+                witness,
+            })
         } else {
             None
         };
 
-        // Step 2-3: OOD challenge + answers
-        let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.ood_samples);
+        // Step 2-3: OOD challenge + answers — Construction 9.7 Steps 2-3, p.55
+        let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.out_domain_samples);
         let msg_len = message.len();
         for &point in &ood_points {
             let f_eval = univariate_evaluate(&message, point);
-            if let Some((mask_msg, _)) = &mask {
-                let mask_msg_eval = univariate_evaluate(mask_msg, point);
+            if let Some(ref mask_oracle) = mask {
+                let mask_msg_eval = univariate_evaluate(&mask_oracle.message, point);
                 let shift = point.pow([msg_len as u64]);
                 prover_state.prover_message(&(f_eval + shift * mask_msg_eval));
             } else {
@@ -264,30 +234,56 @@ impl<M: Embedding> Config<M> {
             }
         }
 
-        // Step 4: in-domain queries
+        // Step 4: in-domain queries — Construction 9.7 Step 4, p.55
         let source_evaluations = self.source.open(prover_state, &[witness]);
 
-        // Step 5: batching (advance transcript to stay in sync with verify)
-        geometric_challenge::<_, M::Target>(
-            prover_state,
-            1 + self.ood_samples + source_evaluations.matrix.len(),
-        );
+        // Step 5: batching — Construction 9.7 Step 5, p.55
+        let num_ood = self.out_domain_samples;
+        let num_in_domain = source_evaluations.matrix.len();
+        let batching_coeffs =
+            geometric_challenge::<_, M::Target>(prover_state, 1 + num_ood + num_in_domain);
+        let (&original_sl_coeff, constraint_rlc_coeffs) = batching_coeffs.split_first().unwrap();
+        let (ood_rlc_coeffs, in_domain_rlc_coeffs) = constraint_rlc_coeffs.split_at(num_ood);
+
+        // Covector update — sl' from Completeness proof (p.55-56)
+        let embedding = self.source.embedding();
+        // ν_1 · sl(st): scale previous constraint
+        for c in &mut *covector {
+            *c *= original_sl_coeff;
+        }
+        // include OOD message weights
+        for (&weight, &ood_point) in ood_rlc_coeffs.iter().zip(&ood_points) {
+            let mut point_pow = M::Target::ONE;
+            for c in &mut *covector {
+                *c += weight * point_pow;
+                point_pow *= ood_point;
+            }
+        }
+        // include In-domain message weights
+        for (&weight, &query_point) in in_domain_rlc_coeffs.iter().zip(&source_evaluations.points) {
+            let eval_point = embedding.map(query_point);
+            let mut point_pow = M::Target::ONE;
+            for c in &mut *covector {
+                *c += weight * point_pow;
+                point_pow *= eval_point;
+            }
+        }
 
         Witness {
-            target_witness,
             message,
-            source_evaluations,
+            target_witness,
             mask,
         }
     }
 
+    /// Verify the code-switch.
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn verify<H>(
         &self,
         verifier_state: &mut VerifierState<H>,
-        mu: M::Target,
+        sum: &mut M::Target,
         commitment: &IrsCommitment<M::Target>,
-    ) -> VerificationResult<CodeSwitchClaim<M::Target, M::Source>>
+    ) -> VerificationResult<Commitments<M::Target>>
     where
         H: DuplexSpongeInterface,
         Standard: Distribution<M::Target>,
@@ -300,7 +296,7 @@ impl<M: Embedding> Config<M> {
             "mask config and target mask_length must agree"
         );
 
-        // Step 1: commitments
+        // Step 1: commitments — Construction 9.7 Step 1, p.55
         let target_commitment = self.target.receive_commitment(verifier_state)?;
         let mask_commitment = self
             .mask_commit
@@ -308,22 +304,23 @@ impl<M: Embedding> Config<M> {
             .map(|mask_cfg| mask_cfg.receive_commitment(verifier_state))
             .transpose()?;
 
-        // Step 2-3: OOD
-        let ood_points: Vec<M::Target> = verifier_state.verifier_message_vec(self.ood_samples);
-        let ood_answers: Vec<M::Target> = verifier_state.prover_messages_vec(self.ood_samples)?;
+        // Step 2-3: OOD — Construction 9.7 Steps 2-3, p.55
+        let _ood_points: Vec<M::Target> =
+            verifier_state.verifier_message_vec(self.out_domain_samples);
+        let ood_answers: Vec<M::Target> =
+            verifier_state.prover_messages_vec(self.out_domain_samples)?;
 
-        // Step 4: source opening
+        // Step 4: source opening — Construction 9.7 Step 4, p.55
         let source_evaluations = self.source.verify(verifier_state, &[commitment])?;
 
-        // Step 5: batching
-        let num_ood = self.ood_samples;
+        // Step 5-6: batching + μ' — Construction 9.7 Decision phase, p.55
+        let num_ood = self.out_domain_samples;
         let num_in_domain = source_evaluations.matrix.len();
         let coeffs = geometric_challenge(verifier_state, 1 + num_ood + num_in_domain);
         let (&original_sl_coeff, all_rlc_coeffs) = coeffs.split_first().unwrap();
         let (ood_rlc_coeffs, in_domain_rlc_coeffs) = all_rlc_coeffs.split_at(num_ood);
 
-        // Step 6: μ'
-        let mu_prime = original_sl_coeff * mu
+        *sum = original_sl_coeff * *sum
             + dot(ood_rlc_coeffs, &ood_answers)
             + mixed_dot(
                 self.source.embedding(),
@@ -331,60 +328,23 @@ impl<M: Embedding> Config<M> {
                 &source_evaluations.matrix,
             );
 
-        // Step 7: constraint weights
-        let source_msg_len = self.source.message_length();
-        let source_weights = ConstraintWeights {
-            ood: ood_points
-                .iter()
-                .map(|&point| UnivariateEvaluation::new(point, source_msg_len))
-                .collect(),
-            in_domain: source_evaluations.evaluators(source_msg_len).collect(),
-        };
-
-        // Mask weights with shift ρ^ℓ baked into RLC coefficients.
-        // In-domain shift lifted G → F via embedding (ring homomorphism).
-        let mask_info = self.mask_commit.as_ref().map(|mask_config| {
-            let source_randomness_len = self.source.mask_length * self.source.num_messages();
-            let weights = ConstraintWeights {
-                ood: ood_points
-                    .iter()
-                    .map(|&point| UnivariateEvaluation::new(point, mask_config.message_length()))
-                    .collect(),
-                in_domain: source_evaluations
-                    .evaluators(source_randomness_len)
-                    .collect(),
-            };
-            let embedding = self.source.embedding();
-            let mask_ood_rlc_coeffs: Vec<M::Target> = ood_rlc_coeffs
-                .iter()
-                .zip(&weights.ood)
-                .map(|(&c, w)| c * w.point.pow([source_msg_len as u64]))
-                .collect();
-            let mask_in_domain_rlc_coeffs: Vec<M::Target> = in_domain_rlc_coeffs
-                .iter()
-                .zip(&weights.in_domain)
-                .map(|(&c, w)| c * embedding.map(w.point.pow([source_msg_len as u64])))
-                .collect();
-
-            MaskClaimInfo {
-                commitment: mask_commitment.expect("mask commitment must exist when masked"),
-                ood_rlc_coeffs: mask_ood_rlc_coeffs,
-                in_domain_rlc_coeffs: mask_in_domain_rlc_coeffs,
-                weights,
-                source_randomness_len,
-            }
-        });
-
-        Ok(CodeSwitchClaim {
-            mu_prime,
-            original_sl_coeff,
-            target_commitment,
-            ood_rlc_coeffs: ood_rlc_coeffs.to_vec(),
-            in_domain_rlc_coeffs: in_domain_rlc_coeffs.to_vec(),
-            source_weights,
-            mask_info,
-            source_evaluations,
+        Ok(Commitments {
+            target: target_commitment,
+            mask: mask_commitment,
         })
+    }
+}
+
+impl<M: Embedding> fmt::Display for Config<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Config(source={}, target={}, ood_samples={}, zk={})",
+            self.source,
+            self.target,
+            self.out_domain_samples,
+            self.mask_commit.is_some()
+        )
     }
 }
 
@@ -397,7 +357,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        algebra::{embedding::Identity, fields, linear_form::Evaluate, ntt, random_vector},
+        algebra::{embedding::Identity, fields, ntt, random_vector},
         transcript::{codecs::U64, DomainSeparator},
     };
 
@@ -422,7 +382,7 @@ mod tests {
                 .prop_flat_map(|(source, masked)| {
                     let msg_len = source.message_length();
                     let rnd_len = source.mask_length * source.num_messages();
-                    let target_mask = if masked { 1 } else { 0 };
+                    let target_mask = usize::from(masked);
 
                     let target = IrsConfig::<Identity<M::Target>>::arbitrary(
                         Identity::new(),
@@ -448,23 +408,16 @@ mod tests {
 
                     (Just(source), target, mask, 0_usize..=5)
                 })
-                .prop_map(move |(source, target, mask_commit, ood_samples)| Self {
-                    embedding: Typed::new(emb2.clone()),
-                    source,
-                    target,
-                    ood_samples,
-                    mask_commit,
-                })
+                .prop_map(
+                    move |(source, target, mask_commit, out_domain_samples)| Self {
+                        embedding: Typed::new(emb2.clone()),
+                        source,
+                        target,
+                        out_domain_samples,
+                        mask_commit,
+                    },
+                )
         }
-    }
-
-    /// Σ rlc[i] * weight[i].evaluate(vector)
-    fn weighted_eval<F: Field>(rlc: &[F], weights: &[UnivariateEvaluation<F>], v: &[F]) -> F {
-        let e = Identity::<F>::new();
-        rlc.iter()
-            .zip(weights)
-            .map(|(&c, w)| c * w.evaluate(&e, v))
-            .sum()
     }
 
     fn test_config<F: Field + Codec<[u8]>>(seed: u64, config: &Config<Identity<F>>)
@@ -482,7 +435,8 @@ mod tests {
         let message: Vec<F> = random_vector(&mut rng, config.source.message_length());
         let target_mu: F = rng.gen();
 
-        // Prover
+        let mut covector: Vec<F> = random_vector(&mut rng, config.source.message_length());
+
         let mut prover_state = ProverState::new_std(&ds);
         let source_witness = config.source.commit(&mut prover_state, &[&message]);
         let witness = config.prove(
@@ -490,57 +444,26 @@ mod tests {
             message.clone(),
             &source_witness.masks,
             &source_witness,
+            &mut covector,
         );
         let proof = prover_state.proof();
 
-        // Verifier
         let mut verifier_state = VerifierState::new_std(&ds, &proof);
-        let commitment = config
+        let source_commitment = config
             .source
             .receive_commitment(&mut verifier_state)
             .unwrap();
-        let claim = config
-            .verify(&mut verifier_state, target_mu, &commitment)
+        let mut verifier_sum = target_mu;
+        let commitments = config
+            .verify(&mut verifier_state, &mut verifier_sum, &source_commitment)
             .unwrap();
+
+        // Transcript fully consumed — prover and verifier are in sync
         verifier_state.check_eof().unwrap();
-
-        // Completeness: μ' = ν_1·μ + ⟨f, source_weights⟩ + ⟨mask_msg, mask_weights⟩
+        // Mask commitment present if ZK mode
+        assert_eq!(commitments.mask.is_some(), config.mask_commit.is_some());
         assert_eq!(witness.message, message);
-
-        let msg_sum = weighted_eval(&claim.ood_rlc_coeffs, &claim.source_weights.ood, &message)
-            + weighted_eval(
-                &claim.in_domain_rlc_coeffs,
-                &claim.source_weights.in_domain,
-                &message,
-            );
-
-        let mask_sum = witness
-            .mask
-            .as_ref()
-            .zip(claim.mask_info.as_ref())
-            .map_or(F::ZERO, |((mm, _), info)| {
-                info.evaluate(&Identity::<F>::new(), mm)
-            });
-
-        assert_eq!(
-            msg_sum + mask_sum,
-            claim.mu_prime - claim.original_sl_coeff * target_mu,
-        );
-
-        // Structural invariants
-        assert_eq!(claim.ood_rlc_coeffs.len(), claim.source_weights.ood.len());
-        assert_eq!(
-            claim.in_domain_rlc_coeffs.len(),
-            claim.source_weights.in_domain.len()
-        );
-        assert_eq!(claim.mask_info.is_some(), config.mask_commit.is_some());
-        if let Some(ref info) = claim.mask_info {
-            assert_eq!(info.ood_rlc_coeffs.len(), info.weights.ood.len());
-            assert_eq!(
-                info.in_domain_rlc_coeffs.len(),
-                info.weights.in_domain.len()
-            );
-        }
+        assert_eq!(witness.mask.is_some(), config.mask_commit.is_some());
     }
 
     fn test<F: Field + Codec<[u8]> + 'static>()

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -116,7 +116,7 @@ impl<M: Embedding> Config<M> {
             // leaving right now for code switching. This will change in parameter
             // selection
             target_config.mask_length = budget.target;
-            target_config.reparameterise_security(security_target, unique_decoding);
+            target_config.recompute_security_parameters(security_target, unique_decoding);
 
             let source_randomness_len = source_config.mask_length * source_config.num_messages();
             assert!(
@@ -135,7 +135,7 @@ impl<M: Embedding> Config<M> {
                 source_config.rate(),
             );
             mask_config.mask_length = budget.mask;
-            mask_config.reparameterise_security(security_target, unique_decoding);
+            mask_config.recompute_security_parameters(security_target, unique_decoding);
             mask_config
         });
 
@@ -227,6 +227,7 @@ impl<M: Embedding> Config<M> {
         };
 
         // Step 2-3: OOD challenge + answers — Construction 9.7 Steps 2-3, p.55
+        // TODO : check the private zero evader for code switch protocol.
         let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.out_domain_samples);
         let msg_len = message.len();
         for &point in &ood_points {

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -33,14 +33,33 @@ use crate::{
     type_info::Typed,
 };
 
+/// Code-switching IOR config with optional ZK.
+#[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct Config<M: Embedding> {
+    pub embedding: Typed<M>,
+    pub source: IrsConfig<M>,
+    pub target: IrsConfig<Identity<M::Target>>,
+    pub ood_samples: usize,
+    pub mask_commit: Option<IrsConfig<Identity<M::Target>>>,
+}
+
+/// Next stage's query budgets for ZK encoding (Prop 3.19).
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+pub struct ZkQueryBudget {
+    /// Queries the next stage makes to the target oracle g.
+    pub target: usize,
+    /// Queries the next stage makes to the mask oracle s.
+    pub mask: usize,
+}
+
 /// Prover output from the code-switch.
 #[derive(Clone, Debug)]
 pub struct Witness<F: Field, G: Field = F> {
     pub target_witness: IrsWitness<F>,
     pub message: Vec<F>,
     pub source_evaluations: IrsEvaluations<G>,
-    pub mask_witness: Option<IrsWitness<F>>,
-    pub mask_message: Option<Vec<F>>,
+    pub mask: Option<(Vec<F>, IrsWitness<F>)>,
 }
 
 /// OOD and in-domain constraint weights for a single oracle.
@@ -100,40 +119,6 @@ pub struct CodeSwitchClaim<F: Field, G: Field = F> {
     pub source_weights: ConstraintWeights<F, G>,
     pub mask_info: Option<MaskClaimInfo<F, G>>,
     pub source_evaluations: IrsEvaluations<G>,
-}
-
-/// Next stage's query budgets for ZK encoding (Prop 3.19).
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
-pub struct ZkQueryBudget {
-    /// Queries the next stage makes to the target oracle g.
-    pub target: usize,
-    /// Queries the next stage makes to the mask oracle s.
-    pub mask: usize,
-}
-
-/// Code-switching IOR config with optional ZK.
-#[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
-#[serde(bound = "")]
-pub struct Config<M: Embedding> {
-    pub embedding: Typed<M>,
-    pub source: IrsConfig<M>,
-    pub target: IrsConfig<Identity<M::Target>>,
-    pub cs_ood_samples: usize,
-    pub mask_commit: Option<IrsConfig<Identity<M::Target>>>,
-}
-
-/// Split geometric challenge into (ν_1, rest). Requires count ≥ 1.
-fn batching_challenge<T, F>(transcript: &mut T, count: usize) -> (F, Vec<F>)
-where
-    T: VerifierMessage,
-    F: Field + Decoding<[T::U]>,
-{
-    assert!(count > 0, "batching requires at least one coefficient");
-    let coeffs = geometric_challenge(transcript, count);
-    let (&first, rest) = coeffs
-        .split_first()
-        .expect("count > 0 guarantees non-empty coefficients");
-    (first, rest.to_vec())
 }
 
 impl<M: Embedding> Config<M> {
@@ -202,7 +187,7 @@ impl<M: Embedding> Config<M> {
                 )
             },
         );
-        let cs_ood_samples = num_ood_samples(
+        let ood_samples = num_ood_samples(
             unique_decoding,
             security_target,
             M::Target::field_size_bits(),
@@ -214,7 +199,7 @@ impl<M: Embedding> Config<M> {
             embedding: Typed::<M>::default(),
             source: source_config,
             target: target_config,
-            cs_ood_samples,
+            ood_samples,
             mask_commit,
         }
     }
@@ -224,8 +209,8 @@ impl<M: Embedding> Config<M> {
         &self,
         prover_state: &mut ProverState<H, R>,
         message: Vec<M::Target>,
-        source_randomness: &[M::Source],
-        source_witness: &IrsWitness<M::Source, M::Target>,
+        masks: &[M::Source],
+        witness: &IrsWitness<M::Source, M::Target>,
     ) -> Witness<M::Target, M::Source>
     where
         H: DuplexSpongeInterface,
@@ -237,7 +222,7 @@ impl<M: Embedding> Config<M> {
     {
         assert_eq!(message.len(), self.source.message_length());
         assert_eq!(
-            source_randomness.len(),
+            masks.len(),
             self.source.mask_length * self.source.num_messages()
         );
         assert!(
@@ -249,56 +234,50 @@ impl<M: Embedding> Config<M> {
         let target_witness = self.target.commit(prover_state, &[&message]);
 
         // Step 1b: s := Enc_{C_zk}((r || padding), r'')
-        let (mask_message, mask_witness) =
-            self.mask_commit
-                .as_ref()
-                .map_or((None, None), |mask_config| {
-                    let mask_msg_len = mask_config.message_length();
-                    let r_embedded = lift(self.source.embedding(), source_randomness);
-                    let embedded_randomness_len = r_embedded.len();
-                    let mut mask_msg = Vec::with_capacity(mask_msg_len);
-                    mask_msg.extend_from_slice(&r_embedded);
-                    let random_padding: Vec<M::Target> =
-                        random_vector(prover_state.rng(), mask_msg_len - embedded_randomness_len);
-                    mask_msg.extend_from_slice(&random_padding);
-                    let witness = mask_config.commit(prover_state, &[&mask_msg]);
-                    (Some(mask_msg), Some(witness))
-                });
+        #[allow(clippy::option_if_let_else)]
+        let mask = if let Some(mask_config) = &self.mask_commit {
+            let mask_msg_len = mask_config.message_length();
+            let r_embedded = lift(self.source.embedding(), masks);
+            let embedded_randomness_len = r_embedded.len();
+            let mut mask_msg = Vec::with_capacity(mask_msg_len);
+            mask_msg.extend_from_slice(&r_embedded);
+            let random_padding: Vec<M::Target> =
+                random_vector(prover_state.rng(), mask_msg_len - embedded_randomness_len);
+            mask_msg.extend_from_slice(&random_padding);
+            let witness = mask_config.commit(prover_state, &[&mask_msg]);
+            Some((mask_msg, witness))
+        } else {
+            None
+        };
 
         // Step 2-3: OOD challenge + answers
-        let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.cs_ood_samples);
+        let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.ood_samples);
         let msg_len = message.len();
         for &point in &ood_points {
             let f_eval = univariate_evaluate(&message, point);
-            if source_randomness.is_empty() {
-                // Non-ZK: codeword encodes only f, so y_i = f̂(ρ)
-                prover_state.prover_message(&f_eval);
-            } else {
-                // ZK: codeword encodes h(X) = f̂(X) + X^ℓ · r̂(X), so y_i = h(ρ)
-                let mask_msg = mask_message
-                    .as_ref()
-                    .expect("ZK code-switch requires mask_message");
-                let randomness_eval = univariate_evaluate(mask_msg, point);
+            if let Some((mask_msg, _)) = &mask {
+                let mask_msg_eval = univariate_evaluate(mask_msg, point);
                 let shift = point.pow([msg_len as u64]);
-                prover_state.prover_message(&(f_eval + shift * randomness_eval));
+                prover_state.prover_message(&(f_eval + shift * mask_msg_eval));
+            } else {
+                prover_state.prover_message(&f_eval);
             }
         }
 
         // Step 4: in-domain queries
-        let source_evaluations = self.source.open(prover_state, &[source_witness]);
+        let source_evaluations = self.source.open(prover_state, &[witness]);
 
         // Step 5: batching (advance transcript to stay in sync with verify)
-        batching_challenge::<_, M::Target>(
+        geometric_challenge::<_, M::Target>(
             prover_state,
-            1 + ood_points.len() + source_evaluations.matrix.len(),
+            1 + self.ood_samples + source_evaluations.matrix.len(),
         );
 
         Witness {
             target_witness,
             message,
             source_evaluations,
-            mask_witness,
-            mask_message,
+            mask,
         }
     }
 
@@ -307,7 +286,7 @@ impl<M: Embedding> Config<M> {
         &self,
         verifier_state: &mut VerifierState<H>,
         mu: M::Target,
-        source_commitment: &IrsCommitment<M::Target>,
+        commitment: &IrsCommitment<M::Target>,
     ) -> VerificationResult<CodeSwitchClaim<M::Target, M::Source>>
     where
         H: DuplexSpongeInterface,
@@ -330,18 +309,17 @@ impl<M: Embedding> Config<M> {
             .transpose()?;
 
         // Step 2-3: OOD
-        let ood_points: Vec<M::Target> = verifier_state.verifier_message_vec(self.cs_ood_samples);
-        let ood_answers: Vec<M::Target> =
-            verifier_state.prover_messages_vec(self.cs_ood_samples)?;
+        let ood_points: Vec<M::Target> = verifier_state.verifier_message_vec(self.ood_samples);
+        let ood_answers: Vec<M::Target> = verifier_state.prover_messages_vec(self.ood_samples)?;
 
         // Step 4: source opening
-        let source_evaluations = self.source.verify(verifier_state, &[source_commitment])?;
+        let source_evaluations = self.source.verify(verifier_state, &[commitment])?;
 
         // Step 5: batching
-        let num_ood = ood_points.len();
+        let num_ood = self.ood_samples;
         let num_in_domain = source_evaluations.matrix.len();
-        let (original_sl_coeff, all_rlc_coeffs) =
-            batching_challenge(verifier_state, 1 + num_ood + num_in_domain);
+        let coeffs = geometric_challenge(verifier_state, 1 + num_ood + num_in_domain);
+        let (&original_sl_coeff, all_rlc_coeffs) = coeffs.split_first().unwrap();
         let (ood_rlc_coeffs, in_domain_rlc_coeffs) = all_rlc_coeffs.split_at(num_ood);
 
         // Step 6: μ'
@@ -415,13 +393,70 @@ mod tests {
     use ark_std::rand::{
         distributions::Standard, prelude::Distribution, rngs::StdRng, Rng, SeedableRng,
     };
-    use proptest::{proptest, sample::select};
+    use proptest::{bool, prelude::Strategy, proptest, sample::select, strategy::Just};
 
     use super::*;
     use crate::{
         algebra::{embedding::Identity, fields, linear_form::Evaluate, ntt, random_vector},
         transcript::{codecs::U64, DomainSeparator},
     };
+
+    impl<M: Embedding> Config<M> {
+        pub fn arbitrary(embedding: M) -> impl Strategy<Value = Self>
+        where
+            M: 'static,
+        {
+            let valid_sizes = (1..=256)
+                .filter(|&n| ntt::next_order::<M::Source>(n) == Some(n))
+                .collect::<Vec<_>>();
+
+            let emb1 = embedding.clone();
+            let emb2 = embedding;
+
+            (select(valid_sizes), 0_usize..=3, bool::ANY)
+                .prop_flat_map(move |(size, mask_length, masked)| {
+                    let source_mask = if masked { mask_length.max(1) } else { 0 };
+                    let source = IrsConfig::arbitrary(emb1.clone(), 1, size, source_mask, 1);
+                    (source, Just(masked))
+                })
+                .prop_flat_map(|(source, masked)| {
+                    let msg_len = source.message_length();
+                    let rnd_len = source.mask_length * source.num_messages();
+                    let target_mask = if masked { 1 } else { 0 };
+
+                    let target = IrsConfig::<Identity<M::Target>>::arbitrary(
+                        Identity::new(),
+                        1,
+                        msg_len,
+                        target_mask,
+                        1,
+                    );
+
+                    let mask = if masked && rnd_len > 0 {
+                        IrsConfig::<Identity<M::Target>>::arbitrary(
+                            Identity::new(),
+                            1,
+                            rnd_len,
+                            0,
+                            1,
+                        )
+                        .prop_map(Some)
+                        .boxed()
+                    } else {
+                        Just(None).boxed()
+                    };
+
+                    (Just(source), target, mask, 0_usize..=5)
+                })
+                .prop_map(move |(source, target, mask_commit, ood_samples)| Self {
+                    embedding: Typed::new(emb2.clone()),
+                    source,
+                    target,
+                    ood_samples,
+                    mask_commit,
+                })
+        }
+    }
 
     /// Σ rlc[i] * weight[i].evaluate(vector)
     fn weighted_eval<F: Field>(rlc: &[F], weights: &[UnivariateEvaluation<F>], v: &[F]) -> F {
@@ -432,120 +467,73 @@ mod tests {
             .sum()
     }
 
-    struct TestResult<F: Field> {
-        claim: CodeSwitchClaim<F>,
-        message: Vec<F>,
-        target_mu: F,
-        mask_message: Option<Vec<F>>,
-    }
-
-    fn run_code_switch<F: Field + FieldWithSize + Codec<[u8]> + 'static>(
-        seed: u64,
-        size: usize,
-        src_lir: usize, // source log inverse rate
-        tgt_lir: usize, // target log inverse rate
-        masked: bool,
-    ) -> TestResult<F>
+    fn test_config<F: Field + Codec<[u8]>>(seed: u64, config: &Config<Identity<F>>)
     where
         Standard: Distribution<F>,
         Hash: ProverMessage<[u8]>,
     {
-        #[allow(clippy::cast_possible_wrap)]
-        let rate = 0.5_f64.powi(src_lir as i32);
-        let mut source_config =
-            IrsConfig::<Identity<F>>::new(32.0, false, crate::hash::BLAKE3, 1, size, 1, rate);
-        if masked {
-            source_config.mask_length = 1;
-        }
+        crate::tests::init();
 
-        let zk = if masked {
-            Some(ZkQueryBudget { target: 1, mask: 1 })
-        } else {
-            None
-        };
-        let cs_config = Config::<Identity<F>>::new(
-            32.0,
-            false,
-            crate::hash::BLAKE3,
-            source_config.clone(),
-            tgt_lir,
-            1,
-            zk,
-        );
-
-        let mut rng = StdRng::seed_from_u64(seed);
-        let message: Vec<F> = random_vector(&mut rng, source_config.message_length());
-        let target_mu: F = rng.gen();
         let instance = U64(seed);
-        let domain_separator = DomainSeparator::protocol(&cs_config)
-            .session(&"cs_test")
+        let ds = DomainSeparator::protocol(config)
+            .session(&format!("Test at {}:{}", file!(), line!()))
             .instance(&instance);
+        let mut rng = StdRng::seed_from_u64(seed);
+        let message: Vec<F> = random_vector(&mut rng, config.source.message_length());
+        let target_mu: F = rng.gen();
 
-        let mut prover_state = ProverState::new_std(&domain_separator);
-        let source_witness = source_config.commit(&mut prover_state, &[&message]);
-        let cs_witness = cs_config.prove(
+        // Prover
+        let mut prover_state = ProverState::new_std(&ds);
+        let source_witness = config.source.commit(&mut prover_state, &[&message]);
+        let witness = config.prove(
             &mut prover_state,
             message.clone(),
             &source_witness.masks,
             &source_witness,
         );
-
         let proof = prover_state.proof();
-        let mut verifier_state = VerifierState::new_std(&domain_separator, &proof);
-        let source_commitment = source_config
+
+        // Verifier
+        let mut verifier_state = VerifierState::new_std(&ds, &proof);
+        let commitment = config
+            .source
             .receive_commitment(&mut verifier_state)
             .unwrap();
-        let claim = cs_config
-            .verify(&mut verifier_state, target_mu, &source_commitment)
+        let claim = config
+            .verify(&mut verifier_state, target_mu, &commitment)
             .unwrap();
         verifier_state.check_eof().unwrap();
-        assert_eq!(cs_witness.message, message);
 
-        TestResult {
-            claim,
-            message,
-            target_mu,
-            mask_message: cs_witness.mask_message,
-        }
-    }
+        // Completeness: μ' = ν_1·μ + ⟨f, source_weights⟩ + ⟨mask_msg, mask_weights⟩
+        assert_eq!(witness.message, message);
 
-    /// Completeness check (p.56): μ' = ν_1·μ + ⟨f, source_weights⟩ + ⟨mask_msg, mask_weights⟩
-    fn check_completeness<F: Field>(result: &TestResult<F>, masked: bool) {
-        let claim = &result.claim;
+        let msg_sum = weighted_eval(&claim.ood_rlc_coeffs, &claim.source_weights.ood, &message)
+            + weighted_eval(
+                &claim.in_domain_rlc_coeffs,
+                &claim.source_weights.in_domain,
+                &message,
+            );
 
-        // ⟨f, ze_ood^{←,i}⟩ + ⟨f, G_C^#[x,·]⟩ (message part of μ' decomposition)
-        let msg_sum = weighted_eval(
-            &claim.ood_rlc_coeffs,
-            &claim.source_weights.ood,
-            &result.message,
-        ) + weighted_eval(
-            &claim.in_domain_rlc_coeffs,
-            &claim.source_weights.in_domain,
-            &result.message,
-        );
-
-        // ⟨(r,s), ze_ood^{→,i}⟩ + ⟨(r,s), (G_C^s[x,·], 0)⟩ (mask part, shift pre-baked)
-        let mask_sum = result
-            .mask_message
-            .as_deref()
+        let mask_sum = witness
+            .mask
+            .as_ref()
             .zip(claim.mask_info.as_ref())
-            .map_or(F::ZERO, |(mm, info)| {
+            .map_or(F::ZERO, |((mm, _), info)| {
                 info.evaluate(&Identity::<F>::new(), mm)
             });
 
-        // Decision phase formula (p.55): μ' = ν_1·μ + message_contribution + mask_contribution
         assert_eq!(
             msg_sum + mask_sum,
-            claim.mu_prime - claim.original_sl_coeff * result.target_mu
+            claim.mu_prime - claim.original_sl_coeff * target_mu,
         );
-        // Coefficient counts match weight counts
+
+        // Structural invariants
         assert_eq!(claim.ood_rlc_coeffs.len(), claim.source_weights.ood.len());
         assert_eq!(
             claim.in_domain_rlc_coeffs.len(),
             claim.source_weights.in_domain.len()
         );
-        // ZK structure: mask_info present iff ZK mode
-        assert_eq!(claim.mask_info.is_some(), masked);
+        assert_eq!(claim.mask_info.is_some(), config.mask_commit.is_some());
         if let Some(ref info) = claim.mask_info {
             assert_eq!(info.ood_rlc_coeffs.len(), info.weights.ood.len());
             assert_eq!(
@@ -555,52 +543,49 @@ mod tests {
         }
     }
 
-    /// Powers of 2 in [8, 256] that are valid NTT domain sizes for field F.
-    fn valid_sizes<F: 'static>() -> Vec<usize> {
-        (3..=8)
-            .map(|k| 1_usize << k)
-            .filter(|&n| ntt::next_order::<F>(n) == Some(n))
-            .collect()
-    }
-
-    fn proptest_completeness<F: Field + FieldWithSize + Codec<[u8]> + 'static>()
+    fn test<F: Field + Codec<[u8]> + 'static>()
     where
         Standard: Distribution<F>,
         Hash: ProverMessage<[u8]>,
     {
-        let rates = select(vec![1_usize, 2, 3]);
-        proptest!(|(seed: u64, sz in select(valid_sizes::<F>()), s in rates.clone(), t in rates, m: bool)| {
-            check_completeness(&run_code_switch::<F>(seed, sz, s, t, m), m);
+        let configs = Config::arbitrary(Identity::<F>::new());
+        proptest!(|(seed: u64, config in configs)| {
+            test_config(seed, &config);
         });
     }
 
     #[test]
-    fn completeness_field64() {
-        proptest_completeness::<fields::Field64>();
+    fn test_field64() {
+        test::<fields::Field64>();
     }
+
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn completeness_field64_2() {
-        proptest_completeness::<fields::Field64_2>();
+    fn test_field64_2() {
+        test::<fields::Field64_2>();
     }
+
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn completeness_field64_3() {
-        proptest_completeness::<fields::Field64_3>();
+    fn test_field64_3() {
+        test::<fields::Field64_3>();
     }
+
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn completeness_field128() {
-        proptest_completeness::<fields::Field128>();
+    fn test_field128() {
+        test::<fields::Field128>();
     }
+
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn completeness_field192() {
-        proptest_completeness::<fields::Field192>();
+    fn test_field192() {
+        test::<fields::Field192>();
     }
+
     #[test]
     #[ignore = "Somewhat expensive and redundant"]
-    fn completeness_field256() {
-        proptest_completeness::<fields::Field256>();
+    fn test_field256() {
+        test::<fields::Field256>();
     }
 }

--- a/src/protocols/irs_commit.rs
+++ b/src/protocols/irs_commit.rs
@@ -237,6 +237,27 @@ impl<M: Embedding> Config<M> {
         self.out_domain_samples == 0 && self.johnson_slack == 0.0
     }
 
+    /// Recompute `johnson_slack`, `in_domain_samples`, and `out_domain_samples`
+    /// for the current rate (which accounts for `mask_length`).
+    pub fn reparameterise_security(&mut self, security_target: f64, unique_decoding: bool) {
+        let rate = self.rate();
+        let johnson_slack = if unique_decoding {
+            0.0
+        } else {
+            rate.sqrt() / 20.
+        };
+        self.johnson_slack = OrderedFloat(johnson_slack);
+        self.in_domain_samples = num_in_domain_queries(unique_decoding, security_target, rate);
+        let list_size = self.list_size();
+        self.out_domain_samples = num_ood_samples(
+            unique_decoding,
+            security_target,
+            M::Target::field_size_bits(),
+            list_size,
+            self.vector_size,
+        );
+    }
+
     /// Compute a list size bound.
     pub fn list_size(&self) -> f64 {
         if self.unique_decoding() {

--- a/src/protocols/irs_commit.rs
+++ b/src/protocols/irs_commit.rs
@@ -149,23 +149,15 @@ impl<M: Embedding> Config<M> {
         } else {
             rate.sqrt() / 20.
         };
-        #[allow(clippy::cast_sign_loss)]
-        let out_domain_samples = if unique_decoding {
-            0
-        } else {
-            let field_size_bits = M::Target::field_size_bits();
-            // Johnson list size bound 1 / (2 η √ρ)
+        let out_domain_samples = {
             let list_size = 1. / (2. * johnson_slack * rate.sqrt());
-
-            // The list size error is (L choose 2) * [(d - 1) / |𝔽|]^s
-            // See [STIR] lemma 4.5.
-            // We want to find s such that the error is less than security_target.
-            let l_choose_2 = list_size * (list_size - 1.) / 2.;
-            let log_per_sample = field_size_bits - ((vector_size - 1) as f64).log2();
-            assert!(log_per_sample > 0.);
-            ((security_target + l_choose_2.log2()) / log_per_sample)
-                .ceil()
-                .max(1.) as usize
+            num_ood_samples(
+                unique_decoding,
+                security_target,
+                M::Target::field_size_bits(),
+                list_size,
+                vector_size,
+            )
         };
         #[allow(clippy::cast_sign_loss)]
         let in_domain_samples = {
@@ -579,6 +571,30 @@ impl<M: Embedding> fmt::Display for Config<M> {
             self.in_domain_samples, self.out_domain_samples
         )
     }
+}
+
+/// Return the number of OOD samples needed.
+///
+/// Solves `(L choose 2) · ((degree - 1) / |F|)^s ≤ 2^{-security_target}`
+/// where `L` is the list size and `degree` is the polynomial degree bound.
+/// See [STIR] Lemma 4.5.
+#[allow(clippy::cast_sign_loss)]
+pub(crate) fn num_ood_samples(
+    unique_decoding: bool,
+    security_target: f64,
+    field_size_bits: f64,
+    list_size: f64,
+    degree: usize,
+) -> usize {
+    if unique_decoding {
+        return 0;
+    }
+    let l_choose_2 = list_size * (list_size - 1.) / 2.;
+    let log_per_sample = field_size_bits - ((degree - 1) as f64).log2();
+    assert!(log_per_sample > 0.);
+    ((security_target + l_choose_2.log2()) / log_per_sample)
+        .ceil()
+        .max(1.) as usize
 }
 
 /// Return the number of in-domain queries.

--- a/src/protocols/irs_commit.rs
+++ b/src/protocols/irs_commit.rs
@@ -324,6 +324,8 @@ impl<M: Embedding> Config<M> {
         let matrix_witness = self.matrix_commit.commit(prover_state, &matrix);
 
         // Handle out-of-domain points and values
+        // TODO : Remove this logic after main whir protocol is updated
+        // as this is not required in the new construction.
         let oods_points: Vec<M::Target> =
             prover_state.verifier_message_vec(self.out_domain_samples);
         let mut oods_matrix = Vec::with_capacity(self.out_domain_samples * self.num_vectors);

--- a/src/protocols/irs_commit.rs
+++ b/src/protocols/irs_commit.rs
@@ -239,7 +239,7 @@ impl<M: Embedding> Config<M> {
 
     /// Recompute `johnson_slack`, `in_domain_samples`, and `out_domain_samples`
     /// for the current rate (which accounts for `mask_length`).
-    pub fn reparameterise_security(&mut self, security_target: f64, unique_decoding: bool) {
+    pub fn recompute_security_parameters(&mut self, security_target: f64, unique_decoding: bool) {
         let rate = self.rate();
         let johnson_slack = if unique_decoding {
             0.0

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod basecase;
 pub mod challenge_indices;
+pub mod code_switch;
 pub mod geometric_challenge;
 pub mod irs_commit;
 pub mod matrix_commit;


### PR DESCRIPTION
**Summary**

Implements the code-switching IOR from Section 9.4 as a standalone sub-protocol in src/protocols/code_switch.rs.
Code switching reduces a proximity claim about oracle f w.r.t. source code C to a proximity claim about oracle g w.r.t. target code C', enabling the polylogarithmic-verifier protocol (Theorem 4) where the tested code shrinks each round.

**What's implemented**

  - Config: Derives target code C' from source (ℓ' = ℓ, m' from rate), optional ZK mask code C_zk, OOD sample computation from Lemma 9.9. ZK query budgets passed via Option<ZkQueryBudget>.
  - Prover (prove): Commits target oracle g, optionally commits mask oracle s = Enc_{C_zk}((r, pad), r''), sends OOD answers, opens source oracle. Reuses irs_commit::commit and irs_commit::open with zero duplicated logic.
  - Verifier (verify): Mirrors prover transcript, computes batched target μ', builds constraint weights for output sl'. Mask weights have pre-shifted RLC coefficients via MaskClaimInfo.
  - Shared batching_challenge helper ensures prover/verifier transcript sync.
  - Shared num_ood_samples extracted to irs_commit — used by both irs_commit::Config::new and code switch.
  - Tests: Proptest over field types, sizes, rates, and ZK/non-ZK mode. Tests here just check the code switch transcript match. (Tests will be added in future PRs).

  **What's NOT in this PR (next PRs)**

  - Integration into whir's round structure as an alternative to sumcheck-only folding
  - Implement zk sumcheck according to the construction 6.3 to include masks
  - Refactoring irs_commit to separate commitment from OOD (deferred to whir integration)
  - Parameter selection
  - Mask resolution per iteration (this makes the basecase verification simple and whole flow clean and contained)