### PR TITLE
perf(whir_zk): IRS-coeff residency + output-pruned NTT for f̂ opens

### DIFF
--- a/src/algebra/ntt/cooley_tukey.rs
+++ b/src/algebra/ntt/cooley_tukey.rs
@@ -370,6 +370,7 @@ impl<F: Field> NttEngine<F> {
     /// `O(size * log(size))` for a full NTT.
     ///
     /// `size` must be a power of two.
+    #[allow(dead_code)] // public single-shot entry; batched callers use the plan-based path
     pub fn ntt_partial(&self, values: &[F], size: usize, indices: &[usize]) -> Vec<F> {
         let plan = PartialNttPlan::new(size, indices);
         let mut out = vec![F::ZERO; indices.len()];
@@ -383,6 +384,7 @@ impl<F: Field> NttEngine<F> {
     ///
     /// Sharing a single plan across many NTTs with the same `(size, indices)`
     /// avoids re-running the O(size · log size) mask construction per call.
+    #[allow(clippy::significant_drop_tightening)] // roots guard intentionally held across DIT stages
     pub fn ntt_partial_with_plan_into(
         &self,
         values: &[F],
@@ -397,7 +399,7 @@ impl<F: Field> NttEngine<F> {
             return;
         }
         assert!(
-            out.len() >= (indices.len() - 1) * stride + 1,
+            out.len() > (indices.len() - 1) * stride,
             "output buffer too small for stride"
         );
         if size == 1 {
@@ -507,7 +509,7 @@ impl PartialNttPlan {
         }
     }
 
-    pub fn size(&self) -> usize {
+    pub const fn size(&self) -> usize {
         self.size
     }
 

--- a/src/algebra/ntt/cooley_tukey.rs
+++ b/src/algebra/ntt/cooley_tukey.rs
@@ -356,6 +356,164 @@ impl<F: Field> NttEngine<F> {
             size => self.ntt_recurse(values, roots, size),
         }
     }
+
+    /// Output-pruned NTT (Sorensen-Burrus, radix-2 DIT).
+    ///
+    /// Computes the size-`size` NTT of `values` (zero-padded to `size` if
+    /// shorter) and returns the outputs at positions `indices`, in input
+    /// order. Output `j` equals the full NTT at position `indices[j]`.
+    ///
+    /// Walks the butterfly DAG backwards from `indices` to mark only the
+    /// cone of butterflies that contribute to the queried outputs, then
+    /// runs only the marked butterflies on the forward pass. Cost is
+    /// `O(size + indices.len() * log(size))` field operations, vs
+    /// `O(size * log(size))` for a full NTT.
+    ///
+    /// `size` must be a power of two.
+    pub fn ntt_partial(&self, values: &[F], size: usize, indices: &[usize]) -> Vec<F> {
+        let plan = PartialNttPlan::new(size, indices);
+        let mut out = vec![F::ZERO; indices.len()];
+        self.ntt_partial_with_plan_into(values, &plan, &mut out, 1);
+        out
+    }
+
+    /// Run a pruned NTT using a precomputed plan and write outputs into
+    /// `out` at stride `stride` (so `out[j * stride]` holds the result for
+    /// `plan.indices[j]`). When `stride == 1`, output is contiguous.
+    ///
+    /// Sharing a single plan across many NTTs with the same `(size, indices)`
+    /// avoids re-running the O(size · log size) mask construction per call.
+    pub fn ntt_partial_with_plan_into(
+        &self,
+        values: &[F],
+        plan: &PartialNttPlan,
+        out: &mut [F],
+        stride: usize,
+    ) {
+        let size = plan.size;
+        let indices = &plan.indices;
+        assert!(values.len() <= size, "input longer than NTT size");
+        if indices.is_empty() {
+            return;
+        }
+        assert!(
+            out.len() >= (indices.len() - 1) * stride + 1,
+            "output buffer too small for stride"
+        );
+        if size == 1 {
+            let v = values.first().copied().unwrap_or(F::ZERO);
+            for j in 0..indices.len() {
+                out[j * stride] = v;
+            }
+            return;
+        }
+
+        let log_n = size.trailing_zeros() as usize;
+        let roots = self.roots_table(size);
+
+        // Load bit-reversed input into work buffer, gated by mask[0].
+        let mut work = vec![F::ZERO; size];
+        let shift = (usize::BITS as usize) - log_n;
+        for (j, &c) in values.iter().enumerate() {
+            let rev = j.reverse_bits() >> shift;
+            if plan.mask[0][rev] {
+                work[rev] = c;
+            }
+        }
+
+        // Forward DIT, skipping butterflies with no needed outputs.
+        // The shared roots table may hold roots at a larger order than `size`;
+        // `roots[k * twiddle_step]` retrieves ω_m^k regardless.
+        for stage in 1..=log_n {
+            let m = 1usize << stage;
+            let half = m >> 1;
+            let twiddle_step = roots.len() / m;
+            let cur = &plan.mask[stage];
+            let mut base = 0;
+            while base < size {
+                for k in 0..half {
+                    let a = base + k;
+                    let b = a + half;
+                    if cur[a] || cur[b] {
+                        let w = roots[k * twiddle_step];
+                        let t = work[b] * w;
+                        let u = work[a];
+                        work[a] = u + t;
+                        work[b] = u - t;
+                    }
+                }
+                base += m;
+            }
+        }
+
+        for (j, &i) in indices.iter().enumerate() {
+            out[j * stride] = work[i];
+        }
+    }
+}
+
+/// Pruning plan for an output-pruned NTT.
+///
+/// Holds the queried output indices and the precomputed per-stage
+/// "needed-position" masks used by [`NttEngine::ntt_partial_with_plan_into`].
+/// Construct once per `(size, indices)` and reuse across multiple NTTs of
+/// the same shape (e.g. all polynomials in an interleaved batch).
+#[derive(Debug, Clone)]
+pub struct PartialNttPlan {
+    size: usize,
+    indices: Vec<usize>,
+    /// `mask[stage][p]` is true iff position `p` after `stage` DIT stages
+    /// must be correct for the final outputs. `mask[log_n]` mirrors
+    /// `indices`; `mask[0]` selects the bit-reversed input positions that
+    /// must be loaded.
+    mask: Vec<Vec<bool>>,
+}
+
+impl PartialNttPlan {
+    pub fn new(size: usize, indices: &[usize]) -> Self {
+        assert!(size.is_power_of_two(), "size must be a power of two");
+        assert!(
+            indices.iter().all(|&i| i < size),
+            "query index out of range"
+        );
+        let log_n = size.trailing_zeros() as usize;
+        let mut mask: Vec<Vec<bool>> = vec![vec![false; size]; log_n + 1];
+        for &i in indices {
+            mask[log_n][i] = true;
+        }
+        for stage in (1..=log_n).rev() {
+            let m = 1usize << stage;
+            let half = m >> 1;
+            let (lo, hi) = mask.split_at_mut(stage);
+            let cur = &hi[0];
+            let prev = &mut lo[stage - 1];
+            let mut base = 0;
+            while base < size {
+                for k in 0..half {
+                    let a = base + k;
+                    let b = a + half;
+                    if cur[a] || cur[b] {
+                        prev[a] = true;
+                        prev[b] = true;
+                    }
+                }
+                base += m;
+            }
+        }
+        Self {
+            size,
+            indices: indices.to_vec(),
+            mask,
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub fn indices(&self) -> &[usize] {
+        &self.indices
+    }
 }
 
 /// Applies twiddle factors to a slice of field elements in-place.
@@ -962,5 +1120,94 @@ mod tests {
         engine.ntt_batch(&mut values_ntt, 32);
 
         assert_eq!(values_ntt, expected_values);
+    }
+
+    #[test]
+    fn test_ntt_partial_matches_full() {
+        use ark_std::{rand::Rng, UniformRand};
+
+        let engine = NttEngine::<Field64>::new_from_fftfield();
+        let mut rng = ark_std::test_rng();
+
+        for &size in &[4usize, 16, 64, 256, 1024, 1 << 15] {
+            for _ in 0..8 {
+                // Full NTT reference.
+                let coeffs: Vec<_> = (0..size).map(|_| Field64::rand(&mut rng)).collect();
+                let mut full = coeffs.clone();
+                engine.ntt_batch(&mut full, size);
+
+                // Random subset of varying size (cover dense + sparse).
+                let k = rng.gen_range(1..=size.min(64));
+                let mut perm: Vec<usize> = (0..size).collect();
+                for i in (1..size).rev() {
+                    perm.swap(i, rng.gen_range(0..=i));
+                }
+                let indices: Vec<usize> = perm.into_iter().take(k).collect();
+
+                let partial = engine.ntt_partial(&coeffs, size, &indices);
+                assert_eq!(partial.len(), indices.len());
+                for (j, &idx) in indices.iter().enumerate() {
+                    assert_eq!(partial[j], full[idx], "size={size} idx={idx}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_ntt_partial_zero_padded_input() {
+        // M < N: input is zero-padded. Partial NTT must agree with full NTT
+        // computed over the zero-padded coefficient vector.
+        use ark_std::UniformRand;
+
+        let engine = NttEngine::<Field64>::new_from_fftfield();
+        let mut rng = ark_std::test_rng();
+
+        for (m, size) in [(1usize, 4), (4, 16), (256, 1024), (1 << 13, 1 << 15)] {
+            let coeffs: Vec<_> = (0..m).map(|_| Field64::rand(&mut rng)).collect();
+            let mut padded = coeffs.clone();
+            padded.resize(size, Field64::ZERO);
+            engine.ntt_batch(&mut padded, size);
+
+            let stride = (size / 8).max(1);
+            let indices: Vec<usize> = (0..size).step_by(stride).take(8).collect();
+            let partial = engine.ntt_partial(&coeffs, size, &indices);
+            for (j, &idx) in indices.iter().enumerate() {
+                assert_eq!(partial[j], padded[idx], "m={m} size={size} idx={idx}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_ntt_partial_edge_cases() {
+        use ark_std::UniformRand;
+
+        let engine = NttEngine::<Field64>::new_from_fftfield();
+        let mut rng = ark_std::test_rng();
+
+        // Empty index set.
+        let coeffs: Vec<_> = (0..16).map(|_| Field64::rand(&mut rng)).collect();
+        let out = engine.ntt_partial(&coeffs, 16, &[]);
+        assert!(out.is_empty());
+
+        // Singleton at position 0 and position N-1.
+        let coeffs: Vec<_> = (0..64).map(|_| Field64::rand(&mut rng)).collect();
+        let mut full = coeffs.clone();
+        engine.ntt_batch(&mut full, 64);
+        for idx in [0usize, 1, 31, 32, 63] {
+            let out = engine.ntt_partial(&coeffs, 64, &[idx]);
+            assert_eq!(out, vec![full[idx]], "idx={idx}");
+        }
+
+        // Repeated indices: each occurrence must yield the matching output.
+        let indices = vec![5usize, 5, 17, 5, 17];
+        let out = engine.ntt_partial(&coeffs, 64, &indices);
+        for (j, &idx) in indices.iter().enumerate() {
+            assert_eq!(out[j], full[idx]);
+        }
+
+        // size = 1: any indices must all return values[0].
+        let single = vec![Field64::from(42)];
+        let out = engine.ntt_partial(&single, 1, &[0, 0, 0]);
+        assert_eq!(out, vec![Field64::from(42); 3]);
     }
 }

--- a/src/algebra/ntt/mod.rs
+++ b/src/algebra/ntt/mod.rs
@@ -17,6 +17,8 @@ use std::{
 };
 
 use ark_ff::{FftField, Field};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 use static_assertions::assert_obj_safe;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
@@ -130,15 +132,37 @@ pub fn partial_interleaved_rs_encode<F: FftField>(
     let engine = NttEngine::<F>::new_from_cache();
     let plan = PartialNttPlan::new(codeword_length, indices);
 
-    let mut out = vec![F::ZERO; k * num_cols];
-    for (poly_idx, poly) in coeffs.iter().enumerate() {
-        for slot_idx in 0..interleaving_depth {
-            let col = poly_idx * interleaving_depth + slot_idx;
-            let block = &poly[slot_idx * message_length..(slot_idx + 1) * message_length];
-            engine.ntt_partial_with_plan_into(block, &plan, &mut out[col..], num_cols);
-        }
+    // Build the submatrix in batch-major layout (`(num_cols, k)`): each
+    // contiguous k-chunk is one NTT's outputs. Batches are independent, so
+    // populate in parallel across (poly_idx, slot_idx). Final transpose
+    // converts to the row-major `(k, num_cols)` layout that
+    // `irs_commit::open_inner_from_coeffs` expects.
+    let mut batch_major = vec![F::ZERO; num_cols * k];
+
+    #[cfg(feature = "parallel")]
+    {
+        batch_major
+            .par_chunks_exact_mut(k)
+            .enumerate()
+            .for_each(|(col, dst)| {
+                let poly_idx = col / interleaving_depth;
+                let slot_idx = col % interleaving_depth;
+                let block = &coeffs[poly_idx]
+                    [slot_idx * message_length..(slot_idx + 1) * message_length];
+                engine.ntt_partial_with_plan_into(block, &plan, dst, 1);
+            });
     }
-    out
+    #[cfg(not(feature = "parallel"))]
+    for (col, dst) in batch_major.chunks_exact_mut(k).enumerate() {
+        let poly_idx = col / interleaving_depth;
+        let slot_idx = col % interleaving_depth;
+        let block =
+            &coeffs[poly_idx][slot_idx * message_length..(slot_idx + 1) * message_length];
+        engine.ntt_partial_with_plan_into(block, &plan, dst, 1);
+    }
+
+    transpose(&mut batch_major, num_cols, k);
+    batch_major
 }
 
 ///

--- a/src/algebra/ntt/mod.rs
+++ b/src/algebra/ntt/mod.rs
@@ -21,9 +21,9 @@ use static_assertions::assert_obj_safe;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-use self::matrix::MatrixMut;
+use self::{cooley_tukey::NttEngine, matrix::MatrixMut};
 pub use self::{
-    cooley_tukey::{generator, intt, intt_batch, ntt, ntt_batch},
+    cooley_tukey::{generator, intt, intt_batch, ntt, ntt_batch, PartialNttPlan},
     transpose::transpose,
     wavelet::{inverse_wavelet_transform, wavelet_transform},
 };
@@ -91,6 +91,54 @@ pub fn interleaved_rs_encode<F: 'static>(
 ) -> Vec<F> {
     let engine = NTT.get::<F>().expect("Unsupported field");
     engine.interleaved_encode(interleaved_coeffs, codeword_length, interleaving_depth)
+}
+
+/// Partial Reed-Solomon encode that materialises only the rows at `indices`.
+///
+/// Equivalent to taking [`interleaved_rs_encode`]'s output (a row-major
+/// `(codeword_length, num_polys * interleaving_depth)` matrix) and
+/// extracting the rows whose row index is in `indices`. Output layout is
+/// row-major `(indices.len(), num_polys * interleaving_depth)`, byte-exact
+/// against the full encode.
+///
+/// Uses an output-pruned NTT (see [`PartialNttPlan`]) so peak memory and
+/// flop count are both proportional to `indices.len()`, not
+/// `codeword_length`. The pruning plan is built once for the index set and
+/// reused across every polynomial × interleaving slot.
+#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(coeffs, indices), fields(size = coeffs.len(), k = indices.len())))]
+pub fn partial_interleaved_rs_encode<F: FftField>(
+    coeffs: &[&[F]],
+    codeword_length: usize,
+    interleaving_depth: usize,
+    indices: &[usize],
+) -> Vec<F> {
+    if coeffs.is_empty() || indices.is_empty() {
+        return Vec::new();
+    }
+    let poly_size = coeffs[0].len();
+    for poly in coeffs {
+        assert_eq!(poly.len(), poly_size);
+    }
+    assert!(poly_size.is_multiple_of(interleaving_depth));
+    let message_length = poly_size / interleaving_depth;
+    assert!(codeword_length.is_multiple_of(message_length));
+
+    let num_polys = coeffs.len();
+    let num_cols = num_polys * interleaving_depth;
+    let k = indices.len();
+
+    let engine = NttEngine::<F>::new_from_cache();
+    let plan = PartialNttPlan::new(codeword_length, indices);
+
+    let mut out = vec![F::ZERO; k * num_cols];
+    for (poly_idx, poly) in coeffs.iter().enumerate() {
+        for slot_idx in 0..interleaving_depth {
+            let col = poly_idx * interleaving_depth + slot_idx;
+            let block = &poly[slot_idx * message_length..(slot_idx + 1) * message_length];
+            engine.ntt_partial_with_plan_into(block, &plan, &mut out[col..], num_cols);
+        }
+    }
+    out
 }
 
 ///
@@ -349,5 +397,59 @@ mod tests {
         let interleaved_ntt =
             interleaved_rs_encode(&[poly.as_slice()], codeword_length, 1 << folding_factor);
         assert_eq!(expected, interleaved_ntt);
+    }
+
+    #[test]
+    fn test_partial_interleaved_rs_encode_matches_full() {
+        use ark_std::{rand::Rng, UniformRand};
+
+        let mut rng = ark_std::test_rng();
+
+        // Span several (num_polys, interleaving_depth, M, N) shapes covering
+        // the regimes that actually appear in whir_zk (single witness with
+        // depth 8, multi-witness with depth 1, M = N/4 blowup).
+        let cases = [
+            (1usize, 1usize, 64usize, 256usize),
+            (1, 8, 16, 64),
+            (2, 4, 32, 128),
+            (1, 8, 1 << 10, 1 << 12),
+        ];
+
+        for (num_polys, interleaving_depth, message_length, codeword_length) in cases {
+            let poly_size = message_length * interleaving_depth;
+            let polys: Vec<Vec<Field64>> = (0..num_polys)
+                .map(|_| (0..poly_size).map(|_| Field64::rand(&mut rng)).collect())
+                .collect();
+            let poly_slices: Vec<&[Field64]> = polys.iter().map(Vec::as_slice).collect();
+
+            let full = interleaved_rs_encode(&poly_slices, codeword_length, interleaving_depth);
+            let num_cols = num_polys * interleaving_depth;
+            assert_eq!(full.len(), codeword_length * num_cols);
+
+            // Random subset including 0, last, and a sprinkling in between.
+            let k = rng.gen_range(1..=codeword_length.min(16));
+            let mut perm: Vec<usize> = (0..codeword_length).collect();
+            for i in (1..codeword_length).rev() {
+                perm.swap(i, rng.gen_range(0..=i));
+            }
+            let indices: Vec<usize> = perm.into_iter().take(k).collect();
+
+            let partial = partial_interleaved_rs_encode(
+                &poly_slices,
+                codeword_length,
+                interleaving_depth,
+                &indices,
+            );
+            assert_eq!(partial.len(), k * num_cols);
+
+            for (row, &idx) in indices.iter().enumerate() {
+                let full_row = &full[idx * num_cols..(idx + 1) * num_cols];
+                let partial_row = &partial[row * num_cols..(row + 1) * num_cols];
+                assert_eq!(
+                    partial_row, full_row,
+                    "shape=({num_polys},{interleaving_depth},{message_length},{codeword_length}) row idx={idx}"
+                );
+            }
+        }
     }
 }

--- a/src/protocols/irs_commit.rs
+++ b/src/protocols/irs_commit.rs
@@ -465,6 +465,114 @@ where
         self.verify_inner(verifier_state, commitments, indices, points)
     }
 
+    /// Opens the commitment without requiring `witness.matrix` to be
+    /// populated.
+    ///
+    /// Functionally identical to [`open`]: same in-domain challenges, same
+    /// transcript bytes (submatrix hint + Merkle paths), same returned
+    /// [`Evaluations`]. The difference is that the queried codeword rows
+    /// are reconstructed from the supplied polynomial coefficients via an
+    /// output-pruned NTT (see [`ntt::partial_interleaved_rs_encode`]), so
+    /// the prover never materialises the full `(num_cols × codeword_length)`
+    /// codeword matrix held in `witness.matrix`.
+    ///
+    /// `coeffs_per_witness[i]` must be the same polynomial slice set that
+    /// would have produced `witnesses[i].matrix` via
+    /// [`interleaved_rs_encode`]. Mismatch results in verifier rejection.
+    pub fn open_from_coeffs<H, R>(
+        &self,
+        prover_state: &mut ProverState<H, R>,
+        coeffs_per_witness: &[&[&[M::Source]]],
+        witnesses: &[&Witness<M::Source, M::Target>],
+    ) -> Evaluations<M::Source>
+    where
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        u8: Decoding<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        assert_eq!(coeffs_per_witness.len(), witnesses.len());
+        for witness in witnesses {
+            assert_eq!(witness.out_of_domain.points.len(), self.out_domain_samples);
+            assert_eq!(
+                witness.out_of_domain.matrix.len(),
+                self.out_domain_samples * self.num_vectors
+            );
+        }
+        let (indices, points) = self.in_domain_challenges(prover_state);
+        self.open_inner_from_coeffs(
+            prover_state,
+            coeffs_per_witness,
+            witnesses,
+            &indices,
+            points,
+        )
+    }
+
+    /// Like [`open_from_coeffs`] but with caller-provided indices, mirroring
+    /// [`open_at_indices`]. Used for the Γ consistency check.
+    pub fn open_at_indices_from_coeffs<H, R>(
+        &self,
+        prover_state: &mut ProverState<H, R>,
+        coeffs_per_witness: &[&[&[M::Source]]],
+        witnesses: &[&Witness<M::Source, M::Target>],
+        indices: &[usize],
+    ) -> Evaluations<M::Source>
+    where
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Hash: ProverMessage<[H::U]>,
+    {
+        assert!(
+            indices.iter().all(|&i| i < self.codeword_length),
+            "index out of bounds: all indices must be < codeword_length ({})",
+            self.codeword_length
+        );
+        assert_eq!(coeffs_per_witness.len(), witnesses.len());
+        let generator = self.generator();
+        let points: Vec<M::Source> = indices.iter().map(|&i| generator.pow([i as u64])).collect();
+        self.open_inner_from_coeffs(prover_state, coeffs_per_witness, witnesses, indices, points)
+    }
+
+    /// Shared open logic for [`open_from_coeffs`] and [`open_at_indices_from_coeffs`].
+    fn open_inner_from_coeffs<H, R>(
+        &self,
+        prover_state: &mut ProverState<H, R>,
+        coeffs_per_witness: &[&[&[M::Source]]],
+        witnesses: &[&Witness<M::Source, M::Target>],
+        indices: &[usize],
+        points: Vec<M::Source>,
+    ) -> Evaluations<M::Source>
+    where
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let num_cols = self.num_cols();
+        let stride = witnesses.len() * num_cols;
+        let mut matrix = vec![M::Source::ZERO; indices.len() * stride];
+        let mut matrix_col_offset = 0;
+        for (coeffs, witness) in coeffs_per_witness.iter().zip(witnesses) {
+            let submatrix = ntt::partial_interleaved_rs_encode(
+                coeffs,
+                self.codeword_length,
+                self.interleaving_depth,
+                indices,
+            );
+            debug_assert_eq!(submatrix.len(), indices.len() * num_cols);
+            for (row, src) in submatrix.chunks_exact(num_cols).enumerate() {
+                let dst = &mut matrix[row * stride + matrix_col_offset
+                    ..row * stride + matrix_col_offset + num_cols];
+                dst.copy_from_slice(src);
+            }
+            prover_state.prover_hint_ark(&submatrix);
+            self.matrix_commit
+                .open(prover_state, &witness.matrix_witness, indices);
+            matrix_col_offset += num_cols;
+        }
+        Evaluations { points, matrix }
+    }
+
     /// Shared open logic for [`open`] and [`open_at_indices`].
     fn open_inner<H, R>(
         &self,

--- a/src/protocols/whir_zk/committer.rs
+++ b/src/protocols/whir_zk/committer.rs
@@ -103,7 +103,14 @@ impl<F: FftField> Config<F> {
 
         // Step 1b: Commit [[f̂]] via first WHIR instance.
         let f_hat_refs: Vec<&[F]> = f_hat_polys.iter().map(|p| p.as_slice()).collect();
-        let f_hat_witness = self.blinded_polynomial.commit(prover_state, &f_hat_refs);
+        let mut f_hat_witness = self.blinded_polynomial.commit(prover_state, &f_hat_refs);
+
+        // Drop the encoded codeword; will be re-encoded immediately before each
+        // open in prove_blinded_polynomial (Steps 4 and 6). This keeps the
+        // ~codeword_length × interleaving_depth field elements out of the
+        // resident set during the prepare_and_sumcheck rounds where global peak
+        // hits.
+        f_hat_witness.matrix = Vec::new();
 
         // Step 1c: Sample ν + 1 random ℓ-variate blinding polynomials ĝ₀..ĝ_ν.
         let num_blinding_polys = dims.num_g_polys();
@@ -138,9 +145,16 @@ impl<F: FftField> Config<F> {
         }
         let blinding_refs: Vec<&[F]> = blinding_vectors.iter().map(|v| v.as_slice()).collect();
 
-        let blinding_poly_witness = self
+        let mut blinding_poly_witness = self
             .blinding_polynomial
             .commit(prover_state, &blinding_refs);
+
+        // The encoded codeword is only needed when [[M, ĝ]] is opened in
+        // Step 7. Until then it is dead weight (held resident through all of
+        // prove_blinded_polynomial, where global peak hits). Drop the matrix
+        // here; the prover re-encodes from `secrets.blinding_vectors` just
+        // before calling `blinding_polynomial.prove`.
+        blinding_poly_witness.matrix = Vec::new();
 
         Witness {
             f_hat_witness,

--- a/src/protocols/whir_zk/mod.rs
+++ b/src/protocols/whir_zk/mod.rs
@@ -964,10 +964,11 @@ mod tests {
             .irs_committer
             .commit(&mut prover_state, &[&f_zk]);
         round_config.pow.prove(&mut prover_state);
+        let f_hat_refs: Vec<&[F]> = f_hat_polys.iter().map(Vec::as_slice).collect();
         let in_domain = config
             .blinded_polynomial
             .initial_committer
-            .open(&mut prover_state, &[&f_hat_witness]);
+            .open_from_coeffs(&mut prover_state, &[&f_hat_refs], &[&f_hat_witness]);
 
         let mut lambda_z_points: Vec<F> = Vec::new();
         let send_blinding = |ps: &mut ProverState<_, _>, z: F| {
@@ -989,7 +990,6 @@ mod tests {
             send_blinding(&mut prover_state, z);
             lambda_z_points.push(z);
         }
-        drop(f_hat_polys);
         for &z in &in_domain.points {
             send_blinding(&mut prover_state, z);
             lambda_z_points.push(z);
@@ -1034,11 +1034,16 @@ mod tests {
             &round0_folding,
         );
         let gamma_points = remaining.first_in_domain_points;
-        let _ = config.blinded_polynomial.initial_committer.open_at_indices(
-            &mut prover_state,
-            &[&f_hat_witness],
-            &gamma_to_f_hat_indices(&gamma_points, &config),
-        );
+        let _ = config
+            .blinded_polynomial
+            .initial_committer
+            .open_at_indices_from_coeffs(
+                &mut prover_state,
+                &[&f_hat_refs],
+                &[&f_hat_witness],
+                &gamma_to_f_hat_indices(&gamma_points, &config),
+            );
+        drop(f_hat_polys);
         for &gamma in &gamma_points {
             send_blinding(&mut prover_state, gamma);
             lambda_z_points.push(gamma);
@@ -1068,6 +1073,21 @@ mod tests {
             .iter()
             .map(|v| Cow::Borrowed(v.as_slice()))
             .collect();
+        // Re-encode blinding_poly_witness.matrix (cleared at commit time);
+        // mirrors prover.rs::prove_blinded_polynomial before
+        // `prove_blinding_polynomial`.
+        let blinding_refs: Vec<&[F]> = secrets
+            .blinding_vectors
+            .iter()
+            .map(|v| v.as_slice())
+            .collect();
+        let mut blinding_poly_witness = blinding_poly_witness;
+        blinding_poly_witness.matrix = crate::algebra::ntt::interleaved_rs_encode(
+            &blinding_refs,
+            config.blinding_polynomial.initial_committer.codeword_length,
+            config.blinding_polynomial.initial_committer.interleaving_depth,
+        );
+        drop(blinding_refs);
         let _ = config.blinding_polynomial.prove(
             &mut prover_state,
             blinding_cows,

--- a/src/protocols/whir_zk/prover.rs
+++ b/src/protocols/whir_zk/prover.rs
@@ -316,11 +316,10 @@ where
 
     /// Step 5: OOD/STIR queries, STIR constraint accumulation, and remaining WHIR rounds.
     ///
-    /// Borrows `f_hat_polys` so it remains available for re-encoding the
-    /// f_hat codeword in Step 6 (`gamma_check`). The codeword in
-    /// `f_hat_witness.matrix` is re-encoded just before its open and cleared
-    /// immediately after, to keep it out of the resident set during the
-    /// memory-intensive sumcheck rounds.
+    /// Borrows `f_hat_polys` so it remains available for the f̂ open in
+    /// Step 6 (`gamma_check`). The [[f̂]] open uses an output-pruned NTT
+    /// (`open_from_coeffs`) that materialises only the queried codeword
+    /// rows, so `f_hat_witness.matrix` stays empty throughout.
     #[allow(clippy::too_many_arguments)]
     fn ood_stir_and_rounds(
         &mut self,
@@ -342,26 +341,20 @@ where
             .commit(self.prover_state, &[state.vector.as_slice()]);
         round_config.pow.prove(self.prover_state);
 
-        // Re-encode f_hat codeword for the upcoming open, then drop it again.
+        // Open [[f̂]] at in-domain indices via output-pruned NTT: only the
+        // k = in_domain_samples queried codeword rows are materialised,
+        // skipping the full Reed-Solomon re-encode and its (num_cols ×
+        // codeword_length) allocation.
         let f_hat_refs: Vec<&[F]> = f_hat_polys.iter().map(|p| p.as_slice()).collect();
-        f_hat_witness.matrix = interleaved_rs_encode(
-            &f_hat_refs,
-            self.config
-                .blinded_polynomial
-                .initial_committer
-                .codeword_length,
-            self.config
-                .blinded_polynomial
-                .initial_committer
-                .interleaving_depth,
-        );
-        drop(f_hat_refs);
         let in_domain = self
             .config
             .blinded_polynomial
             .initial_committer
-            .open(self.prover_state, &[&*f_hat_witness]);
-        f_hat_witness.matrix = Vec::new();
+            .open_from_coeffs(
+                self.prover_state,
+                &[&f_hat_refs],
+                &[&*f_hat_witness],
+            );
 
         let r_bar = folding_randomness.0;
         let eq_weights = compute_eq_weights(&r_bar);
@@ -456,9 +449,9 @@ where
 
     /// Step 6: Γ consistency check.
     ///
-    /// Opens [[f̂]] at Γ indices and sends blinding evaluations for each γ ∈ Γ.
-    /// Re-encodes the f_hat codeword into `f_hat_witness.matrix` before the
-    /// open and clears it after, mirroring the pattern in `ood_stir_and_rounds`.
+    /// Opens [[f̂]] at Γ indices via `open_at_indices_from_coeffs` (output-
+    /// pruned NTT) and sends blinding evaluations for each γ ∈ Γ. The
+    /// codeword matrix is never materialised.
     fn gamma_check(
         &mut self,
         f_hat_witness: &mut irs_commit::Witness<F, F>,
@@ -470,32 +463,20 @@ where
     ) {
         let gamma_f_hat_indices = gamma_to_f_hat_indices(gamma_points, self.config);
 
-        // Re-encode f_hat codeword for the open at Γ indices.
+        // Open [[f̂]] at Γ indices via output-pruned NTT: the verifier
+        // reconstructs fold(r̄, [[f̂]])(γ) from these openings. Return value
+        // is unused; the prover already knows the values.
         let f_hat_refs: Vec<&[F]> = f_hat_polys.iter().map(|p| p.as_slice()).collect();
-        f_hat_witness.matrix = interleaved_rs_encode(
-            &f_hat_refs,
-            self.config
-                .blinded_polynomial
-                .initial_committer
-                .codeword_length,
-            self.config
-                .blinded_polynomial
-                .initial_committer
-                .interleaving_depth,
-        );
-        drop(f_hat_refs);
-
-        // Writes [[f̂]] openings at Γ indices to the transcript.
-        // The verifier uses these to reconstruct fold(r̄, [[f̂]])(γ).
-        // Return value (Evaluations) is unused: the prover already knows the values.
         let _f_hat_openings = self
             .config
             .blinded_polynomial
             .initial_committer
-            .open_at_indices(self.prover_state, &[&*f_hat_witness], &gamma_f_hat_indices);
-
-        // Drop the codeword again; nothing else in this protocol needs it.
-        f_hat_witness.matrix = Vec::new();
+            .open_at_indices_from_coeffs(
+                self.prover_state,
+                &[&f_hat_refs],
+                &[&*f_hat_witness],
+                &gamma_f_hat_indices,
+            );
 
         for &gamma in gamma_points {
             send_blinding_evals(self.prover_state, gamma, masking_coeffs_all, g_i_coeffs);
@@ -507,11 +488,11 @@ where
 impl<F: FftField> Config<F> {
     /// Steps 2-6: Prove the blinded polynomial instance.
     ///
-    /// `f_hat_witness.matrix` is empty on entry (cleared at commit time); it
-    /// is re-encoded transiently around each open and cleared afterwards to
-    /// keep the codeword out of the resident set during sumcheck rounds.
-    /// `f_hat_polys` is borrowed (needed for re-encoding in both Step 5
-    /// `ood_stir_and_rounds` and Step 6 `gamma_check`).
+    /// `f_hat_witness.matrix` is empty on entry (cleared at commit time)
+    /// and stays empty: both [[f̂]] opens (in `ood_stir_and_rounds` and
+    /// `gamma_check`) use output-pruned encoding, so the full codeword
+    /// matrix is never materialised. `f_hat_polys` is borrowed because
+    /// both opens read coefficients from it.
     #[allow(clippy::too_many_arguments)]
     fn prove_blinded_polynomial<H, R>(
         &self,

--- a/src/protocols/whir_zk/prover.rs
+++ b/src/protocols/whir_zk/prover.rs
@@ -119,7 +119,7 @@ where
         &mut self,
         vectors: Vec<Cow<'_, [F]>>,
         g_polys: &[Vec<F>],
-        linear_forms: &[Box<dyn LinearForm<F>>],
+        linear_forms: Vec<Box<dyn LinearForm<F>>>,
         evaluations: &[F],
     ) -> PrepareResult<F> {
         let num_vectors = self.dims.num_vectors;
@@ -159,7 +159,7 @@ where
         let g_claims: Vec<F> = {
             let mut buf = vec![F::ZERO; size];
             let mut claims = Vec::with_capacity(linear_forms.len());
-            for w in linear_forms {
+            for w in &linear_forms {
                 buf.fill(F::ZERO);
                 w.accumulate(&mut buf, F::ONE);
                 claims.push(dot(&buf, &g_poly));
@@ -247,6 +247,8 @@ where
         for (coeff, lf) in constraint_rlc_coeffs.iter().zip(linear_forms.iter()) {
             lf.accumulate(&mut covector, *coeff);
         }
+        // Only the combined `covector` is needed past this point.
+        drop(linear_forms);
 
         let mut the_sum: F = constraint_rlc_coeffs
             .iter()
@@ -475,7 +477,7 @@ impl<F: FftField> Config<F> {
         f_hat_polys: Vec<Vec<F>>,
         masking_polys: &[Vec<F>],
         g_polys: &[Vec<F>],
-        linear_forms: &[Box<dyn LinearForm<F>>],
+        linear_forms: Vec<Box<dyn LinearForm<F>>>,
         evaluations: &[F],
     ) -> BlindedProveResult<F>
     where
@@ -682,13 +684,12 @@ impl<F: FftField> Config<F> {
             f_hat_polys,
             &secrets.masking_polys,
             &secrets.g_polys,
-            &linear_forms,
+            linear_forms,
             &evaluations,
         );
 
         // Free fields only needed during Steps 2-6, before Step 7.
         drop(f_hat_witness);
-        drop(linear_forms);
 
         // Step 7: batched blinding polynomial proof.
         self.prove_blinding_polynomial(

--- a/src/protocols/whir_zk/prover.rs
+++ b/src/protocols/whir_zk/prover.rs
@@ -22,7 +22,9 @@ use crate::{
         embedding::Identity,
         geometric_sequence,
         linear_form::{Covector, Evaluate, LinearForm, UnivariateEvaluation},
-        multilinear_extend, univariate_evaluate, MultilinearPoint,
+        multilinear_extend,
+        ntt::interleaved_rs_encode,
+        univariate_evaluate, MultilinearPoint,
     },
     hash::Hash,
     protocols::{
@@ -314,8 +316,11 @@ where
 
     /// Step 5: OOD/STIR queries, STIR constraint accumulation, and remaining WHIR rounds.
     ///
-    /// Takes ownership of `f_hat_polys` so it can be freed after OOD evaluations,
-    /// before the memory-intensive WHIR rounds begin.
+    /// Borrows `f_hat_polys` so it remains available for re-encoding the
+    /// f_hat codeword in Step 6 (`gamma_check`). The codeword in
+    /// `f_hat_witness.matrix` is re-encoded just before its open and cleared
+    /// immediately after, to keep it out of the resident set during the
+    /// memory-intensive sumcheck rounds.
     #[allow(clippy::too_many_arguments)]
     fn ood_stir_and_rounds(
         &mut self,
@@ -323,8 +328,8 @@ where
         alpha_coeffs: &[F],
         rho: F,
         folding_randomness: MultilinearPoint<F>,
-        f_hat_witness: &irs_commit::Witness<F, F>,
-        f_hat_polys: Vec<Vec<F>>,
+        f_hat_witness: &mut irs_commit::Witness<F, F>,
+        f_hat_polys: &[Vec<F>],
         masking_polys: &[Vec<F>],
         g_polys: &[Vec<F>],
     ) -> OodStirResult<F> {
@@ -336,11 +341,27 @@ where
             .irs_committer
             .commit(self.prover_state, &[state.vector.as_slice()]);
         round_config.pow.prove(self.prover_state);
+
+        // Re-encode f_hat codeword for the upcoming open, then drop it again.
+        let f_hat_refs: Vec<&[F]> = f_hat_polys.iter().map(|p| p.as_slice()).collect();
+        f_hat_witness.matrix = interleaved_rs_encode(
+            &f_hat_refs,
+            self.config
+                .blinded_polynomial
+                .initial_committer
+                .codeword_length,
+            self.config
+                .blinded_polynomial
+                .initial_committer
+                .interleaving_depth,
+        );
+        drop(f_hat_refs);
         let in_domain = self
             .config
             .blinded_polynomial
             .initial_committer
-            .open(self.prover_state, &[f_hat_witness]);
+            .open(self.prover_state, &[&*f_hat_witness]);
+        f_hat_witness.matrix = Vec::new();
 
         let r_bar = folding_randomness.0;
         let eq_weights = compute_eq_weights(&r_bar);
@@ -385,9 +406,9 @@ where
             lambda_z_points.push(z);
         }
 
-        // Release f̂ data before WHIR rounds.
+        // Release f̂_combined before WHIR rounds. f_hat_polys is borrowed
+        // from the caller (still needed for re-encoding in gamma_check).
         drop(f_hat_combined);
-        drop(f_hat_polys);
 
         // --- STIR responses ---
         for &z in &in_domain.points {
@@ -436,15 +457,33 @@ where
     /// Step 6: Γ consistency check.
     ///
     /// Opens [[f̂]] at Γ indices and sends blinding evaluations for each γ ∈ Γ.
+    /// Re-encodes the f_hat codeword into `f_hat_witness.matrix` before the
+    /// open and clears it after, mirroring the pattern in `ood_stir_and_rounds`.
     fn gamma_check(
         &mut self,
-        f_hat_witness: &irs_commit::Witness<F, F>,
+        f_hat_witness: &mut irs_commit::Witness<F, F>,
+        f_hat_polys: &[Vec<F>],
         masking_coeffs_all: &[Vec<F>],
         g_i_coeffs: &[Vec<F>],
         gamma_points: &[F],
         lambda_z_points: &mut Vec<F>,
     ) {
         let gamma_f_hat_indices = gamma_to_f_hat_indices(gamma_points, self.config);
+
+        // Re-encode f_hat codeword for the open at Γ indices.
+        let f_hat_refs: Vec<&[F]> = f_hat_polys.iter().map(|p| p.as_slice()).collect();
+        f_hat_witness.matrix = interleaved_rs_encode(
+            &f_hat_refs,
+            self.config
+                .blinded_polynomial
+                .initial_committer
+                .codeword_length,
+            self.config
+                .blinded_polynomial
+                .initial_committer
+                .interleaving_depth,
+        );
+        drop(f_hat_refs);
 
         // Writes [[f̂]] openings at Γ indices to the transcript.
         // The verifier uses these to reconstruct fold(r̄, [[f̂]])(γ).
@@ -453,7 +492,10 @@ where
             .config
             .blinded_polynomial
             .initial_committer
-            .open_at_indices(self.prover_state, &[f_hat_witness], &gamma_f_hat_indices);
+            .open_at_indices(self.prover_state, &[&*f_hat_witness], &gamma_f_hat_indices);
+
+        // Drop the codeword again; nothing else in this protocol needs it.
+        f_hat_witness.matrix = Vec::new();
 
         for &gamma in gamma_points {
             send_blinding_evals(self.prover_state, gamma, masking_coeffs_all, g_i_coeffs);
@@ -465,16 +507,18 @@ where
 impl<F: FftField> Config<F> {
     /// Steps 2-6: Prove the blinded polynomial instance.
     ///
-    /// `f_hat_polys` is taken by value and freed during OOD evaluations (Step 5),
-    /// before the memory-intensive WHIR rounds begin.
-    /// Other witness fields are borrowed; the caller frees them before Step 7.
+    /// `f_hat_witness.matrix` is empty on entry (cleared at commit time); it
+    /// is re-encoded transiently around each open and cleared afterwards to
+    /// keep the codeword out of the resident set during sumcheck rounds.
+    /// `f_hat_polys` is borrowed (needed for re-encoding in both Step 5
+    /// `ood_stir_and_rounds` and Step 6 `gamma_check`).
     #[allow(clippy::too_many_arguments)]
     fn prove_blinded_polynomial<H, R>(
         &self,
         prover_state: &mut ProverState<H, R>,
         vectors: Vec<Cow<'_, [F]>>,
-        f_hat_witness: &irs_commit::Witness<F, F>,
-        f_hat_polys: Vec<Vec<F>>,
+        f_hat_witness: &mut irs_commit::Witness<F, F>,
+        f_hat_polys: &[Vec<F>],
         masking_polys: &[Vec<F>],
         g_polys: &[Vec<F>],
         linear_forms: Vec<Box<dyn LinearForm<F>>>,
@@ -550,6 +594,7 @@ impl<F: FftField> Config<F> {
 
         ctx.gamma_check(
             f_hat_witness,
+            f_hat_polys,
             &masking_coeffs_all,
             &g_i_coeffs,
             &gamma_points,
@@ -670,18 +715,25 @@ impl<F: FftField> Config<F> {
         Hash: ProverMessage<[H::U]>,
     {
         let Witness {
-            f_hat_witness,
-            blinding_poly_witness,
+            mut f_hat_witness,
+            mut blinding_poly_witness,
             f_hat_polys,
             secrets,
         } = witness;
 
         // Steps 2-6: blinded polynomial proof.
+        // Both `f_hat_witness.matrix` and `blinding_poly_witness.matrix` are
+        // empty here (cleared at commit time). The blinded prover re-encodes
+        // f_hat transiently around each of its two opens; blinding_poly is
+        // re-encoded just before Step 7 below. This keeps both codewords
+        // (~codeword_length × interleaving_depth field elements each) out of
+        // the resident set during the prepare_and_sumcheck rounds where global
+        // peak hits.
         let blinded = self.prove_blinded_polynomial(
             prover_state,
             vectors,
-            &f_hat_witness,
-            f_hat_polys,
+            &mut f_hat_witness,
+            &f_hat_polys,
             &secrets.masking_polys,
             &secrets.g_polys,
             linear_forms,
@@ -690,6 +742,23 @@ impl<F: FftField> Config<F> {
 
         // Free fields only needed during Steps 2-6, before Step 7.
         drop(f_hat_witness);
+        drop(f_hat_polys);
+
+        // Re-encode the [[M, ĝ]] codeword, which was dropped at commit time
+        // to keep the resident set small through Step 6.
+        let blinding_refs: Vec<&[F]> = secrets
+            .blinding_vectors
+            .iter()
+            .map(|v| v.as_slice())
+            .collect();
+        blinding_poly_witness.matrix = interleaved_rs_encode(
+            &blinding_refs,
+            self.blinding_polynomial.initial_committer.codeword_length,
+            self.blinding_polynomial
+                .initial_committer
+                .interleaving_depth,
+        );
+        drop(blinding_refs);
 
         // Step 7: batched blinding polynomial proof.
         self.prove_blinding_polynomial(

--- a/src/protocols/whir_zk/prover.rs
+++ b/src/protocols/whir_zk/prover.rs
@@ -327,7 +327,7 @@ where
         alpha_coeffs: &[F],
         rho: F,
         folding_randomness: MultilinearPoint<F>,
-        f_hat_witness: &mut irs_commit::Witness<F, F>,
+        f_hat_witness: &irs_commit::Witness<F, F>,
         f_hat_polys: &[Vec<F>],
         masking_polys: &[Vec<F>],
         g_polys: &[Vec<F>],
@@ -353,7 +353,7 @@ where
             .open_from_coeffs(
                 self.prover_state,
                 &[&f_hat_refs],
-                &[&*f_hat_witness],
+                &[f_hat_witness],
             );
 
         let r_bar = folding_randomness.0;
@@ -454,7 +454,7 @@ where
     /// codeword matrix is never materialised.
     fn gamma_check(
         &mut self,
-        f_hat_witness: &mut irs_commit::Witness<F, F>,
+        f_hat_witness: &irs_commit::Witness<F, F>,
         f_hat_polys: &[Vec<F>],
         masking_coeffs_all: &[Vec<F>],
         g_i_coeffs: &[Vec<F>],
@@ -474,7 +474,7 @@ where
             .open_at_indices_from_coeffs(
                 self.prover_state,
                 &[&f_hat_refs],
-                &[&*f_hat_witness],
+                &[f_hat_witness],
                 &gamma_f_hat_indices,
             );
 
@@ -498,7 +498,7 @@ impl<F: FftField> Config<F> {
         &self,
         prover_state: &mut ProverState<H, R>,
         vectors: Vec<Cow<'_, [F]>>,
-        f_hat_witness: &mut irs_commit::Witness<F, F>,
+        f_hat_witness: &irs_commit::Witness<F, F>,
         f_hat_polys: &[Vec<F>],
         masking_polys: &[Vec<F>],
         g_polys: &[Vec<F>],
@@ -696,7 +696,7 @@ impl<F: FftField> Config<F> {
         Hash: ProverMessage<[H::U]>,
     {
         let Witness {
-            mut f_hat_witness,
+            f_hat_witness,
             mut blinding_poly_witness,
             f_hat_polys,
             secrets,
@@ -713,7 +713,7 @@ impl<F: FftField> Config<F> {
         let blinded = self.prove_blinded_polynomial(
             prover_state,
             vectors,
-            &mut f_hat_witness,
+            &f_hat_witness,
             &f_hat_polys,
             &secrets.masking_polys,
             &secrets.g_polys,


### PR DESCRIPTION
# Memory + wall optimisations for `whir_zk::prove_blinded_polynomial`

Five cumulative commits on top of `upstream/v1`. **Net trade:** −204 MB peak for +220 ms wall vs upstream/v1. Memory savings are the headline; wall is a small regression vs v1 but recovers ~500 ms of the regression that the IRS-coeff change alone introduced.

## Stack

| Commit | What | Why |
|---|---|---|
| [`c183108`](../commit/c183108) | Drop `linear_forms` after covector build | Linear forms only needed to produce the covector; holding them past that point wastes peak. |
| [`fc3e614`](../commit/fc3e614) | Hold IRS coefficients, re-encode codeword on demand | `f_hat_witness.matrix` is the dominant resident allocation between commit and the two f̂ opens. Drop it after commit; re-encode just for each open. Costs +720 ms wall (the codeword is re-encoded twice, once per [[f̂]] open). |
| [`97fea7c`](../commit/97fea7c) | Output-pruned NTT for f̂ opens | Replaces the transient full re-encode (~`O(N log N)` flops) with an output-pruned NTT (~`O(N + k log N)` flops) that materialises only the queried codeword rows. Recovers ~500 ms of the fc3e614 wall regression. |
| [`d4ad1fb`](../commit/d4ad1fb) | Parallelise `partial_interleaved_rs_encode` batches | Sequential pruned NTT lost to parallel `ntt_batch`. Restore batch-axis rayon via batch-major intermediate + transpose. |
| [`c39ce01`](../commit/c39ce01) | Clippy + signature cleanup | `f_hat_witness: &mut` is no longer accurate (never mutated). |

## Measurements (complete_age_check, m=20, BN254 Fr, 8 threads, 30 s cooldown, 3 iters, σ ≈ 1%)

Same machine, same provekit (`db8ff0fd`), low-noise methodology (cooldown between iters, no other load, single cached binary per ref):

| Metric | upstream/v1 (`0a68627`) | HEAD (`c39ce01`) | Δ |
|---|---:|---:|---:|
| Wall (min/med, ms) | 2630 / 2650 | 2860 / 2870 | **+220 ms / +8.3%** |
| Peak (MB) | **880.0** | **676.0** | **−204 / −23.2%** |
| Allocs | 3.56M | 3.56M | 0% |

**Peak and allocs are deterministic.** Wall σ on cooled-down runs is ~1%, so the +8.3% wall delta is real, not noise.

### Intermediate stage (for context)

The IRS-coeff change alone (`fc3e614`) was measured by the original author at **+720 ms wall** for −99 MB peak. The pruned-NTT path (`97fea7c` + `d4ad1fb`) recovers ~500 ms of that wall regression — bringing the cumulative wall cost from +720 ms down to +220 ms while preserving (and slightly extending) the peak savings.

### Thread scaling (HEAD binary, complete_age_check)

| Threads | Wall (min/med ms) | Peak (MB) |
|---|---:|---:|
| 1 | 10300 / 10400 | 676 |
| 2 | 6120 / 6140 | 676 |
| 4 | 3850 / 3860 | 676 |
| 8 | 2860 / 2870 | 676 |

Peak is **identical at all thread counts** — the 676 MB is set by the IRS-coeff resident witness, not by encode work buffers. Wall scales 1.0× → 3.6× from 1 to 8 cores (parallel fraction ≈ 73% by Amdahl).

## When this PR is a win

- **OOM-bound deployments**: 880 → 676 MB unlocks `complete_age_check` on machines that previously OOM'd, at an 8% wall cost.
- **Provers that batch many proofs**: the −204 MB peak compounds — more concurrent provers per machine.

## When it is not

- **Single-prove, latency-critical, no memory pressure**: the +220 ms wall is a real regression with no return.

## Algorithm (commit [`97fea7c`](../commit/97fea7c))

Output-pruned radix-2 DIT NTT (Sorensen & Burrus 1993; Skinner 1976). For query set `I` of size `k` out of `N`, walks the butterfly DAG backwards from `I` to mark only the cone of butterflies contributing to the queried outputs. Field-op count drops from `O(N log N)` per NTT (full) to `O(N + k log N)` per NTT (pruned). Mask is built once per `(N, I)` via `PartialNttPlan` and reused across all `num_polys × interleaving_depth` NTTs of an interleaved IRS open.

Marking rule: at radix-2 DIT stage `s`, the butterfly at `(a=base+k, b=base+k+half)` has both inputs and both outputs at `(a, b)`. If either output is in the live set at stage `s`, both inputs are marked live at stage `s − 1`. Standard contrapositive of "`Y[i]` depends on `a[k]` iff `k ∈ cone(i)`" for radix-2 DIT.

Twiddle-factor indexing: `roots[k * (roots.len() / m)]` retrieves ω_m^k correctly even when the shared roots table is at an order larger than `m` — same pattern as the existing `apply_twiddles`.

**References**
- Sorensen & Burrus, "Efficient computation of the DFT with only a subset of input or output points," IEEE TSP 41(3), 1993.
- Skinner, "Pruning the decimation in-time FFT algorithm," IEEE ASSP-24(2), 1976.

Doc comments on `NttEngine::ntt_partial` and `PartialNttPlan` carry the full reference.

## Verification

- 155 whir lib tests pass, including 3 new property tests:
  - `test_ntt_partial_matches_full` — random subsets across sizes 4..2^15 vs full NTT.
  - `test_ntt_partial_zero_padded_input` — M < N case.
  - `test_partial_interleaved_rs_encode_matches_full` — byte-identity vs full encode across four IRS shapes.
- 30 whir_zk tests pass. `test_rejects_g_claim_forgery_via_rho` (which was already broken on `fc3e614` from a different upstream change) is fixed and still rejects the forged eval.
- `cargo clippy -- -D warnings` clean.
- Transcript byte-identity audited: `open_inner_from_coeffs` emits the same `prover_hint_ark(&submatrix)` + `matrix_commit.open` sequence as the original `open_inner`. No transcript divergence.
- Independent correctness review confirmed the marking rule, twiddle indexing, bit-reversal, edge cases, and layout match.

## Open follow-ups (out of scope)

- **Close the +220 ms gap**: candidates are (a) per-call mask allocation in `PartialNttPlan::new` (~10 MB bools for N=2^19), (b) pruned-NTT per-butterfly branching overhead, (c) re-encode inherently costs more than holding the matrix resident.
- **Input pruning** (combined Sorensen-Burrus): exploits `M = N / 4` zero-padding for another 2–4× flop reduction per NTT.
- **IRS-coeff witness reduction**: the resident IRS-coeff `Vec` now sets the peak. Reducing it is long-term zkWHIR v3 work.
- **Blinding-poly encode**: small codeword (~32 KB), still uses full encode (intentional).