### PR TITLE
Fix CI error due to typo

### DIFF
--- a/src/protocols/params/regime.rs
+++ b/src/protocols/params/regime.rs
@@ -382,7 +382,7 @@ mod tests {
         assert_close(got, -58.0);
     }
 
-    /// Johnson (BCHKS25 Thm 1.5, η = √ρ/20, m = 10):
+    /// Johnson (BCHKS25 Theorem 1.5, η = √ρ/20, m = 10):
     /// `ε = (2·10.5⁵/3) · n · ρ^{−3/2} / |F|` with codeword length n = k/ρ = 64.
     /// log₂ε = log₂(2·10.5⁵/3) + log₂64 + log₂(ρ^{−3/2}) − 64
     ///       = 16.376624613… + 6 + 3 − 64 = −38.623375386…


### PR DESCRIPTION
With the latest merge e5350ebf2102aae511b48229c4f9897eae249ae0 we broke the CI due to a typo:

```
error: `Thm` should be `Them`
    ╭▸ ./src/protocols/params/regime.rs:385:26
    │
385 │     /// Johnson (BCHKS25 Thm 1.5, η = √ρ/20, m = 10):
    ╰╴                         ━━━
Error: Process completed with exit code 2.
```

I don't think this is really a typo, but renaming `Thm` to `Theorem` makes the CI happy again!