### PR TITLE
Zook : Protocol Wiring 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,10 @@ harness = false
 name = "sumcheck"
 harness = false
 
-[[bench]]
-name = "zook_vs_whir"
-harness = false
+# Enable to bench zook std + ZK vs Base WHIR performance
+# [[bench]]
+# name = "zook_vs_whir"
+# harness = false
 
 # Disable untill fixed.
 # [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ arrayvec = "0.7.6"
 derive-where = { version = "1.6.0", features = ["safe"] }
 ordered-float = { version = "5.1.0", features = ["serde"] }
 thiserror = "2.0"
+zeroize = { version = "1.8", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 proptest = "1.0"
@@ -85,6 +86,10 @@ harness = false
 
 [[bench]]
 name = "sumcheck"
+harness = false
+
+[[bench]]
+name = "zook_vs_whir"
 harness = false
 
 # Disable untill fixed.

--- a/benches/expand_from_coeff.rs
+++ b/benches/expand_from_coeff.rs
@@ -37,7 +37,6 @@ fn interleaved_rs_encode(bencher: Bencher, case: &(usize, usize, usize)) {
             let coeffs_refs = coeffs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
             black_box(ntt::interleaved_rs_encode(
                 &coeffs_refs,
-                &[],
                 coeffs[0].len() * expansion,
             ))
         });

--- a/benches/zook_vs_whir.disabled
+++ b/benches/zook_vs_whir.disabled
@@ -1,3 +1,4 @@
+//! Enable to benchmark base WHIR and Zook Std + ZK Mode
 //! Sweep benchmark: base WHIR (non-ZK), Zook (Standard mode), and Zook (ZK
 //! mode) across polynomial sizes 2^8 .. 2^24. For each (protocol, size) we
 //! run [`ITERATIONS`] passes and record commit / prove / verify wall-clock

--- a/benches/zook_vs_whir.rs
+++ b/benches/zook_vs_whir.rs
@@ -1,0 +1,410 @@
+//! Sweep benchmark: base WHIR (non-ZK), Zook (Standard mode), and Zook (ZK
+//! mode) across polynomial sizes 2^8 .. 2^24. For each (protocol, size) we
+//! run [`ITERATIONS`] passes and record commit / prove / verify wall-clock
+//! separately.
+//!
+//! Outputs:
+//! - Tabular summary printed to stdout (min / mean / max in ms per cell)
+//! - `bench_results.csv` in the working directory — tidy long-form, one row
+//!   per (size, protocol, phase) with min/mean/max columns
+//!
+//! Run: `cargo bench --bench zook_vs_whir`
+//!
+//! NOTE: With `ITERATIONS = 3` the first iteration at each size carries
+//! cold-cache / allocator / rayon-warmup overhead. We do not discard a
+//! warmup pass — at 2^24 each prove can take ~1 min and the user opted for
+//! tight iters. `max` therefore tends to be inflated by the first sample.
+
+use std::{
+    borrow::Cow,
+    fs::File,
+    io::Write,
+    time::{Duration, Instant},
+};
+
+use whir::{
+    algebra::{
+        embedding::Identity,
+        fields::Field64_3,
+        linear_form::{Evaluate, LinearForm, MultilinearExtension},
+        random_vector,
+    },
+    hash,
+    parameters::ProtocolParameters,
+    protocols::{
+        params::{
+            DecodingRegime, FoldingFactor, Mode, PowBudget, ProtocolConfig, RateSchedule,
+            SecuritySpec, TuningSpec,
+        },
+        whir as whir_non_zk,
+    },
+    transcript::{codecs::Empty, DomainSeparator, ProverState, VerifierState},
+};
+
+type F = Field64_3;
+type Embed = Identity<F>;
+
+/// Polynomial sizes swept by `main`. Each entry `k` means a witness of
+/// length 2^k. 2^24 is ~16M F-elements ≈ 384 MB raw; the prover allocates
+/// a few × that for the codeword + Merkle tree, so peak RSS at the top end
+/// will be several GB. Trim the slice if you run into memory pressure.
+const LOG_SIZES: &[u32] = &[
+    8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+];
+
+/// Number of measured iterations per (size, protocol). User-chosen tight
+/// budget — see module note about first-iteration cold-cache noise.
+const ITERATIONS: usize = 25;
+
+/// Shared protocol params — held constant across sizes so we measure scaling
+/// in vector size only.
+const FOLDING_FACTOR: usize = 4;
+const STARTING_LOG_INV_RATE: u32 = 2;
+const SECURITY_LEVEL: u32 = 128;
+const POW_BITS: u32 = 10;
+
+/// Fixed RNG seed so iteration-to-iteration variance comes only from runtime
+/// noise, not from sampling a different witness.
+const SEED: u64 = 0;
+
+/// Per-iteration timings for one (size, protocol) cell. `proof_bytes` is
+/// deterministic given the spec + seeded witness, so it's recorded once
+/// (overwritten on every iter — all values are equal).
+#[derive(Default)]
+struct PhaseSamples {
+    commit: Vec<Duration>,
+    prove: Vec<Duration>,
+    verify: Vec<Duration>,
+    proof_bytes: usize,
+}
+
+/// (min, mean, max). Caller guarantees `samples` is non-empty.
+fn summarize(samples: &[Duration]) -> (Duration, Duration, Duration) {
+    let min = *samples.iter().min().expect("non-empty");
+    let max = *samples.iter().max().expect("non-empty");
+    let sum_ns: u128 = samples.iter().map(Duration::as_nanos).sum();
+    let mean = Duration::from_nanos((sum_ns / samples.len() as u128) as u64);
+    (min, mean, max)
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+/// Deterministic per-size witness + a single linear form to evaluate. We
+/// reuse the same `(witness, form, eval)` across iterations to keep CPU
+/// caches as warm as they would be in a tight prove loop.
+fn make_workload(log_size: u32) -> (Vec<F>, MultilinearExtension<F>, F) {
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
+    let size = 1usize << log_size;
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let witness = random_vector::<F>(&mut rng, size);
+    let form = MultilinearExtension::<F> {
+        point: random_vector::<F>(&mut rng, log_size as usize),
+    };
+    let embedding = Embed::default();
+    let evaluation = form.evaluate(&embedding, &witness);
+    (witness, form, evaluation)
+}
+
+fn bench_whir(log_size: u32) -> Result<PhaseSamples, String> {
+    let size = 1usize << log_size;
+    let whir_params = ProtocolParameters {
+        decoding_regime: DecodingRegime::Johnson,
+        starting_log_inv_rate: STARTING_LOG_INV_RATE as usize,
+        initial_folding_factor: FOLDING_FACTOR,
+        folding_factor: FOLDING_FACTOR,
+        security_level: SECURITY_LEVEL as usize,
+        pow_bits: POW_BITS as usize,
+        batch_size: 1,
+        hash_id: hash::SHA2,
+    };
+    let config = whir_non_zk::Config::<Embed>::new(size, &whir_params);
+    let (witness, form, evaluation) = make_workload(log_size);
+    let mut samples = PhaseSamples::default();
+
+    for _ in 0..ITERATIONS {
+        // Fresh DS per iteration so the transcript is independent each run.
+        let ds = DomainSeparator::protocol(&config)
+            .session(&format!("bench-whir-non-zk-2^{log_size}"))
+            .instance(&Empty);
+        let mut ps = ProverState::new_std(&ds);
+
+        // ---- commit ----
+        let t = Instant::now();
+        let committed = config.commit(&mut ps, &[&witness]);
+        samples.commit.push(t.elapsed());
+
+        // ---- prove ----
+        // Clone witness/form into the prove call (it consumes them). Clones
+        // happen before the timer starts so they don't contaminate prove time.
+        let witness_owned = witness.clone();
+        let form_box: Box<dyn LinearForm<F>> = Box::new(form.clone());
+        let t = Instant::now();
+        let _ = config.prove(
+            &mut ps,
+            vec![Cow::Owned(witness_owned)],
+            vec![Cow::Owned(committed)],
+            vec![form_box],
+            Cow::Owned(vec![evaluation]),
+        );
+        samples.prove.push(t.elapsed());
+
+        // ---- verify ----
+        let proof = ps.proof();
+        samples.proof_bytes = proof.narg_string.len() + proof.hints.len();
+        let mut vs = VerifierState::new_std(&ds, &proof);
+        let t = Instant::now();
+        let commitment = config
+            .receive_commitment(&mut vs)
+            .map_err(|e| format!("whir receive_commitment: {e:?}"))?;
+        let final_claim = config
+            .verify(&mut vs, &[&commitment], &[evaluation])
+            .map_err(|e| format!("whir verify: {e:?}"))?;
+        final_claim
+            .verify(std::iter::once(&form as &dyn LinearForm<F>))
+            .map_err(|e| format!("whir final_claim verify: {e:?}"))?;
+        samples.verify.push(t.elapsed());
+    }
+    Ok(samples)
+}
+
+fn bench_zook(
+    log_size: u32,
+    mode: Mode,
+    rate_schedule: RateSchedule,
+) -> Result<PhaseSamples, String> {
+    let size = 1usize << log_size;
+    let schedule_tag = match rate_schedule {
+        RateSchedule::Adaptive { .. } => "adaptive",
+        RateSchedule::Stepping => "stepping",
+        RateSchedule::Capped { .. } => "capped",
+    };
+    let mode_tag = match mode {
+        Mode::Standard => "standard",
+        Mode::ZeroKnowledge => "zk",
+    };
+    let label = format!("zook-{mode_tag}-{schedule_tag}");
+    let spec = SecuritySpec {
+        mode,
+        decoding_regime: DecodingRegime::Johnson,
+        target_security_bits: SECURITY_LEVEL,
+        pow_budget: PowBudget::per_slot(POW_BITS),
+        hash_id: hash::SHA2,
+    };
+    let tuning = TuningSpec {
+        vector_size: size,
+        starting_log_inv_rate: STARTING_LOG_INV_RATE,
+        folding_factor: FoldingFactor::Constant(FOLDING_FACTOR),
+        rate_schedule,
+    };
+    let config = ProtocolConfig::<Embed>::derive(spec, tuning)
+        .map_err(|e| format!("{label} derive: {e:?}"))?;
+    let (witness, form, evaluation) = make_workload(log_size);
+    let mut samples = PhaseSamples::default();
+
+    for _ in 0..ITERATIONS {
+        let ds = DomainSeparator::protocol(&format!("bench-{label}"))
+            .session(&format!("bench-{label}-2^{log_size}"))
+            .instance(&Empty);
+        let mut ps = ProverState::new_std(&ds);
+
+        // ---- commit ----
+        let t = Instant::now();
+        let committed = config.commit(&mut ps, &witness);
+        samples.commit.push(t.elapsed());
+
+        // ---- prove ----
+        let form_ref: &dyn LinearForm<F> = &form;
+        let t = Instant::now();
+        config.prove(&mut ps, committed, &[form_ref], &[evaluation]);
+        samples.prove.push(t.elapsed());
+
+        // ---- verify ----
+        let proof = ps.proof();
+        samples.proof_bytes = proof.narg_string.len() + proof.hints.len();
+        let mut vs = VerifierState::new_std(&ds, &proof);
+        let t = Instant::now();
+        let commitment = config
+            .receive_commitment(&mut vs)
+            .map_err(|e| format!("{label} receive_commitment: {e:?}"))?;
+        let _ = config
+            .verify(&mut vs, commitment, &[form_ref], &[evaluation])
+            .map_err(|e| format!("{label} verify: {e:?}"))?;
+        samples.verify.push(t.elapsed());
+    }
+    Ok(samples)
+}
+
+fn print_header() {
+    println!(
+        "{:<9} {:<14} {:<8} {:>12} {:>12} {:>12} {:>12}",
+        "log_size", "protocol", "phase", "min (ms)", "mean (ms)", "max (ms)", "proof (B)"
+    );
+    println!("{}", "-".repeat(85));
+}
+
+fn record_cell(
+    csv: &mut File,
+    log_size: u32,
+    size: usize,
+    protocol: &str,
+    phase: &str,
+    samples: &[Duration],
+    proof_bytes: usize,
+) {
+    let (min, mean, max) = summarize(samples);
+    println!(
+        "{:<9} {:<14} {:<8} {:>12.3} {:>12.3} {:>12.3} {:>12}",
+        log_size,
+        protocol,
+        phase,
+        ms(min),
+        ms(mean),
+        ms(max),
+        proof_bytes,
+    );
+    writeln!(
+        csv,
+        "{},{},{},{},{},{},{},{}",
+        log_size,
+        size,
+        protocol,
+        phase,
+        ms(min),
+        ms(mean),
+        ms(max),
+        proof_bytes,
+    )
+    .expect("write CSV row");
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "bench harness — sweep + table format is naturally long"
+)]
+fn main() {
+    let mut csv = File::create("bench_results.csv").expect("create bench_results.csv");
+    writeln!(
+        csv,
+        "log_size,size,protocol,phase,min_ms,mean_ms,max_ms,proof_bytes"
+    )
+    .unwrap();
+    print_header();
+
+    for &log_size in LOG_SIZES {
+        let size = 1usize << log_size;
+
+        eprintln!("\n[2^{log_size} = {size} elements] whir_non_zk ...");
+        match bench_whir(log_size) {
+            Ok(s) => {
+                let pb = s.proof_bytes;
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "whir_non_zk",
+                    "commit",
+                    &s.commit,
+                    pb,
+                );
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "whir_non_zk",
+                    "prove",
+                    &s.prove,
+                    pb,
+                );
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "whir_non_zk",
+                    "verify",
+                    &s.verify,
+                    pb,
+                );
+            }
+            Err(e) => eprintln!("  whir_non_zk failed: {e}"),
+        }
+
+        // Zook Standard on `RateSchedule::Stepping` — same per-round step
+        // WHIR's legacy `Config::new` uses internally, so proof-size and
+        // prove-time comparisons isolate the *protocol* delta rather than
+        // the rate-schedule delta.
+        let stepping = RateSchedule::Stepping;
+        eprintln!("[2^{log_size}] zook_standard_stepping ...");
+        match bench_zook(log_size, Mode::Standard, stepping) {
+            Ok(s) => {
+                let pb = s.proof_bytes;
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "zook_standard_stepping",
+                    "commit",
+                    &s.commit,
+                    pb,
+                );
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "zook_standard_stepping",
+                    "prove",
+                    &s.prove,
+                    pb,
+                );
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "zook_standard_stepping",
+                    "verify",
+                    &s.verify,
+                    pb,
+                );
+            }
+            Err(e) => eprintln!("  zook_standard_stepping failed: {e}"),
+        }
+
+        eprintln!("[2^{log_size}] zook_zk_stepping ...");
+        match bench_zook(log_size, Mode::ZeroKnowledge, RateSchedule::Stepping) {
+            Ok(s) => {
+                let pb = s.proof_bytes;
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "zook_zk_stepping",
+                    "commit",
+                    &s.commit,
+                    pb,
+                );
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "zook_zk_stepping",
+                    "prove",
+                    &s.prove,
+                    pb,
+                );
+                record_cell(
+                    &mut csv,
+                    log_size,
+                    size,
+                    "zook_zk_stepping",
+                    "verify",
+                    &s.verify,
+                    pb,
+                );
+            }
+            Err(e) => eprintln!("  zook_zk failed: {e}"),
+        }
+    }
+
+    println!("\nCSV written to bench_results.csv");
+}

--- a/src/algebra/ntt/cooley_tukey.rs
+++ b/src/algebra/ntt/cooley_tukey.rs
@@ -18,10 +18,7 @@ use super::{
 };
 #[cfg(not(feature = "rs_in_order"))]
 use crate::algebra::ntt::transpose::transpose_permute;
-use crate::{
-    algebra::ntt::utils::divisors,
-    utils::{chunks_exact_or_empty, zip_strict},
-};
+use crate::algebra::ntt::utils::divisors;
 
 // Supported primes
 const PRIMES: [usize; 2] = [2, 3];
@@ -374,17 +371,17 @@ impl<F: Field> ReedSolomon<F> for NttEngine<F> {
 
     fn evaluation_points(
         &self,
-        masked_message_length: usize,
+        poly_length: usize,
         codeword_length: usize,
         indices: &[usize],
     ) -> Vec<F> {
-        assert!(masked_message_length <= codeword_length);
+        assert!(poly_length <= codeword_length);
         assert!(self.order.is_multiple_of(codeword_length));
         let mut result = Vec::new();
         let generator = self.generator(codeword_length);
 
         // Coset transformation
-        let mut coset_size = self.next_order(masked_message_length).unwrap();
+        let mut coset_size = self.next_order(poly_length).unwrap();
         while !codeword_length.is_multiple_of(coset_size) {
             coset_size = self.next_order(coset_size + 1).unwrap();
         }
@@ -401,26 +398,20 @@ impl<F: Field> ReedSolomon<F> for NttEngine<F> {
         result
     }
 
-    #[cfg_attr(feature = "tracing", instrument(skip(self, messages, masks), fields(
-        num_messages = messages.len(),
-        message_len = messages.first().map(|c| c.len()),
+    #[cfg_attr(feature = "tracing", instrument(skip(self, polys), fields(
+        num_polys = polys.len(),
+        poly_length = polys.first().map(|p| p.len()),
         codeword_length = codeword_length,
-        mask_len = masks.len().checked_div(messages.len())
-
     )))]
-    fn interleaved_encode(&self, messages: &[&[F]], masks: &[F], codeword_length: usize) -> Vec<F> {
+    fn interleaved_encode(&self, polys: &[&[F]], codeword_length: usize) -> Vec<F> {
         assert!(self.order.is_multiple_of(codeword_length));
-        if messages.is_empty() {
-            assert!(masks.is_empty());
+        if polys.is_empty() {
             return Vec::new();
         }
-        let num_messages = messages.len();
-        let message_len = messages[0].len();
-        assert!(messages.iter().all(|m| m.len() == message_len));
-        assert!(masks.len().is_multiple_of(num_messages));
-        let mask_length = masks.len() / num_messages;
-        let masked_message_length = message_len + mask_length;
-        assert!(masked_message_length <= codeword_length);
+        let num_polys = polys.len();
+        let poly_length = polys[0].len();
+        assert!(polys.iter().all(|p| p.len() == poly_length));
+        assert!(poly_length <= codeword_length);
 
         // Coset-NTT: instead of doing one codeword-length NTT on mostly zeros,
         // do `num_cosets` many `coset_size`-point NTTs on twisted coefficient
@@ -433,28 +424,24 @@ impl<F: Field> ReedSolomon<F> for NttEngine<F> {
         // You can also see this as applying a first round of Cooley-Tukey with
         // N = coset_size × num_cosets, and solving it directly by observing that
         // only the first coset is non-zero.
-        let mut coset_size = self.next_order(masked_message_length).unwrap();
+        let mut coset_size = self.next_order(poly_length).unwrap();
         while !codeword_length.is_multiple_of(coset_size) {
             coset_size = self.next_order(coset_size + 1).unwrap();
         }
         let num_cosets = codeword_length / coset_size;
-        let coset_padding = coset_size - masked_message_length;
+        let coset_padding = coset_size - poly_length;
 
         // Lay out twisted coefficients in contiguous coset blocks of length
         // `coset_size`, zero-padding each block as needed.
-        let mut result = Vec::with_capacity(num_messages * codeword_length);
-        for (message, mask) in zip_strict(
-            messages,
-            chunks_exact_or_empty(masks, mask_length, num_messages),
-        ) {
+        let mut result = Vec::with_capacity(num_polys * codeword_length);
+        for poly in polys {
             // FFT[a 0 0 0] = [a a a a], so just replicate input in coset dimension.
             for _ in 0..num_cosets {
-                result.extend_from_slice(message);
-                result.extend_from_slice(mask);
+                result.extend_from_slice(poly);
                 result.resize(result.len() + coset_padding, F::ZERO);
             }
         }
-        assert_eq!(result.len(), num_messages * codeword_length);
+        assert_eq!(result.len(), num_polys * codeword_length);
 
         // NTT each coset block, then transpose each codeword block from
         // coset-major `(num_cosets × coset_size)` layout into standard codeword
@@ -472,7 +459,7 @@ impl<F: Field> ReedSolomon<F> for NttEngine<F> {
         transpose(&mut result, num_cosets, coset_size);
 
         // Transpose to row-major order with vectors stacked horizontally.
-        transpose(&mut result, num_messages, codeword_length);
+        transpose(&mut result, num_polys, codeword_length);
         result
     }
 }

--- a/src/algebra/ntt/mod.rs
+++ b/src/algebra/ntt/mod.rs
@@ -61,42 +61,50 @@ impl type_map::Family for NttFamily {
     type Dyn<F: 'static> = dyn ReedSolomon<F>;
 }
 
-/// Trait for a Reed-Solomon encoder implementation for a given field `F`.
+/// Reed-Solomon encoder for a given field `F`.
+///
+/// Pure-NTT abstraction: encodes polynomials, knows nothing about how callers
+/// structure those polynomials (whir's IRS, for example, concatenates a
+/// message and a mask into a single polynomial before calling this trait —
+/// that split lives entirely on the caller side).
 pub trait ReedSolomon<F>: Debug + Send + Sync {
-    /// Returns the next supported order equal or larger than `size`.
-    ///
-    /// The result will be an NTT-smooth number suitable for `codeword_length`.
-    ///
-    /// Returns `None` if `size` exceeds the largest supported order.
+    /// Smallest supported codeword length `>= size`, or `None` if `size`
+    /// exceeds the engine's maximum order. The returned length is always
+    /// NTT-smooth for this engine.
     fn next_order(&self, size: usize) -> Option<usize>;
 
+    /// Generator of the multiplicative subgroup of order `codeword_length`.
     fn generator(&self, codeword_length: usize) -> F;
 
-    /// Returns the `index`th evaluation point.
+    /// Evaluation points for the requested codeword positions.
     ///
-    /// `masked_message_length`: the total message length including any mask values.
+    /// `result[i]` is the field point at which `codeword[indices[i]]` lives.
+    /// `poly_length` is the length of the polynomial whose codeword is being
+    /// queried — some engines (e.g. cooley_tukey) derive their internal coset
+    /// structure from it, so the same codeword index can map to different
+    /// points depending on `poly_length`.
     ///
     /// # Panics
     ///
-    /// Panics if any of the indices are `>= codeword_length` or `order` is not supported.
+    /// Panics if any index is `>= codeword_length` or `codeword_length` is
+    /// not supported.
     fn evaluation_points(
         &self,
-        masked_message_length: usize,
+        poly_length: usize,
         codeword_length: usize,
         indices: &[usize],
     ) -> Vec<F>;
 
-    /// Compute a masked interleaved Reed-Solomon encoding.
+    /// Batch-encode polynomials in parallel.
     ///
-    /// `messages` are `num_messages` slices of `message_length` elements.
-    /// `masks` is a `num_messages` × `mask_length` matrix of blinding coefficients.
-    /// `codeword_length` must be an NTT-smooth number >= `message_length + mask_length`.
-    /// returns an `codeword_length × num_messages` matrix.
+    /// All `polys[i]` must have the same length. Output is a flat buffer of
+    /// `polys.len() * codeword_length` elements in row-major
+    /// `(eval_index, poly)` layout: `result[i * polys.len() + j]` is poly
+    /// `j`'s value at the `i`-th evaluation point.
     ///
-    /// Each output value is the univariate polynomial evaluation in the evaluation point
-    /// corresponding with the index of a coefficient list formed by concatenating message and mask.
-    ///
-    fn interleaved_encode(&self, messages: &[&[F]], masks: &[F], codeword_length: usize) -> Vec<F>;
+    /// `codeword_length` must be NTT-smooth for this engine and at least the
+    /// polynomial length.
+    fn interleaved_encode(&self, polys: &[&[F]], codeword_length: usize) -> Vec<F>;
 }
 
 assert_obj_safe!(ReedSolomon<crate::algebra::fields::Field256>);
@@ -108,23 +116,19 @@ pub fn next_order<F: 'static>(size: usize) -> Option<usize> {
 }
 
 pub fn evaluation_points<F: 'static>(
-    masked_message_length: usize,
+    poly_length: usize,
     codeword_length: usize,
     indices: &[usize],
 ) -> Vec<F> {
     NTT.get::<F>()
         .expect("Unsupported NTT field.")
-        .evaluation_points(masked_message_length, codeword_length, indices)
+        .evaluation_points(poly_length, codeword_length, indices)
 }
 
-pub fn interleaved_rs_encode<F: 'static>(
-    messages: &[&[F]],
-    masks: &[F],
-    codeword_length: usize,
-) -> Vec<F> {
+pub fn interleaved_rs_encode<F: 'static>(polys: &[&[F]], codeword_length: usize) -> Vec<F> {
     NTT.get::<F>()
         .expect("Unsupported NTT field.")
-        .interleaved_encode(messages, masks, codeword_length)
+        .interleaved_encode(polys, codeword_length)
 }
 
 pub fn generator<F: 'static>(codeword_length: usize) -> F {
@@ -145,7 +149,7 @@ mod tests {
     use super::*;
     use crate::{
         algebra::{random_vector, univariate_evaluate},
-        utils::{chunks_exact_or_empty, zip_strict},
+        utils::zip_strict,
     };
 
     fn valid_codeword_lengths<F: 'static>(size: usize, count: usize) -> Vec<usize> {
@@ -187,13 +191,17 @@ mod tests {
             let messages = (0..num_messages)
                 .map(|_| random_vector(&mut rng, message_length))
                 .collect::<Vec<_>>();
-            let masks = random_vector(&mut rng, mask_length * num_messages);
-            let message_refs = messages.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
-            let codeword = ntt.interleaved_encode(
-                &message_refs,
-                &masks,
-                codeword_length,
-            );
+            let masks: Vec<Vec<F>> = (0..num_messages)
+                .map(|_| random_vector(&mut rng, mask_length))
+                .collect();
+            // Build each polynomial as `message || mask`. The engine takes
+            // unified polynomial slices; the message/mask split is purely a
+            // caller-side concept.
+            let polys: Vec<Vec<F>> = (0..num_messages)
+                .map(|i| messages[i].iter().chain(masks[i].iter()).copied().collect())
+                .collect();
+            let poly_refs: Vec<&[F]> = polys.iter().map(Vec::as_slice).collect();
+            let codeword = ntt.interleaved_encode(&poly_refs, codeword_length);
 
             // Output must be the right size.
             assert_eq!(codeword.len(), codeword_length * num_messages);
@@ -202,8 +210,7 @@ mod tests {
             let mut evaluation_points = ntt.evaluation_points(message_length + mask_length, codeword_length, &sampled_indices);
             for (&index, &evaluation_point) in zip_strict(&sampled_indices, &evaluation_points) {
                 let evaluations = &codeword[index * num_messages.. (index + 1) * num_messages];
-                let masks = chunks_exact_or_empty(&masks, mask_length, num_messages);
-                for ((message, mask), value) in zip_strict(zip_strict(&messages, masks), evaluations) {
+                for ((message, mask), value) in zip_strict(zip_strict(&messages, &masks), evaluations) {
                     assert_eq!(*value,
                         univariate_evaluate(message, evaluation_point)
                         + evaluation_point.pow([message_length as u64])

--- a/src/buffer/cpu.rs
+++ b/src/buffer/cpu.rs
@@ -4,6 +4,7 @@ use std::{any::Any, mem};
 
 use ark_ff::Field;
 use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, Rng, RngCore};
+use zeroize::Zeroize;
 
 use crate::{
     algebra::{
@@ -54,6 +55,10 @@ impl<T: Copy> BufferOps<T> for CpuBuffer<T> {
         &self.data
     }
 
+    fn into_vec(self) -> Vec<T> {
+        self.data
+    }
+
     fn len(&self) -> usize {
         self.data.len()
     }
@@ -72,6 +77,13 @@ impl<T: Copy> BufferOps<T> for CpuBuffer<T> {
 
     fn get(&self, index: usize) -> Option<&T> {
         self.data.get(index)
+    }
+
+    fn wipe(&mut self)
+    where
+        T: Zeroize,
+    {
+        self.data.zeroize();
     }
 }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -36,6 +36,14 @@ pub type DefaultRs<T> = crate::algebra::ntt::NttEngine<T>;
 pub trait BufferOps<T: Copy> {
     /// Read back the buffer contents as a host slice.
     fn to_slice(&self) -> &[T];
+    /// Consume the buffer and return its contents as an owned host `Vec`.
+    ///
+    /// The dual of the `From<Vec<T>>` constructor: on the CPU backend this is a
+    /// zero-copy move of the backing storage; an accelerator backend would copy
+    /// device memory back to the host once.
+    fn into_vec(self) -> Vec<T>
+    where
+        Self: Sized;
     fn len(&self) -> usize;
     fn is_empty(&self) -> bool {
         self.len() == 0
@@ -45,6 +53,15 @@ pub trait BufferOps<T: Copy> {
     /// Gather elements at arbitrary indices.
     fn gather_at_indices(&self, indices: &[usize]) -> Vec<T>;
     fn get(&self, index: usize) -> Option<&T>;
+
+    /// Best-effort in-place zeroization of the buffer's contents.
+    ///
+    /// Used to scrub secret material (blinding masks, witness randomness)
+    /// before the buffer is dropped. On the CPU backend this zeroizes the
+    /// backing storage; accelerator backends would override with a device wipe.
+    fn wipe(&mut self)
+    where
+        T: zeroize::Zeroize;
 }
 
 /// Field operations on owned buffers.

--- a/src/protocols/challenge_indices.rs
+++ b/src/protocols/challenge_indices.rs
@@ -16,37 +16,85 @@ where
     if count == 0 {
         return Vec::new();
     }
-    // TODO: This is blocking non-power-of-two support.
-    assert!(
-        num_leaves.is_power_of_two(),
-        "Number of leaves must be a power of two for unbiased results."
-    );
-    if num_leaves == 1 {
-        // `size_bytes` would be zero, making `chunks_exact` panic.
+    if num_leaves <= 1 {
+        // `size_bytes` would be zero; short-circuit before the entropy loop.
         return if deduplicate { vec![0] } else { vec![0; count] };
     }
 
-    // Calculate the required bytes of entropy
-    // TODO: Round total to bytes, instead of per index.
-    let size_bytes = (num_leaves.ilog2() as usize).div_ceil(8);
+    let domain = IndexDomain::new(num_leaves);
+    let mut indices = Vec::with_capacity(count);
+    for _ in 0..count {
+        indices.push(domain.sample(transcript));
+    }
 
-    // Get required entropy bits.
-    let entropy: Vec<u8> = (0..count * size_bytes)
-        .map(|_| transcript.verifier_message())
-        .collect();
-
-    // Convert bytes into indices
-    let mut indices = entropy
-        .chunks_exact(size_bytes)
-        .map(|chunk| chunk.iter().fold(0usize, |acc, &b| (acc << 8) | b as usize) % num_leaves)
-        .collect::<Vec<usize>>();
-
-    // Sort and deduplicate indices if requested
     if deduplicate {
         indices.sort_unstable();
         indices.dedup();
     }
     indices
+}
+
+/// Rejection-sampling domain for transcript-derived row indices.
+///
+/// For power-of-two domains, `entropy_space` is an exact multiple of
+/// `num_leaves`, so rejection never triggers and sampling is bit-identical to
+/// the legacy `% num_leaves` implementation. For non-power-of-two domains,
+/// candidates in the biased tail are rejected and redrawn.
+#[derive(Clone, Copy, Debug)]
+struct IndexDomain {
+    num_leaves: usize,
+    size_bytes: usize,
+    threshold: u128,
+}
+
+impl IndexDomain {
+    fn new(num_leaves: usize) -> Self {
+        debug_assert!(num_leaves > 1);
+        let bits_needed = ceil_log2(num_leaves);
+        let size_bytes = bits_needed.div_ceil(8);
+        let entropy_bits = 8 * size_bytes;
+        debug_assert!(entropy_bits < u128::BITS as usize);
+
+        let entropy_space = 1u128 << entropy_bits;
+        let num_leaves_u = num_leaves as u128;
+        let threshold = (entropy_space / num_leaves_u) * num_leaves_u;
+
+        Self {
+            num_leaves,
+            size_bytes,
+            threshold,
+        }
+    }
+
+    fn sample<T>(&self, transcript: &mut T) -> usize
+    where
+        T: VerifierMessage,
+        u8: Decoding<[T::U]>,
+    {
+        loop {
+            let candidate = self.draw_candidate(transcript);
+            if candidate < self.threshold {
+                return (candidate % self.num_leaves as u128) as usize;
+            }
+        }
+    }
+
+    fn draw_candidate<T>(&self, transcript: &mut T) -> u128
+    where
+        T: VerifierMessage,
+        u8: Decoding<[T::U]>,
+    {
+        let mut candidate = 0u128;
+        for _ in 0..self.size_bytes {
+            candidate = (candidate << 8) | u128::from(transcript.verifier_message::<u8>());
+        }
+        candidate
+    }
+}
+
+fn ceil_log2(n: usize) -> usize {
+    debug_assert!(n > 1);
+    usize::BITS as usize - (n - 1).leading_zeros() as usize
 }
 
 #[cfg(test)]
@@ -200,5 +248,74 @@ mod tests {
             result, expected_indices,
             "Mismatch in computed indices for deduplication test"
         );
+    }
+
+    /// Non-pow2 `num_leaves`. With `num_leaves = 589824 = 2^16 · 9`:
+    ///   `bits_needed = 20`, `size_bytes = 3`, entropy_space = 2^24 = 16_777_216,
+    ///   `threshold = floor(2^24 / 589824) · 589824 = 28 · 589824 = 16_515_072`.
+    ///
+    /// The first 3-byte chunk decodes to 0xFFFFFF = 16_777_215, which is ≥
+    /// threshold and must be rejected. The second chunk decodes to a small
+    /// value < threshold and is returned.
+    #[test]
+    fn test_challenge_indices_non_pow2_rejection_retry() {
+        let num_leaves: usize = 589_824;
+        let ds = DomainSeparator::protocol(&module_path!())
+            .session(&format!("Test at {}:{}", file!(), line!()))
+            .instance(&Empty);
+        let sponge = MockSponge {
+            absorb: None,
+            squeeze: &[
+                0xFF, 0xFF, 0xFF, // candidate = 16_777_215 ≥ threshold → reject
+                0x00, 0x00, 0x05, // candidate = 5 < threshold → accept
+            ],
+        };
+        let mut prover_state = ProverState::new(&ds, sponge);
+
+        let result = challenge_indices(&mut prover_state, num_leaves, 1, false);
+        assert_eq!(result, vec![5]);
+    }
+
+    /// All indices returned for a non-pow2 `num_leaves` lie in `[0, num_leaves)`,
+    /// and the function is deterministic (same sponge bytes → same result).
+    #[test]
+    fn test_challenge_indices_non_pow2_in_range_and_deterministic() {
+        let num_leaves: usize = 589_824;
+        let count = 5;
+        let bytes: &[u8] = &[
+            0x12, 0x34, 0x56, // candidate 1_193_046 < threshold
+            0x78, 0x9A, 0xBC, // candidate 7_904_956 < threshold
+            0xDE, 0xF0, 0x11, // candidate 14_610_449 < threshold
+            0x22, 0x33, 0x44, // candidate 2_241_348 < threshold
+            0x55, 0x66, 0x77, // candidate 5_596_791 < threshold
+        ];
+        let make_state = || {
+            let ds = DomainSeparator::protocol(&module_path!())
+                .session(&format!("Test at {}:{}", file!(), line!()))
+                .instance(&Empty);
+            ProverState::new(
+                &ds,
+                MockSponge {
+                    absorb: None,
+                    squeeze: bytes,
+                },
+            )
+        };
+
+        let mut first = make_state();
+        let mut second = make_state();
+        let r1 = challenge_indices(&mut first, num_leaves, count, false);
+        let r2 = challenge_indices(&mut second, num_leaves, count, false);
+
+        assert_eq!(r1, r2, "challenge_indices must be deterministic");
+        assert_eq!(r1.len(), count);
+        assert!(
+            r1.iter().all(|&i| i < num_leaves),
+            "all indices must lie in [0, {num_leaves}): got {r1:?}",
+        );
+
+        // Spot-check the first index: 0x123456 = 1_193_046 < threshold 16_515_072
+        // → accepted, index = 1_193_046 % 589_824 = 13_398.
+        assert_eq!(r1[0], 1_193_046 % num_leaves);
     }
 }

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -57,8 +57,34 @@ pub struct Witness<F: Field> {
     pub target_witness: IrsWitness<F>,
 }
 
+/// Mutable claim state threaded through `prove`/`verify`: a covector (extended
+/// with `ℓ_zk` slack in ZK mode) paired with the running sum `μ` such that
+/// `μ = ⟨vector, covector⟩` after each protocol step.
+pub struct Claim<'a, F: Field> {
+    pub covector: &'a mut [F],
+    pub sum: &'a mut F,
+}
+
 /// Verifier output from the code-switch.
 pub type Commitment = IrsCommitment;
+
+/// Code-switch verification output for implicit-covector callers.
+///
+/// Returned by [`Config::verify_for_implicit`]. The caller accumulates
+/// constraint terms from these instead of updating an explicit `Vec<F>`.
+#[must_use]
+pub struct CovectorUpdateParams<F: Field> {
+    /// The `original_sl_coeff` that would have scaled the covector.
+    pub original_sl_coeff: F,
+    /// RLC coefficients for each OOD constraint.
+    pub ood_rlc_coeffs: Vec<F>,
+    /// OOD evaluation points (alpha_i).
+    pub ood_eval_points: Vec<F>,
+    /// RLC coefficients for each in-domain constraint.
+    pub in_domain_rlc_coeffs: Vec<F>,
+    /// In-domain evaluation points (omega_j, already lifted via embedding).
+    pub in_domain_eval_points: Vec<F>,
+}
 
 impl<M: Embedding> Config<M> {
     /// Create a code-switch config.
@@ -211,8 +237,8 @@ impl<M: Embedding> Config<M> {
         &self,
         prover_state: &mut ProverState<H, R>,
         message: Vec<M::Target>,
-        witness: &IrsWitness<M::Source>,
-        covector: &mut [M::Target],
+        witness: IrsWitness<M::Source>,
+        claim: Claim<'_, M::Target>,
         folding_randomness: &[M::Target],
         mask: &[M::Target],
     ) -> Witness<M::Target>
@@ -226,6 +252,7 @@ impl<M: Embedding> Config<M> {
         U64: Codec<[H::U]>,
         Hash: ProverMessage<[H::U]>,
     {
+        let Claim { covector, sum } = claim;
         assert_eq!(message.len(), self.source.message_length());
         assert_eq!(covector.len(), self.covector_length());
         assert_eq!(mask.len(), self.message_mask_length());
@@ -245,10 +272,19 @@ impl<M: Embedding> Config<M> {
 
         // Step 2-3: OOD challenge + answers — Construction 9.7 Steps 2-3, p.55
         let ood_points: Vec<M::Target> = prover_state.verifier_message_vec(self.out_domain_samples);
-        self.maybe_send_ood_answers(prover_state, &message, mask, &ood_points);
+        let ood_answers = self.maybe_send_ood_answers(prover_state, &message, mask, &ood_points);
 
         // Step 4: in-domain queries — Construction 9.7 Step 4, p.55
-        let source_evaluations = self.source.open(prover_state, &[witness]);
+        let source_evaluations = self.source.open(prover_state, &[&witness]);
+        // Source IRS matrix is no longer needed; release it before the trailing
+        // arithmetic and the caller's mask-discharge phase.
+        drop(witness);
+        let collapse_weights = eq_weights(folding_randomness);
+        let collapsed_values: Vec<M::Target> = source_evaluations
+            .matrix
+            .chunks_exact(self.source.interleaving_depth())
+            .map(|row| mixed_dot(self.source.embedding(), &collapse_weights, row))
+            .collect();
 
         // Step 4.1: batching — Construction 9.7 Step 4, p.55
         let num_ood = self.out_domain_samples;
@@ -257,6 +293,11 @@ impl<M: Embedding> Config<M> {
             geometric_challenge::<_, M::Target>(prover_state, 1 + num_ood + num_in_domain);
         let (&original_sl_coeff, constraint_rlc_coeffs) = batching_coeffs.split_first().unwrap();
         let (ood_rlc_coeffs, in_domain_rlc_coeffs) = constraint_rlc_coeffs.split_at(num_ood);
+
+        // Mirror verifier's sum update — Construction 9.7 Decision phase, p.55.
+        *sum = original_sl_coeff * *sum
+            + dot(ood_rlc_coeffs, &ood_answers)
+            + dot(in_domain_rlc_coeffs, &collapsed_values);
 
         // Covector update — sl' from Completeness proof (p.55-56)
         let eval_points = lift(self.source.embedding(), &source_evaluations.points);
@@ -275,20 +316,23 @@ impl<M: Embedding> Config<M> {
         }
     }
 
-    /// Send OOD answers `y_i = f(α_i) [+ α_i^ℓ · (r ‖ s)(α_i)]`.
-    /// In Standard mode the bracketed term is omitted.
+    /// Send OOD answers `y_i = f(α_i) [+ α_i^ℓ · (r ‖ s)(α_i)]` and return them
+    /// so the caller can reuse them for the sum update. In Standard mode the
+    /// bracketed term is omitted.
     fn maybe_send_ood_answers<H, R>(
         &self,
         prover_state: &mut ProverState<H, R>,
         message: &[M::Target],
         mask: &[M::Target],
         ood_points: &[M::Target],
-    ) where
+    ) -> Vec<M::Target>
+    where
         H: DuplexSpongeInterface,
         R: RngCore + CryptoRng,
         M::Target: Codec<[H::U]>,
     {
         let msg_len = message.len();
+        let mut answers = Vec::with_capacity(ood_points.len());
         for &point in ood_points {
             let f_eval = univariate_evaluate(message, point);
             let answer = match &self.mode {
@@ -300,7 +344,9 @@ impl<M: Embedding> Config<M> {
                 }
             };
             prover_state.prover_message(&answer);
+            answers.push(answer);
         }
+        answers
     }
 
     /// Accumulate OOD and in-domain weights into the covector.
@@ -362,11 +408,72 @@ impl<M: Embedding> Config<M> {
     /// per-round mask tree containing `s` and is responsible for
     /// running `mask_proximity::verify` on that same tree before
     /// accepting the round.
+    /// Shared transcript work: receive target commitment, verify source opening,
+    /// sample batching coefficients, update `sum`. Returns the target commitment
+    /// and the parameters needed to update a covector (explicitly or implicitly).
+    fn verify_inner<H>(
+        &self,
+        verifier_state: &mut VerifierState<H>,
+        sum: &mut M::Target,
+        folding_randomness: &[M::Target],
+        commitment: &IrsCommitment,
+    ) -> VerificationResult<(Commitment, CovectorUpdateParams<M::Target>)>
+    where
+        H: DuplexSpongeInterface,
+        Standard: Distribution<M::Target>,
+        M::Target: Codec<[H::U]>,
+        u8: Decoding<[H::U]>,
+        [u8; 32]: Decoding<[H::U]>,
+        U64: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let collapse_weights = eq_weights(folding_randomness);
+
+        let target_commitment = self.target.receive_commitment(verifier_state)?;
+        self.pow.verify(verifier_state)?;
+
+        let ood_eval_points: Vec<M::Target> =
+            verifier_state.verifier_message_vec(self.out_domain_samples);
+        let ood_answers: Vec<M::Target> =
+            verifier_state.prover_messages_vec(self.out_domain_samples)?;
+
+        let source_evaluations = self.source.verify(verifier_state, &[commitment])?;
+        let collapsed_values: Vec<M::Target> = source_evaluations
+            .matrix
+            .chunks_exact(self.source.interleaving_depth())
+            .map(|row| mixed_dot(self.source.embedding(), &collapse_weights, row))
+            .collect();
+
+        let num_ood = self.out_domain_samples;
+        let num_in_domain = source_evaluations.points.len();
+        let coeffs = geometric_challenge(verifier_state, 1 + num_ood + num_in_domain);
+        let (&original_sl_coeff, all_rlc_coeffs) = coeffs.split_first().unwrap();
+        let (ood_rlc_coeffs, in_domain_rlc_coeffs) = all_rlc_coeffs.split_at(num_ood);
+
+        *sum = original_sl_coeff * *sum
+            + dot(ood_rlc_coeffs, &ood_answers)
+            + dot(in_domain_rlc_coeffs, &collapsed_values);
+
+        let in_domain_eval_points = lift(self.source.embedding(), &source_evaluations.points);
+
+        Ok((
+            target_commitment,
+            CovectorUpdateParams {
+                original_sl_coeff,
+                ood_rlc_coeffs: ood_rlc_coeffs.to_vec(),
+                ood_eval_points,
+                in_domain_rlc_coeffs: in_domain_rlc_coeffs.to_vec(),
+                in_domain_eval_points,
+            },
+        ))
+    }
+
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn verify<H>(
         &self,
         verifier_state: &mut VerifierState<H>,
         sum: &mut M::Target,
+        covector: &mut [M::Target],
         folding_randomness: &[M::Target],
         commitment: &IrsCommitment,
     ) -> VerificationResult<Commitment>
@@ -380,44 +487,46 @@ impl<M: Embedding> Config<M> {
         Hash: ProverMessage<[H::U]>,
     {
         verify!(1 << folding_randomness.len() == self.source.interleaving_depth());
+        assert_eq!(covector.len(), self.covector_length());
 
-        let collapse_weights = eq_weights(folding_randomness);
+        let (target_commitment, params) =
+            self.verify_inner(verifier_state, sum, folding_randomness, commitment)?;
 
-        // Step 1: target commitment — Construction 9.7 Step 1, p.55
-        // Mask oracle is committed in the shared mask tree by the orchestrator.
-        let target_commitment = self.target.receive_commitment(verifier_state)?;
-
-        // Grind Lemma 9.9 OOD gap before α is sampled.
-        self.pow.verify(verifier_state)?;
-
-        // Step 2-3: OOD — Construction 9.7 Steps 2-3, p.55
-        // In ZK mode, ood_answers = f(α) + α^ℓ · (r,s)(α) where (r,s) is
-        // the mask oracle message committed in the shared tree.
-        let _ood_points: Vec<M::Target> =
-            verifier_state.verifier_message_vec(self.out_domain_samples);
-        let ood_answers: Vec<M::Target> =
-            verifier_state.prover_messages_vec(self.out_domain_samples)?;
-
-        // Step 4: source opening — Construction 9.7 Step 4, p.55
-        let source_evaluations = self.source.verify(verifier_state, &[commitment])?;
-        let collapsed_values: Vec<M::Target> = source_evaluations
-            .matrix
-            .chunks_exact(self.source.interleaving_depth())
-            .map(|row| mixed_dot(self.source.embedding(), &collapse_weights, row))
-            .collect();
-
-        // Step 4.1: batching + μ' — Construction 9.7 Decision phase, p.55
-        let num_ood = self.out_domain_samples;
-        let num_in_domain = source_evaluations.points.len();
-        let coeffs = geometric_challenge(verifier_state, 1 + num_ood + num_in_domain);
-        let (&original_sl_coeff, all_rlc_coeffs) = coeffs.split_first().unwrap();
-        let (ood_rlc_coeffs, in_domain_rlc_coeffs) = all_rlc_coeffs.split_at(num_ood);
-
-        *sum = original_sl_coeff * *sum
-            + dot(ood_rlc_coeffs, &ood_answers)
-            + dot(in_domain_rlc_coeffs, &collapsed_values);
+        scalar_mul(covector, params.original_sl_coeff);
+        self.update_covector(
+            covector,
+            &params.ood_rlc_coeffs,
+            &params.ood_eval_points,
+            &params.in_domain_rlc_coeffs,
+            &params.in_domain_eval_points,
+        );
 
         Ok(target_commitment)
+    }
+
+    /// Like [`verify`] but does NOT update an explicit covector. Instead it
+    /// returns [`CovectorUpdateParams`] so the caller can accumulate constraint
+    /// terms implicitly. Also does NOT assert `covector.len() == covector_length()`
+    /// since there is no covector. The `sum` is still updated as normal.
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
+    pub fn verify_for_implicit<H>(
+        &self,
+        verifier_state: &mut VerifierState<H>,
+        sum: &mut M::Target,
+        folding_randomness: &[M::Target],
+        commitment: &IrsCommitment,
+    ) -> VerificationResult<(Commitment, CovectorUpdateParams<M::Target>)>
+    where
+        H: DuplexSpongeInterface,
+        Standard: Distribution<M::Target>,
+        M::Target: Codec<[H::U]>,
+        u8: Decoding<[H::U]>,
+        [u8; 32]: Decoding<[H::U]>,
+        U64: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        verify!(1 << folding_randomness.len() == self.source.interleaving_depth());
+        self.verify_inner(verifier_state, sum, folding_randomness, commitment)
     }
 }
 
@@ -432,6 +541,27 @@ impl<M: Embedding> fmt::Display for Config<M> {
             self.is_zk(),
         )
     }
+}
+
+/// Fold ι parallel chunks of length `chunk_len` into a single chunk.
+///
+/// Uses `eq_weights(γ)` over the layout
+/// `values = [chunk_0; chunk_1; ...; chunk_{ι−1}]` (each chunk of length
+/// `chunk_len`) and returns `Σ_l eq_weights(γ)[l] · chunk_l`.
+pub fn fold_chunks<F: Field>(values: &[F], chunk_len: usize, folding_randomness: &[F]) -> Vec<F> {
+    let iota = 1 << folding_randomness.len();
+    assert_eq!(values.len(), chunk_len * iota);
+    if iota == 1 {
+        return values.to_vec();
+    }
+    let weights = eq_weights(folding_randomness);
+    (0..chunk_len)
+        .map(|j| {
+            (0..iota)
+                .map(|l| weights[l] * values[l * chunk_len + j])
+                .sum()
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -537,25 +667,6 @@ mod tests {
         }
     }
 
-    /// Fold ι parallel chunks of length `chunk_len` into a single chunk via
-    /// eq_weights(γ). Layout: values = [chunk_0; chunk_1; ...; chunk_{ι-1}],
-    /// each of length `chunk_len`. Returns Σ_l eq_weights(γ)[l] · chunk_l.
-    fn fold_chunks<F: Field>(values: &[F], chunk_len: usize, folding_randomness: &[F]) -> Vec<F> {
-        let iota = 1 << folding_randomness.len();
-        assert_eq!(values.len(), chunk_len * iota);
-        if iota == 1 {
-            return values.to_vec();
-        }
-        let weights = eq_weights(folding_randomness);
-        (0..chunk_len)
-            .map(|j| {
-                (0..iota)
-                    .map(|l| weights[l] * values[l * chunk_len + j])
-                    .sum()
-            })
-            .collect()
-    }
-
     /// Sample folding randomness of length log2(source.interleaving_depth).
     fn sample_folding_randomness<F: Field>(
         config: &Config<Identity<F>>,
@@ -583,7 +694,8 @@ mod tests {
             return Vec::new();
         }
         // Lift ι parallel masks (total length source.mask_length × ι) and fold
-        // chunks of length source.mask_length down to a single chunk.
+        // chunks of length source.mask_length down to a single chunk. Masks
+        // are stored in whir's canonical per-poly contiguous layout.
         let raw = lift(config.source.embedding(), &source_witness.masks);
         let mut mask = fold_chunks(&raw, config.source.mask_length(), folding_randomness);
         // Append fresh padding s of length message_mask_length - source.mask_length.
@@ -607,6 +719,8 @@ mod tests {
 
         let mut covector: Vec<F> = random_vector(&mut rng, config.source.message_length());
         covector.resize(config.covector_length(), F::ZERO);
+        let mut verifier_covector = covector.clone();
+        let mut prover_sum = initial_sum;
 
         let instance = U64(seed);
         let ds = DomainSeparator::protocol(config)
@@ -625,8 +739,11 @@ mod tests {
         let witness = config.prove(
             &mut prover_state,
             folded_message.clone(),
-            &source_witness,
-            &mut covector,
+            source_witness,
+            Claim {
+                covector: &mut covector,
+                sum: &mut prover_sum,
+            },
             &folding_randomness,
             &mask_msg,
         );
@@ -642,12 +759,14 @@ mod tests {
             .verify(
                 &mut verifier_state,
                 &mut verifier_sum,
+                &mut verifier_covector,
                 &folding_randomness,
                 &source_commitment,
             )
             .unwrap();
         verifier_state.check_eof().unwrap();
         assert_eq!(witness.message, folded_message);
+        assert_eq!(covector, verifier_covector);
     }
 
     fn test_ior_identity_config<F: Field + Codec<[u8]>>(seed: u64, config: &Config<Identity<F>>)
@@ -660,6 +779,7 @@ mod tests {
 
         let mut covector: Vec<F> = random_vector(&mut rng, config.source.message_length());
         covector.resize(config.covector_length(), F::ZERO);
+        let mut verifier_covector = covector.clone();
 
         let instance = U64(seed);
         let ds = DomainSeparator::protocol(config)
@@ -687,12 +807,16 @@ mod tests {
                 .collect()
         };
         let initial_mu = dot(&h, &covector);
+        let mut prover_sum = initial_mu;
 
         let _witness = config.prove(
             &mut prover_state,
             folded_message,
-            &source_witness,
-            &mut covector,
+            source_witness,
+            Claim {
+                covector: &mut covector,
+                sum: &mut prover_sum,
+            },
             &folding_randomness,
             &mask_msg,
         );
@@ -708,13 +832,15 @@ mod tests {
             .verify(
                 &mut verifier_state,
                 &mut verifier_sum,
+                &mut verifier_covector,
                 &folding_randomness,
                 &source_commitment,
             )
             .unwrap();
         verifier_state.check_eof().unwrap();
 
-        assert_eq!(dot(&h, &covector), verifier_sum);
+        assert_eq!(covector, verifier_covector);
+        assert_eq!(dot(&h, &verifier_covector), verifier_sum);
     }
 
     fn test_tampered_ood_config<F: Field + Codec<[u8]>>(seed: u64, config: &Config<Identity<F>>)
@@ -731,6 +857,7 @@ mod tests {
 
         let mut covector: Vec<F> = random_vector(&mut rng, config.source.message_length());
         covector.resize(config.covector_length(), F::ZERO);
+        let mut verifier_covector = covector.clone();
 
         // Commit honest f_full, fold to get the honest post-fold message.
         let mut prover_state = ProverState::new_std(&ds);
@@ -741,6 +868,7 @@ mod tests {
 
         // For non-ZK and source.mask_length == 0, h = folded_message and identity holds.
         let initial_mu = dot(&folded_message, &covector);
+        let mut prover_sum = initial_mu;
 
         // Tamper the post-fold message before proving.
         let mut tampered = folded_message.clone();
@@ -748,8 +876,11 @@ mod tests {
         let _witness = config.prove(
             &mut prover_state,
             tampered,
-            &source_witness,
-            &mut covector,
+            source_witness,
+            Claim {
+                covector: &mut covector,
+                sum: &mut prover_sum,
+            },
             &folding_randomness,
             &[],
         );
@@ -765,6 +896,7 @@ mod tests {
             .verify(
                 &mut verifier_state,
                 &mut verifier_sum,
+                &mut verifier_covector,
                 &folding_randomness,
                 &source_commitment,
             )
@@ -772,7 +904,7 @@ mod tests {
         verifier_state.check_eof().unwrap();
 
         // Sum diverges — downstream sumcheck would reject
-        assert_ne!(dot(&folded_message, &covector), verifier_sum);
+        assert_ne!(dot(&folded_message, &verifier_covector), verifier_sum);
     }
 
     fn test<F: Field + Codec<[u8]> + 'static>()

--- a/src/protocols/code_switch.rs
+++ b/src/protocols/code_switch.rs
@@ -553,16 +553,35 @@ impl<M: Embedding> fmt::Display for Config<M> {
 /// `values = [chunk_0; chunk_1; ...; chunk_{ι−1}]` (each chunk of length
 /// `chunk_len`) and returns `Σ_l eq_weights(γ)[l] · chunk_l`.
 pub fn fold_chunks<F: Field>(values: &[F], chunk_len: usize, folding_randomness: &[F]) -> Vec<F> {
+    // The identity case of `mixed_fold_chunks`: for `Identity<F>`, `map` is a
+    // no-op, so this monomorphizes to a plain multiply-and-sum with no overhead.
+    mixed_fold_chunks(&Identity::<F>::new(), values, chunk_len, folding_randomness)
+}
+
+/// Embedding-aware [`fold_chunks`].
+///
+/// The values live in the source field `M::Source` while the folding randomness
+/// lives in the target field `M::Target`, so each output chunk is
+/// `Σ_l eq_weights(γ)[l] · φ(chunk_l)` with `φ = embedding.map`. Used to fold a
+/// round's base-field IRS masks by the ext-field sumcheck challenges
+/// (Construction 9.7 `(r ‖ s)`).
+pub fn mixed_fold_chunks<M: Embedding>(
+    embedding: &M,
+    values: &[M::Source],
+    chunk_len: usize,
+    folding_randomness: &[M::Target],
+) -> Vec<M::Target> {
     let iota = 1 << folding_randomness.len();
     assert_eq!(values.len(), chunk_len * iota);
     if iota == 1 {
-        return values.to_vec();
+        // No folding: each chunk is a single value, lifted into `M::Target`.
+        return values.iter().map(|&v| embedding.map(v)).collect();
     }
     let weights = eq_weights(folding_randomness);
     (0..chunk_len)
         .map(|j| {
             (0..iota)
-                .map(|l| weights[l] * values[l * chunk_len + j])
+                .map(|l| embedding.mixed_mul(weights[l], values[l * chunk_len + j]))
                 .sum()
         })
         .collect()

--- a/src/protocols/irs_commit.rs
+++ b/src/protocols/irs_commit.rs
@@ -179,16 +179,37 @@ impl<M: Embedding> Config<M> {
         } = params;
         assert!(vector_size.is_multiple_of(interleaving_depth));
         assert!(rate > 0. && rate <= 1.);
-        let masked_message_length = vector_size / interleaving_depth + mode.mask_length();
-        // `interleaved_encode` requires `codeword_length` to divide the NTT root
-        // order. `masked_message_length` is allowed to be arbitrary (the coset
-        // NTT zero-extends internally), so we only round the codeword side here.
+        let message_length = vector_size / interleaving_depth;
+        let masked_message_length = message_length + mode.mask_length();
+        // `interleaved_encode` requires `codeword_length` to divide the NTT
+        // root order. `masked_message_length` is allowed to be arbitrary (the
+        // coset NTT zero-extends internally), so we only round the codeword
+        // side here. Use the unmasked codeword when it (a) fits the masked
+        // message and (b) keeps effective rate within 20% of the requested
+        // rate. This avoids a `next_order` jump caused by the small IRS
+        // randomness mask pushing the masked length past an NTT-smooth
+        // boundary (e.g. avoids 524288 → 589824, a 12.5% jump on a
+        // 2^17-message commit). When the mask is large enough that the
+        // effective rate would exceed 1.2 × requested (tail rounds at very low
+        // rates), fall back to sizing the codeword from the masked length.
         #[allow(clippy::cast_sign_loss)]
-        let raw_codeword_length = (masked_message_length as f64 / rate).ceil() as usize;
-        let codeword_length =
-            ntt::next_order::<M::Source>(raw_codeword_length).ok_or(CodewordLengthError {
-                length: raw_codeword_length,
-            })?;
+        let codeword_length = {
+            let unmasked_target = (message_length as f64 / rate).ceil() as usize;
+            let unmasked =
+                ntt::next_order::<M::Source>(unmasked_target).ok_or(CodewordLengthError {
+                    length: unmasked_target,
+                })?;
+            let fits_masked = unmasked >= masked_message_length;
+            let effective_rate = masked_message_length as f64 / unmasked as f64;
+            if fits_masked && effective_rate <= 1.2 * rate {
+                unmasked
+            } else {
+                let masked_target = (masked_message_length as f64 / rate).ceil() as usize;
+                ntt::next_order::<M::Source>(masked_target).ok_or(CodewordLengthError {
+                    length: masked_target,
+                })?
+            }
+        };
         let rate = masked_message_length as f64 / codeword_length as f64;
 
         let regime = DecodingRegimeParams::from_policy(decoding_regime, rate);

--- a/src/protocols/irs_commit.rs
+++ b/src/protocols/irs_commit.rs
@@ -375,15 +375,32 @@ impl<M: Embedding> Config<M> {
         assert_eq!(vectors.len(), self.num_vectors);
         assert!(vectors.iter().all(|p| p.len() == self.vector_size));
 
-        // Generate random mask
-        let masks = random_vector(prover_state.rng(), self.mask_length() * self.num_messages());
+        // Sample masks in whir's canonical per-polynomial-contiguous layout:
+        // `masks[i * mask_length + c]` is polynomial `i`'s coefficient at
+        // column `c`. Downstream sites (mask_proximity discharge, code_switch
+        // fold) read masks back via this layout.
+        let mask_length = self.mask_length();
+        let num_polys = self.num_messages();
+        let masks: Vec<M::Source> = random_vector(prover_state.rng(), mask_length * num_polys);
 
-        // Interleaved RS Encode the vectors
-        let messages = vectors
-            .iter()
-            .flat_map(|v| chunks_exact_or_empty(v, self.message_length(), self.interleaving_depth))
-            .collect::<Vec<_>>();
-        let matrix = ntt::interleaved_rs_encode(&messages, &masks, self.codeword_length);
+        // Engine takes unified polynomial slices (message || mask); the
+        // message/mask split is an IRS-side concept, not part of the NTT API.
+        let message_length = self.message_length();
+        let poly_length = message_length + mask_length;
+        let mut poly_buf = Vec::with_capacity(num_polys * poly_length);
+        let mut poly_idx = 0;
+        for vector in vectors {
+            for message in chunks_exact_or_empty(vector, message_length, self.interleaving_depth) {
+                poly_buf.extend_from_slice(message);
+                poly_buf.extend_from_slice(
+                    &masks[poly_idx * mask_length..(poly_idx + 1) * mask_length],
+                );
+                poly_idx += 1;
+            }
+        }
+        debug_assert_eq!(poly_idx, num_polys);
+        let polys: Vec<&[M::Source]> = poly_buf.chunks_exact(poly_length).collect();
+        let matrix = ntt::interleaved_rs_encode(&polys, self.codeword_length);
 
         // Commit to the matrix
         let matrix_witness = self.matrix_commit.commit(prover_state, &matrix);

--- a/src/protocols/mask_proximity.rs
+++ b/src/protocols/mask_proximity.rs
@@ -286,9 +286,9 @@ impl<F: Field> Config<F> {
         self.c_zk_commit
             .open(prover_state, &[&witness.mask_witness]);
 
-        // NOTE: the IRS mask/matrix secret material lives in opaque backend
-        // `Buffer`s, which do not expose in-place host mutation, so we can no
-        // longer explicitly zeroize it here (it is dropped with the witness).
+        // Zeroize IRS mask secret material after the tree open.
+        witness.mask_witness.masks.wipe();
+        witness.mask_witness.matrix.wipe();
     }
 
     /// Verify that each original mask is close to a C_zk codeword. When

--- a/src/protocols/mask_proximity.rs
+++ b/src/protocols/mask_proximity.rs
@@ -1,4 +1,4 @@
-//! Mask proximity verification via γ-combination.
+//! Mask proximity verification via γ-combination + optional inner-product discharge.
 //!
 //! Implements Construction 7.2 (p.43-44) specialized for zero-constraint mask
 //! oracles. Given a shared Merkle tree containing 2n vectors — n original masks
@@ -10,12 +10,19 @@
 //!   columns n..2n-1:  mask-of-masks    s_1, ..., s_n
 //!
 //! Protocol:
-//!   1. Verifier sends γ (combination randomness)
-//!   2. Prover sends combined polynomials ξ*_i = s_i + γ·ξ_i and
+//!   1. (Optional discharge) Prover sends X_i = <ξ_i, w_i> and X'_i = <s_i, w_i>
+//!      for each mask `i` with its own covector `w_i` — Construction 7.2 step 1
+//!      target-claim setup, generalized to per-mask covectors.
+//!   2. Verifier sends γ (combination randomness)
+//!   3. Prover sends combined polynomials ξ*_i = s_i + γ·ξ_i and
 //!      combined IRS randomness r*_i = r'_i + γ·r_i for each mask pair
-//!   3. Shared tree is opened at random positions
-//!   4. Verifier checks: Enc(ξ*_i, r*_i)(y_j) = s_i(y_j) + γ·ξ_i(y_j)
+//!   4. Shared tree is opened at random positions
+//!   5. Verifier checks: Enc(ξ*_i, r*_i)(y_j) = s_i(y_j) + γ·ξ_i(y_j)
 //!      at each opened position, using linearity of the RS encoding
+//!   6. (Optional discharge) Verifier target check: <ξ*_i, w_i> = X'_i + γ·X_i
+//!      for every mask `i`. Binds each X_i to the committed ξ_i via the same
+//!      γ-randomness — the orchestrator uses the returned X_i values to
+//!      reconcile sum offsets and project to f-only.
 //!
 //! ZK safety (follows the pattern of Construction 7.2, §7.1):
 //!   - Only the combined ξ*_i = s_i + γ·ξ_i is revealed in full. Since s_i
@@ -33,7 +40,13 @@
 //! is that the simulator can simulate all 2n values at each position
 //! independently (each pair (ξ_i, s_i) is simulatable from C_zk's ZK
 //! property, and the pairs are independent across i). Formal derivation
-//! for the shared-tree case is pending.
+//! for the shared-tree case: Bound 6 (§5.6) of the parameter
+//! derivation document establishes SD ≤ ζ_C + 2n·ζ_{C_zk} for the shared tree
+//! (vs Lemma 7.3's ζ_C + n·ζ_{C_zk} for separate oracles) by P8 (independent
+//! sampling preserved by the Merkle authentication layer). Under perfect-ZK
+//! encoder conditions (t_zk ≤ r_zk), both terms are 0 and the shared-tree
+//! model is perfectly ZK. The 2n multiplier vs paper's n is the only permanent
+//! artifact and is accounted for in the per-round mask-proximity error budget.
 //!
 //! Soundness: if ξ_i is far from C_zk, the spot-check fails with high
 //! probability over γ (Lemma 7.4, p.45).
@@ -43,9 +56,11 @@ use std::fmt;
 use ark_ff::Field;
 use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
 
 use crate::{
-    algebra::{embedding::Identity, random_vector, scalar_mul_add_new, univariate_evaluate},
+    algebra::{dot, embedding::Identity, random_vector, scalar_mul_add_new, univariate_evaluate},
     hash::Hash,
     protocols::{
         irs_commit::{Commitment as IrsCommitment, Config as IrsConfig, Witness as IrsWitness},
@@ -126,10 +141,11 @@ impl<F: Field> Config<F> {
     ///
     /// Samples n fresh mask-of-mask polynomials, combines them with the
     /// provided original masks into a 2n-vector tree, and commits via IRS.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "mask_proximity::commit", fields(num_masks = self.num_masks, vector_size = self.c_zk_commit.vector_size())))]
     pub fn commit<H, R>(
         &self,
         prover_state: &mut ProverState<H, R>,
-        original_msgs: &[Vec<F>],
+        original_msgs: &[&[F]],
     ) -> Witness<F>
     where
         F: Codec<[H::U]>,
@@ -151,8 +167,8 @@ impl<F: Field> Config<F> {
         // Tree layout: [originals..., freshes...]
         let all_vectors: Vec<&[F]> = original_msgs
             .iter()
-            .chain(fresh_msgs.iter())
-            .map(|v| v.as_slice())
+            .copied()
+            .chain(fresh_msgs.iter().map(Vec::as_slice))
             .collect();
 
         let mask_witness = self.c_zk_commit.commit(prover_state, &all_vectors);
@@ -164,6 +180,7 @@ impl<F: Field> Config<F> {
     }
 
     /// Receive a mask proximity commitment
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "mask_proximity::receive_commitment", fields(num_masks = self.num_masks)))]
     pub fn receive_commitment<H>(
         &self,
         verifier_state: &mut VerifierState<H>,
@@ -176,12 +193,19 @@ impl<F: Field> Config<F> {
         self.c_zk_commit.receive_commitment(verifier_state)
     }
 
-    /// Prove that each original mask is close to a C_zk codeword.
+    /// Prove that each original mask is close to a C_zk codeword. When
+    /// `mask_contribution_covectors` is `Some(per_mask)`, also runs the
+    /// Construction 7.2 target check for each mask `i` with its own covector
+    /// `per_mask[i]`, discharging `X_i = <originals[i], per_mask[i]>`. All
+    /// `X_i` and `X'_i` are sent before γ so γ binds them; the returned
+    /// values are bound by the verifier-side target checks.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "mask_proximity::prove", fields(num_masks = self.num_masks, vector_size = self.c_zk_commit.vector_size(), with_discharge = mask_contribution_covectors.is_some())))]
     pub fn prove<H, R>(
         &self,
         prover_state: &mut ProverState<H, R>,
-        witness: &Witness<F>,
-        original_msgs: &[Vec<F>],
+        mut witness: Witness<F>,
+        original_msgs: &[&[F]],
+        mask_contribution_covectors: Option<&[&[F]]>,
     ) where
         F: Codec<[H::U]>,
         H: DuplexSpongeInterface,
@@ -194,6 +218,23 @@ impl<F: Field> Config<F> {
     {
         assert_eq!(original_msgs.len(), self.num_masks);
         assert_eq!(witness.fresh_msgs.len(), self.num_masks);
+
+        // Construction 7.2 step 1: per-mask discharge claims X_i and X'_i must
+        // be sent BEFORE γ so γ-randomness binds them.
+        if let Some(covectors) = mask_contribution_covectors {
+            assert_eq!(
+                covectors.len(),
+                self.num_masks,
+                "one covector per mask required"
+            );
+            for (i, &covector) in covectors.iter().enumerate() {
+                assert_eq!(covector.len(), self.c_zk_commit.vector_size());
+                let claimed_value = dot(original_msgs[i], covector);
+                let fresh_claim = dot(&witness.fresh_msgs[i], covector);
+                prover_state.prover_message(&claimed_value);
+                prover_state.prover_message(&fresh_claim);
+            }
+        }
 
         // Grind the Lemma 7.4 γ-combination gap before γ is sampled.
         self.pow.prove(prover_state);
@@ -217,29 +258,51 @@ impl<F: Field> Config<F> {
             let combined_msg = scalar_mul_add_new(fresh_msg, gamma, orig_msg);
             prover_state.prover_messages(&combined_msg);
 
-            // r*_i = r'_i + γ · r_i
+            // r*_i = r'_i + γ · r_i — IRS stores masks per-polynomial
+            // contiguous, so direct slicing reconstructs each poly's mask.
             if irs_masks_per_vector > 0 {
-                let orig_r = &witness.mask_witness.masks
-                    [i * irs_masks_per_vector..(i + 1) * irs_masks_per_vector];
-                let fresh_r = &witness.mask_witness.masks[(self.num_masks + i)
-                    * irs_masks_per_vector
-                    ..(self.num_masks + i + 1) * irs_masks_per_vector];
+                let masks = &witness.mask_witness.masks;
+                let orig_r = &masks[i * irs_masks_per_vector..(i + 1) * irs_masks_per_vector];
+                let fresh_offset = (self.num_masks + i) * irs_masks_per_vector;
+                let fresh_r = &masks[fresh_offset..fresh_offset + irs_masks_per_vector];
                 let combined_r = scalar_mul_add_new(fresh_r, gamma, orig_r);
                 prover_state.prover_messages(&combined_r);
             }
         }
 
+        // Zeroize secret mask-of-masks polynomials before freeing.
+        for msg in &mut witness.fresh_msgs {
+            for elem in msg.iter_mut() {
+                elem.zeroize();
+            }
+        }
+        witness.fresh_msgs = Vec::new();
+
         // Step 3: open the shared tree at random in-domain positions
         self.c_zk_commit
             .open(prover_state, &[&witness.mask_witness]);
+
+        // Zeroize IRS mask secret material after the tree open.
+        for elem in &mut witness.mask_witness.masks {
+            elem.zeroize();
+        }
+        for elem in &mut witness.mask_witness.matrix {
+            elem.zeroize();
+        }
     }
 
-    /// Verify that each original mask is close to a C_zk codeword.
+    /// Verify that each original mask is close to a C_zk codeword. When
+    /// `mask_contribution_covectors` is `Some(per_mask)`, also verifies the
+    /// Construction 7.2 target check for each mask `i` against `per_mask[i]`
+    /// and returns `Some(Vec<X_i>)` — the verified claimed values
+    /// `<originals[i], per_mask[i]>`.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "mask_proximity::verify", fields(num_masks = self.num_masks, vector_size = self.c_zk_commit.vector_size(), with_discharge = mask_contribution_covectors.is_some())))]
     pub fn verify<H>(
         &self,
         verifier_state: &mut VerifierState<H>,
         commitment: &Commitment,
-    ) -> VerificationResult<()>
+        mask_contribution_covectors: Option<&[&[F]]>,
+    ) -> VerificationResult<Option<Vec<F>>>
     where
         F: Codec<[H::U]>,
         H: DuplexSpongeInterface,
@@ -248,6 +311,22 @@ impl<F: Field> Config<F> {
         U64: Codec<[H::U]>,
         Hash: ProverMessage<[H::U]>,
     {
+        // Construction 7.2 step 1: read X_i and X'_i for each mask before γ
+        // so γ binds them.
+        let mask_contribution_claims = if let Some(covectors) = mask_contribution_covectors {
+            verify!(covectors.len() == self.num_masks);
+            let mut claims = Vec::with_capacity(self.num_masks);
+            for &covector in covectors {
+                verify!(covector.len() == self.c_zk_commit.vector_size());
+                let claimed_value: F = verifier_state.prover_message()?;
+                let fresh_claim: F = verifier_state.prover_message()?;
+                claims.push((covector, claimed_value, fresh_claim));
+            }
+            Some(claims)
+        } else {
+            None
+        };
+
         // Grind the Lemma 7.4 γ-combination gap before γ is sampled.
         self.pow.verify(verifier_state)?;
 
@@ -295,7 +374,19 @@ impl<F: Field> Config<F> {
             }
         }
 
-        Ok(())
+        // Construction 7.2 target check per mask: <ξ*_i, w_i> = X'_i + γ·X_i.
+        mask_contribution_claims.map_or(Ok(None), |claims| {
+            let mut claimed_values = Vec::with_capacity(claims.len());
+            for (i, (covector, claimed_value, fresh_claim)) in claims.into_iter().enumerate() {
+                let lhs = dot(&combined_msgs[i], covector);
+                let rhs = fresh_claim + gamma * claimed_value;
+                if lhs != rhs {
+                    return Err(spongefish::VerificationError);
+                }
+                claimed_values.push(claimed_value);
+            }
+            Ok(Some(claimed_values))
+        })
     }
 }
 
@@ -370,15 +461,18 @@ mod tests {
         let original_msgs: Vec<Vec<F>> = (0..config.num_masks)
             .map(|_| random_vector(&mut rng, config.c_zk_commit.vector_size()))
             .collect();
+        let original_refs: Vec<&[F]> = original_msgs.iter().map(Vec::as_slice).collect();
 
         let mut prover_state = ProverState::new_std(&ds);
-        let witness = config.commit(&mut prover_state, &original_msgs);
-        config.prove(&mut prover_state, &witness, &original_msgs);
+        let witness = config.commit(&mut prover_state, &original_refs);
+        config.prove(&mut prover_state, witness, &original_refs, None);
         let proof = prover_state.proof();
 
         let mut verifier_state = VerifierState::new_std(&ds, &proof);
         let commitment = config.receive_commitment(&mut verifier_state).unwrap();
-        config.verify(&mut verifier_state, &commitment).unwrap();
+        let _ = config
+            .verify(&mut verifier_state, &commitment, None)
+            .unwrap();
         verifier_state.check_eof().unwrap();
     }
 
@@ -444,18 +538,20 @@ mod tests {
         let original_msgs: Vec<Vec<F>> = (0..config.num_masks)
             .map(|_| random_vector(&mut rng, config.c_zk_commit.vector_size()))
             .collect();
+        let original_refs: Vec<&[F]> = original_msgs.iter().map(Vec::as_slice).collect();
 
         let mut prover_state = ProverState::new_std(&ds);
-        let witness = config.commit(&mut prover_state, &original_msgs);
+        let witness = config.commit(&mut prover_state, &original_refs);
 
         let mut tampered_msgs = original_msgs;
         tampered_msgs[0][0] += F::ONE;
-        config.prove(&mut prover_state, &witness, &tampered_msgs);
+        let tampered_refs: Vec<&[F]> = tampered_msgs.iter().map(Vec::as_slice).collect();
+        config.prove(&mut prover_state, witness, &tampered_refs, None);
         let proof = prover_state.proof();
 
         let mut verifier_state = VerifierState::new_std(&ds, &proof);
         let commitment = config.receive_commitment(&mut verifier_state).unwrap();
-        assert_rejected(|| config.verify(&mut verifier_state, &commitment));
+        assert_rejected(|| config.verify(&mut verifier_state, &commitment, None));
     }
 
     /// Post-γ tamper: commit honestly, then corrupt the combined message to
@@ -475,9 +571,10 @@ mod tests {
         let original_msgs: Vec<Vec<F>> = (0..config.num_masks)
             .map(|_| random_vector(&mut rng, config.c_zk_commit.vector_size()))
             .collect();
+        let original_refs: Vec<&[F]> = original_msgs.iter().map(Vec::as_slice).collect();
 
         let mut prover_state = ProverState::new_std(&ds);
-        let witness = config.commit(&mut prover_state, &original_msgs);
+        let witness = config.commit(&mut prover_state, &original_refs);
 
         let gamma: F = prover_state.verifier_message();
         let irs_masks_per_vector =
@@ -512,7 +609,7 @@ mod tests {
 
         let mut verifier_state = VerifierState::new_std(&ds, &proof);
         let commitment = config.receive_commitment(&mut verifier_state).unwrap();
-        assert_rejected(|| config.verify(&mut verifier_state, &commitment));
+        assert_rejected(|| config.verify(&mut verifier_state, &commitment, None));
     }
 
     fn assert_rejected<T>(verify: impl FnOnce() -> VerificationResult<T>) {
@@ -547,6 +644,140 @@ mod tests {
         proptest!(|(seed: u64, config in Config::<fields::Field64>::arbitrary())| {
             prop_assume!(config.c_zk_commit.in_domain_samples() > 0);
             test_tampered_combined_msg_config(seed, &config);
+        });
+    }
+
+    /// Construction 7.2 target check: per-mask discharge round-trip.
+    fn test_discharge_config<F>(seed: u64, config: &Config<F>)
+    where
+        F: Field + Codec<[u8]> + 'static,
+        Standard: Distribution<F>,
+        Hash: crate::transcript::ProverMessage<[u8]>,
+    {
+        let instance = U64(seed);
+        let ds = DomainSeparator::protocol(config)
+            .session(&format!("Test at {}:{}", file!(), line!()))
+            .instance(&instance);
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        let original_msgs: Vec<Vec<F>> = (0..config.num_masks)
+            .map(|_| random_vector(&mut rng, config.c_zk_commit.vector_size()))
+            .collect();
+        let original_refs: Vec<&[F]> = original_msgs.iter().map(Vec::as_slice).collect();
+        // One distinct covector per mask.
+        let covectors: Vec<Vec<F>> = (0..config.num_masks)
+            .map(|_| random_vector(&mut rng, config.c_zk_commit.vector_size()))
+            .collect();
+        let expected_claims: Vec<F> = original_msgs
+            .iter()
+            .zip(covectors.iter())
+            .map(|(m, c)| dot(m, c))
+            .collect();
+        let covector_refs: Vec<&[F]> = covectors.iter().map(|v| v.as_slice()).collect();
+
+        let mut prover_state = ProverState::new_std(&ds);
+        let witness = config.commit(&mut prover_state, &original_refs);
+        config.prove(
+            &mut prover_state,
+            witness,
+            &original_refs,
+            Some(&covector_refs),
+        );
+        let proof = prover_state.proof();
+
+        let mut verifier_state = VerifierState::new_std(&ds, &proof);
+        let commitment = config.receive_commitment(&mut verifier_state).unwrap();
+        let returned = config
+            .verify(&mut verifier_state, &commitment, Some(&covector_refs))
+            .unwrap();
+        assert_eq!(returned, Some(expected_claims));
+        verifier_state.check_eof().unwrap();
+    }
+
+    /// Discharge with the wrong `claimed_value` — target check must reject.
+    fn test_discharge_wrong_claim_config<F>(seed: u64, config: &Config<F>)
+    where
+        F: Field + Codec<[u8]> + 'static,
+        Standard: Distribution<F>,
+        Hash: crate::transcript::ProverMessage<[u8]>,
+    {
+        let instance = U64(seed);
+        let ds = DomainSeparator::protocol(config)
+            .session(&format!("Test at {}:{}", file!(), line!()))
+            .instance(&instance);
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        let original_msgs: Vec<Vec<F>> = (0..config.num_masks)
+            .map(|_| random_vector(&mut rng, config.c_zk_commit.vector_size()))
+            .collect();
+        let original_refs: Vec<&[F]> = original_msgs.iter().map(Vec::as_slice).collect();
+        let covectors: Vec<Vec<F>> = (0..config.num_masks)
+            .map(|_| random_vector(&mut rng, config.c_zk_commit.vector_size()))
+            .collect();
+        let covector_refs: Vec<&[F]> = covectors.iter().map(|v| v.as_slice()).collect();
+
+        let mut prover_state = ProverState::new_std(&ds);
+        let witness = config.commit(&mut prover_state, &original_refs);
+
+        // Lie on mask 0's X; emit honest claims for the rest, then complete
+        // the protocol manually to exercise the verifier's target check.
+        let wrong_claim = dot(&original_msgs[0], &covectors[0]) + F::ONE;
+        let fresh_claim_0 = dot(&witness.fresh_msgs[0], &covectors[0]);
+        prover_state.prover_message(&wrong_claim);
+        prover_state.prover_message(&fresh_claim_0);
+        for i in 1..config.num_masks {
+            let x = dot(&original_msgs[i], &covectors[i]);
+            let x_prime = dot(&witness.fresh_msgs[i], &covectors[i]);
+            prover_state.prover_message(&x);
+            prover_state.prover_message(&x_prime);
+        }
+
+        // Run the rest of the protocol manually (mirror prove without the
+        // discharge prelude we already emitted).
+        config.pow.prove(&mut prover_state);
+        let gamma: F = prover_state.verifier_message();
+        let irs_masks_per_vector =
+            config.c_zk_commit.mask_length() * config.c_zk_commit.interleaving_depth();
+        for (i, (orig_msg, fresh_msg)) in original_msgs
+            .iter()
+            .zip(witness.fresh_msgs.iter())
+            .enumerate()
+        {
+            let combined_msg = scalar_mul_add_new(fresh_msg, gamma, orig_msg);
+            prover_state.prover_messages(&combined_msg);
+            if irs_masks_per_vector > 0 {
+                let orig_r = &witness.mask_witness.masks
+                    [i * irs_masks_per_vector..(i + 1) * irs_masks_per_vector];
+                let fresh_r = &witness.mask_witness.masks[(config.num_masks + i)
+                    * irs_masks_per_vector
+                    ..(config.num_masks + i + 1) * irs_masks_per_vector];
+                let combined_r = scalar_mul_add_new(fresh_r, gamma, orig_r);
+                prover_state.prover_messages(&combined_r);
+            }
+        }
+        config
+            .c_zk_commit
+            .open(&mut prover_state, &[&witness.mask_witness]);
+        let proof = prover_state.proof();
+
+        let mut verifier_state = VerifierState::new_std(&ds, &proof);
+        let commitment = config.receive_commitment(&mut verifier_state).unwrap();
+        assert_rejected(|| config.verify(&mut verifier_state, &commitment, Some(&covector_refs)));
+    }
+
+    #[test]
+    fn test_discharge_roundtrip() {
+        crate::tests::init();
+        proptest!(|(seed: u64, config in Config::<fields::Field64>::arbitrary())| {
+            test_discharge_config(seed, &config);
+        });
+    }
+
+    #[test]
+    fn test_discharge_wrong_claim_rejected() {
+        crate::tests::init();
+        proptest!(|(seed: u64, config in Config::<fields::Field64>::arbitrary())| {
+            test_discharge_wrong_claim_config(seed, &config);
         });
     }
 }

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -21,3 +21,4 @@ pub mod proof_of_work;
 pub mod sumcheck;
 pub mod whir;
 pub mod whir_zk;
+pub mod zook;

--- a/src/protocols/params/adaptive.rs
+++ b/src/protocols/params/adaptive.rs
@@ -1,0 +1,413 @@
+//! Adaptive rate planner.
+//!
+//! Picks per-round `target_log_inv_rate` values by enumerating candidates,
+//! scoring them on a (prover_time_proxy, proof_size_proxy) pareto knee, and
+//! returning the schedule chosen by [`KneeWeight`]. Driven by
+//! [`super::layout::round_layout`] when [`super::spec::RateSchedule::Adaptive`]
+//! is selected.
+
+use std::collections::HashMap;
+
+use crate::{
+    algebra::{
+        embedding::{Embedding, Identity},
+        fields::FieldWithSize,
+    },
+    protocols::{
+        irs_commit::Config as IrsConfig,
+        params::{
+            basecase as basecase_params,
+            branch::{Branch, RoundBuildMode},
+            build_round::{build_mask_oracle, solve_t_ood},
+            code_switch as code_switch_params,
+            error::DeriveError,
+            irs_commit as irs_params,
+            layout::RoundShape,
+            protocol_config::MaskOracleInfo,
+            spec::{KneeWeight, Mode, OodSampleBudget, RoundContext, SecuritySpec, TuningSpec},
+            sumcheck as sumcheck_params,
+        },
+    },
+};
+
+/// Hard cap on `log_inv_rate` searched. Beyond this the codeword would blow
+/// past sane NTT-friendly sizes for typical witnesses.
+const ADAPTIVE_MAX_LOG_INV_RATE: u32 = 20;
+
+/// Real per-IRS dimensions extracted from a built `IrsConfig`. Drives the
+/// cost proxy with NTT-rounded codeword length and the actual decoding-regime
+/// query count — no closed-form approximation.
+#[derive(Clone, Copy, Debug)]
+struct RoundDims {
+    codeword_length: usize,
+    in_domain_samples: usize,
+    interleaving_depth: usize,
+}
+
+/// Fixed per-encode-call overhead in the cost-proxy's nominal units.
+///
+/// Each `interleaved_encode` invocation pays a setup cost (allocator,
+/// roots-table extension, rayon thread fan-out) that's amortized poorly for
+/// small NTTs. The production trace showed sub-ms cold-cache outliers on
+/// 4k-element NTTs that the pure `codeword · log codeword · interleaving`
+/// model wouldn't see. This constant biases the planner against schedules
+/// that fragment work into many small encodes — same direction as proof-size
+/// pressure but for a different reason.
+///
+/// Calibration: at ~1.4 ns / field-op (variable cost) on Apple Silicon,
+/// per-call fixed overhead observed at ~10 μs ≈ 7000 "ops" worth. Round to
+/// 4096 — within an order of magnitude is enough for correct pareto ordering;
+/// the absolute number doesn't matter under log-scale knee normalization.
+const ENCODE_FIXED_OVERHEAD: f64 = 4096.0;
+
+/// NTT/Merkle cost proxy for one encoded IRS. Uses real solver outputs so
+/// per-round NTT smoothness rounding (`12288 = 4096·3` etc.) and per-regime
+/// query counts (Johnson vs Unique vs Capacity) are accurate.
+///
+/// Constants are nominal — pareto ordering is invariant under positive
+/// rescaling of either axis, and the log-knee picker compounds that.
+fn round_cost_from_dims(dims: RoundDims, field_bytes: f64, hash_bytes: f64) -> (f64, f64) {
+    let codeword = dims.codeword_length as f64;
+    let interleaving = dims.interleaving_depth as f64;
+    let queries = dims.in_domain_samples as f64;
+    let log_codeword = codeword.log2().max(1.0);
+
+    let encode = ENCODE_FIXED_OVERHEAD + codeword * log_codeword * interleaving;
+    let proof = queries * (interleaving * field_bytes + log_codeword * hash_bytes);
+    (encode, proof)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Cost {
+    encode: f64,
+    proof: f64,
+}
+
+impl Cost {
+    const ZERO: Self = Self {
+        encode: 0.0,
+        proof: 0.0,
+    };
+    fn add(self, other: (f64, f64)) -> Self {
+        Self {
+            encode: self.encode + other.0,
+            proof: self.proof + other.1,
+        }
+    }
+    fn dominates(self, other: Self) -> bool {
+        self.encode <= other.encode
+            && self.proof <= other.proof
+            && (self.encode < other.encode || self.proof < other.proof)
+    }
+}
+
+/// Bound on how aggressive Adaptive can be at a single round, expressed as a
+/// multiple of the canonical WHIR per-round step `folding − 1` (the increment
+/// [`super::spec::RateSchedule::Stepping`] applies, inherited from legacy
+/// in-place WHIR's stepping invariant). This lets Adaptive explore schedules
+/// slightly more aggressive than the legacy step, gated by the per-candidate
+/// feasibility check. Pure search-space heuristic, not a correctness bound.
+const ADAPTIVE_STEP_BUDGET: u32 = 2;
+
+/// Search per-round target rates that minimize a pareto-knee cost. The
+/// skeleton is fixed (folding factors, message-length sequence); only
+/// `target_log_inv_rate` per round is searched. Each candidate (round,
+/// source_rate, target_rate) is checked against the per-round PoW budget via
+/// the actual analytic-error formulas (memoized) — schedules whose PoW gap
+/// at any round would exceed `pow_budget` are dropped before pareto.
+///
+/// Returns `Err(DeriveError::AdaptiveNoFeasibleSchedule)` if no candidate
+/// passes the per-slot PoW check — the spec is too tight for the planner's
+/// search space.
+pub(super) fn plan_adaptive_rates<M: Embedding + Default>(
+    spec: &SecuritySpec,
+    tuning: &TuningSpec,
+    knee_weight: KneeWeight,
+    skeleton: &[RoundShape],
+    basecase_vector_size: usize,
+    mode: RoundBuildMode<'_>,
+) -> Result<Vec<u32>, DeriveError> {
+    let mut planner: Planner<'_, M> = Planner::new(spec, skeleton, basecase_vector_size, mode);
+    let candidates = planner.search(tuning.starting_log_inv_rate);
+    // No feasible candidates means even the most conservative search choice
+    // (constant rate at every round) failed the per-slot PoW check. The spec
+    // is fundamentally too tight — surface this as a planner-level error
+    // rather than returning placeholder rates that would just fail downstream
+    // validation with a less informative message.
+    if candidates.is_empty() {
+        return Err(DeriveError::AdaptiveNoFeasibleSchedule);
+    }
+    Ok(pick_knee(pareto_frontier(candidates), knee_weight.get()))
+}
+
+/// Adapter that returns `Some(())` when an analytic floor `bits` leaves a
+/// gap small enough for `pow_budget` to close. Used via `?` so a too-low
+/// floor short-circuits the surrounding `_dims` builder.
+fn fits(bits: f64, deficit: f64) -> Option<()> {
+    (bits >= deficit).then_some(())
+}
+
+/// DFS state for the adaptive rate search. Owns the loop-invariants and the
+/// two memoization caches so `recurse` doesn't have to thread a dozen
+/// parameters down each level.
+struct Planner<'a, M> {
+    spec: &'a SecuritySpec,
+    skeleton: &'a [RoundShape],
+    basecase_vector_size: usize,
+    mode: RoundBuildMode<'a>,
+    field_bytes: f64,
+    hash_bytes: f64,
+    /// Memoize per `(round_idx, source_rate, target_rate)`. `Some(dims)` is
+    /// feasible with real IRS dimensions; `None` is infeasible (PoW budget
+    /// can't close the analytic gap).
+    round_cache: HashMap<(usize, u32, u32), Option<RoundDims>>,
+    /// Basecase candidates only vary by rate, so cache separately.
+    basecase_cache: HashMap<u32, Option<RoundDims>>,
+    _m: std::marker::PhantomData<M>,
+}
+
+impl<'a, M: Embedding + Default> Planner<'a, M> {
+    fn new(
+        spec: &'a SecuritySpec,
+        skeleton: &'a [RoundShape],
+        basecase_vector_size: usize,
+        mode: RoundBuildMode<'a>,
+    ) -> Self {
+        Self {
+            spec,
+            skeleton,
+            basecase_vector_size,
+            mode,
+            field_bytes: <M::Target as FieldWithSize>::field_size_bits() / 8.0,
+            hash_bytes: 32.0,
+            round_cache: HashMap::new(),
+            basecase_cache: HashMap::new(),
+            _m: std::marker::PhantomData,
+        }
+    }
+
+    fn search(&mut self, starting_log_inv_rate: u32) -> Vec<(Vec<u32>, Cost)> {
+        let mut out = Vec::new();
+        let mut chosen = Vec::with_capacity(self.skeleton.len());
+        self.recurse(0, starting_log_inv_rate, &mut chosen, Cost::ZERO, &mut out);
+        out
+    }
+
+    fn recurse(
+        &mut self,
+        idx: usize,
+        cur_rate: u32,
+        chosen: &mut Vec<u32>,
+        acc: Cost,
+        out: &mut Vec<(Vec<u32>, Cost)>,
+    ) {
+        // handle basecase
+        if idx == self.skeleton.len() {
+            let spec = self.spec;
+            let vector_size = self.basecase_vector_size;
+            let dims = *self
+                .basecase_cache
+                .entry(cur_rate)
+                .or_insert_with(|| basecase_dims::<M>(spec, vector_size, cur_rate));
+            if let Some(dims) = dims {
+                let (e, p) = round_cost_from_dims(dims, self.field_bytes, self.hash_bytes);
+                out.push((chosen.clone(), acc.add((e, p))));
+            }
+            return;
+        }
+        let shape = self.skeleton[idx];
+        // Per-round step capped at `ADAPTIVE_STEP_BUDGET · (folding − 1)` —
+        // the canonical WHIR per-round increment scaled by the search budget.
+        // Hard cap on absolute rate via `ADAPTIVE_MAX_LOG_INV_RATE`. Each
+        // candidate (src, tgt) is feasibility-checked below; exceeding the
+        // canonical increment is allowed when the PoW budget actually fits.
+        let max_step = shape
+            .source_folding_factor
+            .saturating_sub(1)
+            .saturating_mul(ADAPTIVE_STEP_BUDGET);
+        for delta in 0..=max_step {
+            let next_rate = cur_rate.saturating_add(delta);
+            if next_rate > ADAPTIVE_MAX_LOG_INV_RATE {
+                break;
+            }
+            let spec = self.spec;
+            let mode = self.mode;
+            let dims = *self
+                .round_cache
+                .entry((idx, cur_rate, next_rate))
+                .or_insert_with(|| try_round_dims::<M>(spec, &shape, cur_rate, next_rate, mode));
+            let Some(dims) = dims else { continue };
+            let (e, p) = round_cost_from_dims(dims, self.field_bytes, self.hash_bytes);
+            chosen.push(next_rate);
+            self.recurse(idx + 1, next_rate, chosen, acc.add((e, p)), out);
+            chosen.pop();
+        }
+    }
+}
+
+/// Drop any (schedule, cost) dominated by another. `O(|candidates|²)` —
+/// fine at planner scale.
+fn pareto_frontier(candidates: Vec<(Vec<u32>, Cost)>) -> Vec<(Vec<u32>, Cost)> {
+    let mut frontier: Vec<(Vec<u32>, Cost)> = Vec::new();
+    'outer: for cand in candidates {
+        for f in &frontier {
+            if f.1.dominates(cand.1) {
+                continue 'outer;
+            }
+        }
+        frontier.retain(|f| !cand.1.dominates(f.1));
+        frontier.push(cand);
+    }
+    frontier
+}
+
+/// Weighted log-scale pareto knee. Picks the schedule whose deficit from
+/// per-axis minima — measured in log-space, weighted by `knee_weight` — is
+/// smallest. Log-space normalizes the units mismatch between the
+/// encode/proof proxies (ops vs bytes) and makes the picker invariant to any
+/// constant rescaling of either axis.
+///
+/// `knee_weight ∈ [0, 1]` is the encode-axis bias (see
+/// [`super::spec::KneeWeight`]).
+fn pick_knee(frontier: Vec<(Vec<u32>, Cost)>, knee_weight: f64) -> Vec<u32> {
+    let logs: Vec<(Vec<u32>, f64, f64)> = frontier
+        .into_iter()
+        .map(|(s, c)| (s, c.encode.max(1.0).log2(), c.proof.max(1.0).log2()))
+        .collect();
+    let min_e = logs.iter().map(|f| f.1).fold(f64::INFINITY, f64::min);
+    let min_p = logs.iter().map(|f| f.2).fold(f64::INFINITY, f64::min);
+    let score = |le: f64, lp: f64| {
+        knee_weight * (le - min_e).powi(2) + (1.0 - knee_weight) * (lp - min_p).powi(2)
+    };
+    logs.into_iter()
+        .min_by(|a, b| {
+            score(a.1, a.2)
+                .partial_cmp(&score(b.1, b.2))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .expect("frontier non-empty: candidates non-empty implies frontier non-empty")
+        .0
+}
+
+/// Build the basecase IRS at `cur_rate` and return its dimensions, or `None`
+/// if its analytic floors can't be closed by `pow_budget`.
+fn basecase_dims<M: Embedding + Default>(
+    spec: &SecuritySpec,
+    vector_size: usize,
+    log_inv_rate: u32,
+) -> Option<RoundDims> {
+    let ctx = RoundContext {
+        vector_size,
+        log_inv_rate,
+        folding_factor: 0,
+    };
+    let commit: IrsConfig<Identity<M::Target>> =
+        irs_params::solve(spec, &ctx, OodSampleBudget::ZERO).ok()?;
+
+    let max_deficit = f64::from(spec.target_security_bits) - f64::from(spec.pow_budget.bits());
+
+    fits(
+        f64::from(sumcheck_params::analytic_error_bits(
+            &commit,
+            Option::<MaskOracleInfo>::None,
+        )),
+        max_deficit,
+    )?;
+    if matches!(spec.mode, Mode::ZeroKnowledge) {
+        fits(
+            f64::from(basecase_params::analytic_error_bits(&commit)),
+            max_deficit,
+        )?;
+    }
+
+    Some(RoundDims {
+        codeword_length: commit.codeword_length(),
+        in_domain_samples: commit.in_domain_samples(),
+        interleaving_depth: commit.interleaving_depth(),
+    })
+}
+
+/// Build a round at this (source_rate, target_rate, mode) and return the
+/// **target IRS's** dimensions (`codeword_length`, `in_domain_samples`,
+/// `interleaving_depth`) if every per-slot analytic floor fits inside
+/// `pow_budget`. Returns `None` if any floor is too low — even max grinding
+/// can't close the gap.
+///
+/// The returned dims drive the cost proxy, so the planner uses NTT-rounded
+/// codeword sizes and per-regime query counts — no closed-form approximation.
+fn try_round_dims<M: Embedding + Default>(
+    spec: &SecuritySpec,
+    shape: &RoundShape,
+    source_log_inv_rate: u32,
+    target_log_inv_rate: u32,
+    mode: RoundBuildMode<'_>,
+) -> Option<RoundDims> {
+    let max_deficit = f64::from(spec.target_security_bits) - f64::from(spec.pow_budget.bits());
+
+    let src_ctx = RoundContext {
+        vector_size: shape.source_vector_size,
+        log_inv_rate: source_log_inv_rate,
+        folding_factor: shape.source_folding_factor,
+    };
+    let target_log_degree = f64::from(
+        shape
+            .source_vector_size
+            .trailing_zeros()
+            .saturating_sub(shape.source_folding_factor),
+    );
+    let target_list_size = spec
+        .decoding_regime
+        .list_size_estimate(target_log_degree, f64::from(target_log_inv_rate));
+
+    let ood_mode = mode.map(|p| p.c_zk_log_inv_rate);
+    let (source, t_ood) = solve_t_ood::<M>(spec, &src_ctx, target_list_size, ood_mode, 0).ok()?;
+
+    let target_budget = match mode {
+        Branch::Standard => OodSampleBudget::ZERO,
+        Branch::ZeroKnowledge(_) => OodSampleBudget::new(t_ood),
+    };
+    let tgt_ctx = RoundContext {
+        vector_size: source.message_length(),
+        log_inv_rate: target_log_inv_rate,
+        folding_factor: shape.target_folding_factor,
+    };
+    let target_irs: IrsConfig<Identity<M::Target>> =
+        irs_params::solve(spec, &tgt_ctx, target_budget).ok()?;
+
+    let mask_info = match mode {
+        Branch::Standard => None,
+        Branch::ZeroKnowledge(payload) => {
+            let mo = build_mask_oracle::<M>(
+                payload.zk_spec,
+                &src_ctx,
+                &source,
+                t_ood,
+                payload.c_zk_log_inv_rate,
+                shape.round_index,
+            )
+            .ok()?;
+            fits(f64::from(mo.analytic_bits()), max_deficit)?;
+            Some(mo.info())
+        }
+    };
+
+    fits(
+        f64::from(sumcheck_params::analytic_error_bits(&source, mask_info)),
+        max_deficit,
+    )?;
+    fits(
+        f64::from(code_switch_params::analytic_error_bits(
+            &source,
+            &target_irs,
+            t_ood,
+            mask_info,
+        )),
+        max_deficit,
+    )?;
+
+    Some(RoundDims {
+        codeword_length: target_irs.codeword_length(),
+        in_domain_samples: target_irs.in_domain_samples(),
+        interleaving_depth: target_irs.interleaving_depth(),
+    })
+}

--- a/src/protocols/params/basecase.rs
+++ b/src/protocols/params/basecase.rs
@@ -33,6 +33,20 @@ pub fn solve<F: Field>(
         folding_factor: 0,
     };
     let commit = irs_params::solve(spec, &ctx, OodSampleBudget::ZERO)?;
+    solve_with_commit(spec, commit)
+}
+
+/// Same as [`solve`] but with a pre-built IRS config — used by `derive` when
+/// the last round's `code_switch.target` is being reused as the basecase
+/// commit (Phase 2: no recommit of the folded message). The shared IRS is
+/// built once at the previous-round layer; this function only owns the
+/// basecase-specific sumcheck + γ-combination PoW grind.
+pub fn solve_with_commit<F: Field>(
+    spec: &SecuritySpec,
+    commit: IrsConfig<Identity<F>>,
+) -> Result<BasecasePlan<F>, DeriveError> {
+    let vector_size = commit.vector_size();
+    assert!(vector_size > 0, "basecase requires vector_size ≥ 1");
 
     let sumcheck_analytic = sumcheck_params::analytic_error_bits(&commit, None);
     let sumcheck_pow = grind_to_at(spec, sumcheck_analytic, Pow::BasecaseSumcheck)?;

--- a/src/protocols/params/build_round.rs
+++ b/src/protocols/params/build_round.rs
@@ -51,13 +51,11 @@ pub(super) fn build_round_config<M: Embedding + Default>(
             zk_spec,
             c_zk_log_inv_rate,
         }) => {
-            let num_masks =
-                sumcheck_params::masks_required(&ctx) + code_switch_params::masks_required();
             let mask_oracle = build_mask_oracle::<M>(
                 zk_spec,
+                &ctx,
                 &source,
                 t_ood,
-                num_masks,
                 c_zk_log_inv_rate,
                 shape.round_index,
             )?;
@@ -101,11 +99,13 @@ fn solve_round_source<M: Embedding + Default>(
     ood_mode: OodMode,
 ) -> Result<(IrsConfig<M>, usize), DeriveError> {
     let src_ctx = round_context(shape);
-    let target_log_inv_rate = f64::from(
-        shape
-            .source_log_inv_rate
-            .saturating_add(shape.source_folding_factor.saturating_sub(1)),
-    );
+    // Use the rate the layout planner picked for this round's target IRS —
+    // `RateSchedule::{Capped, Adaptive}` may deviate from the unbounded
+    // `Stepping` formula (`source + folding − 1`). Recomputing inline here
+    // would silently disagree with `target_context`'s view, and the t_ood
+    // search would solve for a different target list size than the IRS the
+    // round actually builds.
+    let target_log_inv_rate = f64::from(shape.target_log_inv_rate);
     let target_log_degree = f64::from(
         shape
             .source_vector_size
@@ -124,38 +124,62 @@ fn solve_round_source<M: Embedding + Default>(
     )
 }
 
-/// ZK-only: assemble the per-round mask oracle (C_zk codeword + mask-proximity
-/// check).
-fn build_mask_oracle<M: Embedding>(
+/// ZK-only: assemble the per-round mask oracle, splitting masks across a
+/// `sumcheck_masks` tree (committed BEFORE sumcheck) and a `cs_mask` tree
+/// (committed AFTER sumcheck). Both trees use the same C_zk code rate.
+pub(super) fn build_mask_oracle<M: Embedding>(
     zk_spec: ZkSpec<'_>,
+    ctx: &RoundContext,
     source: &IrsConfig<M>,
     t_ood: usize,
-    num_masks: usize,
     c_zk_log_inv_rate: LogInvRate,
     round_index: usize,
 ) -> Result<MaskOracleConfig<M::Target>, DeriveError> {
     let spec = zk_spec.as_inner();
+    let k = sumcheck_params::masks_required(ctx);
+    let cs_masks = code_switch_params::masks_required();
     let l_zk = compute_l_zk(source, t_ood);
-    let c_zk: IrsConfig<Identity<M::Target>> = irs_params::solve_mask_code(
+
+    // Sumcheck-masks tree: tiny vector size (next_pow2(3) = 4), no padding to ℓ_zk.
+    let sumcheck_mask_vec_size =
+        MaskCodeMessageLen::new(sumcheck_params::zk_mask_length().get().next_power_of_two());
+    let sumcheck_c_zk: IrsConfig<Identity<M::Target>> = irs_params::solve_mask_code(
+        zk_spec,
+        sumcheck_mask_vec_size,
+        0,
+        c_zk_log_inv_rate,
+        MaskProximityConfig::<M::Target>::num_vectors_for(k),
+    )?;
+
+    // cs_mask tree: vector_size = ℓ_zk, holds the `(r ‖ s)` mask.
+    let cs_c_zk: IrsConfig<Identity<M::Target>> = irs_params::solve_mask_code(
         zk_spec,
         l_zk,
         source.mask_length(),
         c_zk_log_inv_rate,
-        MaskProximityConfig::<M::Target>::num_vectors_for(num_masks),
+        MaskProximityConfig::<M::Target>::num_vectors_for(cs_masks),
     )?;
+
     let c_zk_list_size_estimate = spec.decoding_regime.list_size_estimate(
         (l_zk.get() as f64).log2(),
         f64::from(c_zk_log_inv_rate.get()),
     );
     debug_assert!(
-        (c_zk.list_size() - c_zk_list_size_estimate).abs()
+        (cs_c_zk.list_size() - c_zk_list_size_estimate).abs()
             < 1e-9 * c_zk_list_size_estimate.max(1.0),
-        "c_zk.list_size() {} drifted from planner estimate {}",
-        c_zk.list_size(),
+        "cs_c_zk.list_size() {} drifted from planner estimate {}",
+        cs_c_zk.list_size(),
         c_zk_list_size_estimate,
     );
-    let mask_proximity = mask_proximity_params::solve(spec, c_zk.clone(), num_masks, round_index)?;
-    Ok(MaskOracleConfig::new(c_zk, l_zk, mask_proximity))
+
+    let sumcheck_masks = mask_proximity_params::solve(spec, sumcheck_c_zk, k, round_index)?;
+    let cs_mask = mask_proximity_params::solve(spec, cs_c_zk, cs_masks, round_index)?;
+    Ok(MaskOracleConfig::new(
+        sumcheck_masks,
+        cs_mask,
+        l_zk,
+        OodSampleBudget::new(t_ood),
+    ))
 }
 
 /// `ℓ_zk = next_pow2(r + t_ood)` (Theorem 9.6 + Lemma 9.3).

--- a/src/protocols/params/derive.rs
+++ b/src/protocols/params/derive.rs
@@ -17,25 +17,43 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
     /// Fails with [`DeriveError`] when the spec/tuning combination is
     /// infeasible.
     pub fn derive(spec: SecuritySpec, tuning: TuningSpec) -> Result<Self, DeriveError> {
+        let mode: RoundBuildMode<'_> = spec.as_zk().map_or(Branch::Standard, |zk_spec| {
+            Branch::ZeroKnowledge(RoundBuildPayload {
+                zk_spec,
+                // Hardcoded to 2^-4 to decouple the C_zk code rate from the
+                // message rate. The mask-proximity γ-combination discharge
+                // (Lemma 7.4 slot) needs headroom in |Λ(C_zk, δ_zk)|, and
+                // tightening to `tuning.starting_log_inv_rate` (which is set
+                // by the witness rate, not the C_zk rate) shrinks that
+                // headroom unpredictably. Adaptive schedules can still tune
+                // the witness side without touching C_zk.
+                c_zk_log_inv_rate: LogInvRate::new(4),
+            })
+        });
+
         let RoundLayout {
             shapes,
             basecase_vector_size,
             basecase_log_inv_rate,
-        } = round_layout(&tuning)?;
-
-        let mode: RoundBuildMode<'_> = spec.as_zk().map_or(Branch::Standard, |zk_spec| {
-            Branch::ZeroKnowledge(RoundBuildPayload {
-                zk_spec,
-                c_zk_log_inv_rate: LogInvRate::new(tuning.starting_log_inv_rate),
-            })
-        });
+        } = round_layout::<M>(&spec, &tuning, mode)?;
 
         let rounds: Vec<RoundConfig<M>> = shapes
             .iter()
             .map(|shape| build_round_config::<M>(&spec, shape, mode))
             .collect::<Result<_, _>>()?;
 
-        let basecase = basecase_params::solve(&spec, basecase_vector_size, basecase_log_inv_rate)?;
+        // When at least one round exists, the last round's `code_switch.target`
+        // is exactly the IRS that holds the folded basecase message — it has
+        // `interleaving_depth = 1` thanks to the override in `round_layout`.
+        // Build basecase around that same IRS so `zook::prove` can pass the
+        // existing witness directly to `basecase.prove` without re-encoding.
+        // PoW (sumcheck + γ-combination) is re-solved against the swapped
+        // IRS so analytic + PoW still meets the security target.
+        let basecase = if let Some(last) = rounds.last() {
+            basecase_params::solve_with_commit(&spec, last.code_switch().target().clone())?
+        } else {
+            basecase_params::solve(&spec, basecase_vector_size, basecase_log_inv_rate)?
+        };
 
         let plan = Self::new(spec, tuning, rounds, basecase);
         plan.validate()?;
@@ -57,7 +75,10 @@ mod tests {
             params::{
                 error::{ChainSource, ChainTarget, DeriveError, Pow},
                 protocol_config::{ProtocolConfig, RoundMode},
-                spec::{DecodingRegime, FoldingFactor, Mode, PowBudget, SecuritySpec, TuningSpec},
+                spec::{
+                    DecodingRegime, FoldingFactor, KneeWeight, Mode, PowBudget, RateSchedule,
+                    SecuritySpec, TuningSpec,
+                },
                 test_utils::{assert_close, assert_pow_closes_gap, TestEmbedding},
             },
         },
@@ -70,13 +91,23 @@ mod tests {
                 FoldingFactor::ConstantFromSecondRound { initial, rest }
             }),
         ];
-        (4u32..=8, 1u32..=3, folding).prop_map(|(log_size, log_inv_rate, folding_factor)| {
-            TuningSpec {
+        // Mix the three RateSchedule variants so proptest covers Capped and
+        // Adaptive code paths, not just Stepping.
+        let schedule = prop_oneof![
+            Just(RateSchedule::Stepping),
+            (4u32..=10).prop_map(|max_log_inv_rate| RateSchedule::Capped { max_log_inv_rate }),
+            Just(RateSchedule::Adaptive {
+                knee_weight: KneeWeight::DEFAULT,
+            }),
+        ];
+        (4u32..=8, 1u32..=3, folding, schedule).prop_map(
+            |(log_size, log_inv_rate, folding_factor, rate_schedule)| TuningSpec {
                 vector_size: 1usize << log_size,
                 starting_log_inv_rate: log_inv_rate,
                 folding_factor,
-            }
-        })
+                rate_schedule,
+            },
+        )
     }
 
     const FIXTURE_FOLDING_FACTOR: usize = 2;
@@ -90,6 +121,7 @@ mod tests {
             vector_size,
             starting_log_inv_rate: FIXTURE_LOG_INV_RATE,
             folding_factor: FoldingFactor::Constant(FIXTURE_FOLDING_FACTOR),
+            rate_schedule: RateSchedule::Stepping,
         }
     }
 
@@ -181,8 +213,19 @@ mod tests {
                 .source()
                 .interleaving_depth()
                 .trailing_zeros() as usize;
-            let expected_num_masks = k + 1;
-            assert_eq!(mask_oracle.c_zk().num_vectors(), 2 * expected_num_masks);
+            // Split-tree mask oracle: sumcheck tree carries the `k` sumcheck
+            // masks (2·k vectors after originals + freshes); cs_mask tree
+            // carries the single `(r ‖ s)` code-switch mask (2 vectors).
+            assert_eq!(
+                mask_oracle.sumcheck_masks().c_zk_commit().num_vectors(),
+                2 * k,
+                "sumcheck_masks tree must carry 2·k originals+freshes",
+            );
+            assert_eq!(
+                mask_oracle.cs_mask().c_zk_commit().num_vectors(),
+                2,
+                "cs_mask tree carries one (r ‖ s) mask + its fresh pair",
+            );
         }
     }
 
@@ -426,6 +469,206 @@ mod tests {
     }
 
     #[test]
+    fn validate_security_target_met_catches_zeroed_basecase_pow() {
+        // ZK basecase has a γ-combination PoW slot whose analytic floor is
+        // below the security target under the test fixture. Wiping the PoW
+        // must trip `validate_security_target_met`.
+        use crate::{bits::Bits, protocols::proof_of_work::Config as PowConfig};
+        let spec = test_spec(Mode::ZeroKnowledge);
+        let mut plan = ProtocolConfig::<TestEmbedding>::derive(
+            spec,
+            tuning_with(1 << LOG_VECTOR_SIZE_MULTI_ROUND),
+        )
+        .unwrap();
+        assert!(
+            plan.check_all_invariants(),
+            "fresh plan must validate including soundness"
+        );
+
+        // Skip the test if this fixture's basecase γ-combination doesn't
+        // actually require PoW (i.e., analytic ≥ target already). Otherwise
+        // force a violation by zeroing the basecase PoW.
+        let pre_pow = plan.basecase().pow().difficulty();
+        if f64::from(pre_pow) == 0.0 {
+            return;
+        }
+
+        plan.override_basecase_pow_for_test(PowConfig::from_difficulty(Bits::new(0.0)));
+        let err = plan
+            .validate_security_target_met()
+            .expect_err("zeroed γ-combination PoW must trip soundness validation");
+        assert!(
+            matches!(
+                err,
+                DeriveError::SecurityTargetNotMet {
+                    pow: Pow::BasecaseGammaCombination,
+                    ..
+                }
+            ),
+            "got {err:?}",
+        );
+    }
+
+    /// Adaptive plan must validate end-to-end across modes and produce a
+    /// strictly less aggressive rate schedule than the unbounded `Stepping`
+    /// baseline at the tail.
+    #[test]
+    fn adaptive_plan_validates_and_caps_tail_rate() {
+        for mode in [Mode::Standard, Mode::ZeroKnowledge] {
+            let spec = test_spec(mode);
+            let tuning = TuningSpec {
+                vector_size: 1 << LOG_VECTOR_SIZE_MULTI_ROUND,
+                starting_log_inv_rate: FIXTURE_LOG_INV_RATE,
+                folding_factor: FoldingFactor::Constant(FIXTURE_FOLDING_FACTOR),
+                rate_schedule: RateSchedule::Adaptive {
+                    knee_weight: KneeWeight::DEFAULT,
+                },
+            };
+            let plan =
+                ProtocolConfig::<TestEmbedding>::derive(spec.clone(), tuning.clone()).unwrap();
+            assert!(
+                plan.check_all_invariants(),
+                "Adaptive plan must satisfy validate() in mode={mode:?}"
+            );
+
+            // Unbounded `Stepping` is the maximally-aggressive baseline (the
+            // canonical WHIR step-forever schedule). Adaptive should never
+            // propose a schedule whose basecase rate exceeds it — that's the
+            // whole point: Adaptive may stop growing rate earlier.
+            let unbounded = ProtocolConfig::<TestEmbedding>::derive(
+                spec,
+                TuningSpec {
+                    rate_schedule: RateSchedule::Stepping,
+                    ..tuning
+                },
+            )
+            .unwrap();
+            assert!(
+                plan.basecase().commit().rate() >= unbounded.basecase().commit().rate(),
+                "Adaptive basecase rate ({}) must be ≥ unbounded baseline's ({}) — \
+                 Adaptive should pick a *smaller* `1/ρ` at the tail",
+                plan.basecase().commit().rate(),
+                unbounded.basecase().commit().rate(),
+            );
+        }
+    }
+
+    /// When rounds exist, basecase IRS must equal the last round's
+    /// `code_switch.target` IRS — `zook::prove` skips re-encoding the folded
+    /// message at basecase entry.
+    #[test]
+    fn basecase_irs_aliases_last_round_target_when_rounds_present() {
+        for mode in [Mode::Standard, Mode::ZeroKnowledge] {
+            let spec = test_spec(mode);
+            for schedule in [
+                RateSchedule::Stepping,
+                RateSchedule::Capped {
+                    max_log_inv_rate: 6,
+                },
+                RateSchedule::Adaptive {
+                    knee_weight: KneeWeight::DEFAULT,
+                },
+            ] {
+                let tuning = TuningSpec {
+                    vector_size: 1 << LOG_VECTOR_SIZE_MULTI_ROUND,
+                    starting_log_inv_rate: FIXTURE_LOG_INV_RATE,
+                    folding_factor: FoldingFactor::Constant(FIXTURE_FOLDING_FACTOR),
+                    rate_schedule: schedule,
+                };
+                let plan = ProtocolConfig::<TestEmbedding>::derive(spec.clone(), tuning).unwrap();
+                assert!(!plan.rounds().is_empty(), "fixture must have rounds");
+                let last_target = plan.rounds().last().unwrap().code_switch().target();
+                let basecase_commit = plan.basecase().commit();
+                assert_eq!(
+                    last_target, basecase_commit,
+                    "basecase.commit must alias the last round's code_switch.target — \
+                     mode={mode:?} schedule={schedule:?}",
+                );
+                assert_eq!(basecase_commit.interleaving_depth(), 1);
+            }
+        }
+    }
+
+    #[test]
+    fn derive_with_capped_rate_shrinks_basecase_codeword() {
+        // Same shape that historically inflates basecase via rate stepping:
+        // ~2^20 witness, folding 3, 5 rounds → stepped log_inv_rate ≈ 12.
+        const LOG_VECTOR_SIZE: u32 = 12;
+        let spec = test_spec(Mode::ZeroKnowledge);
+        let folding = FoldingFactor::Constant(3);
+
+        let stepped_tuning = TuningSpec {
+            vector_size: 1usize << LOG_VECTOR_SIZE,
+            starting_log_inv_rate: 2,
+            folding_factor: folding,
+            rate_schedule: RateSchedule::Stepping,
+        };
+        let stepped_plan =
+            ProtocolConfig::<TestEmbedding>::derive(spec.clone(), stepped_tuning).unwrap();
+
+        let capped_tuning = TuningSpec {
+            vector_size: 1usize << LOG_VECTOR_SIZE,
+            starting_log_inv_rate: 2,
+            folding_factor: folding,
+            rate_schedule: RateSchedule::Capped {
+                max_log_inv_rate: 4,
+            },
+        };
+        let capped_plan = ProtocolConfig::<TestEmbedding>::derive(spec, capped_tuning).unwrap();
+
+        // Same number of rounds — cap only affects per-round rate, not layout shape.
+        assert_eq!(stepped_plan.rounds().len(), capped_plan.rounds().len());
+        // Cap forces a strictly smaller basecase codeword (the saving we're after).
+        let stepped_codeword = stepped_plan.basecase().commit().codeword_length();
+        let capped_codeword = capped_plan.basecase().commit().codeword_length();
+        assert!(
+            capped_codeword < stepped_codeword,
+            "capped basecase codeword ({capped_codeword}) should be smaller than stepped \
+             ({stepped_codeword})",
+        );
+        // For this fixture the cap should produce at least a 4× reduction.
+        assert!(
+            capped_codeword * 4 <= stepped_codeword,
+            "expected ≥4× reduction; got stepped={stepped_codeword}, capped={capped_codeword}",
+        );
+    }
+
+    /// Adaptive must not be worse than the unbounded-`Stepping` baseline on
+    /// basecase NTT work for the folding-3 / 2^12 ZK fixture that historically
+    /// inflates basecase via unbounded rate stepping. At minimum, Adaptive's
+    /// basecase codeword must be ≤ the baseline's.
+    #[test]
+    fn adaptive_basecase_no_worse_than_unbounded_on_inflating_fixture() {
+        const LOG_VECTOR_SIZE: u32 = 12;
+        let spec = test_spec(Mode::ZeroKnowledge);
+        let base = TuningSpec {
+            vector_size: 1usize << LOG_VECTOR_SIZE,
+            starting_log_inv_rate: 2,
+            folding_factor: FoldingFactor::Constant(3),
+            rate_schedule: RateSchedule::Stepping,
+        };
+        let unbounded =
+            ProtocolConfig::<TestEmbedding>::derive(spec.clone(), base.clone()).unwrap();
+        let adaptive = ProtocolConfig::<TestEmbedding>::derive(
+            spec,
+            TuningSpec {
+                rate_schedule: RateSchedule::Adaptive {
+                    knee_weight: KneeWeight::DEFAULT,
+                },
+                ..base
+            },
+        )
+        .unwrap();
+        let unbounded_basecode = unbounded.basecase().commit().codeword_length();
+        let adaptive_basecode = adaptive.basecase().commit().codeword_length();
+        assert!(
+            adaptive_basecode <= unbounded_basecode,
+            "Adaptive basecase codeword ({adaptive_basecode}) must be ≤ unbounded \
+             baseline's ({unbounded_basecode})",
+        );
+    }
+
+    #[test]
     fn derive_reports_pow_ungrindable() {
         const UNREACHABLE_TARGET_BITS: u32 = 200;
         let spec = SecuritySpec {
@@ -526,7 +769,7 @@ mod tests {
         assert!(!plan.rounds().is_empty(), "expected multi-round plan");
         for r in plan.rounds() {
             let mo = r.mask_oracle().expect("ZK round must own a mask oracle");
-            assert!(mo.c_zk().unique_decoding());
+            assert!(mo.cs_mask().c_zk_commit().unique_decoding());
             assert!(r.code_switch().source().unique_decoding());
             assert!(r.code_switch().out_domain_samples() >= 1);
         }
@@ -629,9 +872,9 @@ mod tests {
                 };
                 let cs = r.code_switch();
                 let k = cs.source().interleaving_depth().trailing_zeros() as usize;
-                let num_masks = k + 1;
-                prop_assert_eq!(mask_oracle.c_zk().num_vectors(), 2 * num_masks);
-                prop_assert_eq!(mask_oracle.mask_proximity().num_masks(), num_masks);
+                // Split-tree mask oracle: sumcheck tree has 2·k vectors, cs tree has 2.
+                prop_assert_eq!(mask_oracle.sumcheck_masks().c_zk_commit().num_vectors(), 2 * k);
+                prop_assert_eq!(mask_oracle.cs_mask().c_zk_commit().num_vectors(), 2);
                 let source_mask = cs.source().mask_length();
                 prop_assert!(mask_oracle.l_zk().get() >= source_mask + t_ood.get());
             }

--- a/src/protocols/params/derive.rs
+++ b/src/protocols/params/derive.rs
@@ -143,6 +143,19 @@ mod tests {
     }
 
     #[test]
+    fn protocol_config_json_roundtrip() {
+        let spec = test_spec(Mode::Standard);
+        let vector_size = 1usize << LOG_VECTOR_SIZE_NO_ROUNDS;
+        let plan = ProtocolConfig::<TestEmbedding>::derive(spec, tuning_with(vector_size)).unwrap();
+
+        let json = serde_json::to_string(&plan).unwrap();
+        let decoded: ProtocolConfig<TestEmbedding> = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, plan);
+        assert!(decoded.check_all_invariants());
+    }
+
+    #[test]
     fn derive_zk_with_no_rounds_uses_zk_basecase_only() {
         let spec = test_spec(Mode::ZeroKnowledge);
         let plan = ProtocolConfig::<TestEmbedding>::derive(

--- a/src/protocols/params/derive.rs
+++ b/src/protocols/params/derive.rs
@@ -1,7 +1,7 @@
 //! Derives a [`ProtocolConfig`] from a spec + tuning.
 
 use crate::{
-    algebra::embedding::Embedding,
+    algebra::embedding::{Embedding, Identity},
     protocols::params::{
         basecase as basecase_params,
         branch::{Branch, RoundBuildMode, RoundBuildPayload},
@@ -37,9 +37,16 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
             basecase_log_inv_rate,
         } = round_layout::<M>(&spec, &tuning, mode)?;
 
-        let rounds: Vec<RoundConfig<M>> = shapes
-            .iter()
+        // Round 0 carries the base→ext embedding `M`; every later round runs
+        // ext→ext on the code-switch output, so it is built over
+        // `Identity<M::Target>`.
+        let mut shape_iter = shapes.iter();
+        let first_round: Option<RoundConfig<M>> = shape_iter
+            .next()
             .map(|shape| build_round_config::<M>(&spec, shape, mode))
+            .transpose()?;
+        let tail_rounds: Vec<RoundConfig<Identity<M::Target>>> = shape_iter
+            .map(|shape| build_round_config::<Identity<M::Target>>(&spec, shape, mode))
             .collect::<Result<_, _>>()?;
 
         // When at least one round exists, the last round's `code_switch.target`
@@ -49,13 +56,21 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
         // existing witness directly to `basecase.prove` without re-encoding.
         // PoW (sumcheck + γ-combination) is re-solved against the swapped
         // IRS so analytic + PoW still meets the security target.
-        let basecase = if let Some(last) = rounds.last() {
-            basecase_params::solve_with_commit(&spec, last.code_switch().target().clone())?
+        let last_target = tail_rounds
+            .last()
+            .map(|last| last.code_switch().target().clone())
+            .or_else(|| {
+                first_round
+                    .as_ref()
+                    .map(|last| last.code_switch().target().clone())
+            });
+        let basecase = if let Some(target) = last_target {
+            basecase_params::solve_with_commit(&spec, target)?
         } else {
             basecase_params::solve(&spec, basecase_vector_size, basecase_log_inv_rate)?
         };
 
-        let plan = Self::new(spec, tuning, rounds, basecase);
+        let plan = Self::new(spec, tuning, first_round, tail_rounds, basecase);
         plan.validate()?;
         Ok(plan)
     }

--- a/src/protocols/params/error.rs
+++ b/src/protocols/params/error.rs
@@ -154,6 +154,16 @@ pub enum DeriveError {
         recorded: Bits,
         recompute: Bits,
     },
+
+    /// `RateSchedule::Adaptive` could not find any per-slot-feasible rate
+    /// schedule under the current spec. The pareto search exhausted its
+    /// candidates without any surviving the per-round PoW budget check.
+    #[error(
+        "adaptive rate planner found no feasible schedule under pow_budget; \
+         raise pow_budget, lower target_security_bits, or use \
+         RateSchedule::Capped/Stepping with a manual cap"
+    )]
+    AdaptiveNoFeasibleSchedule,
 }
 
 impl From<CodewordLengthError> for DeriveError {

--- a/src/protocols/params/irs_commit.rs
+++ b/src/protocols/params/irs_commit.rs
@@ -18,6 +18,13 @@ use crate::{
     },
 };
 
+/// Convergence cap for the mask-length / effective-rate fixpoint in [`solve`].
+/// Lemma 9.5 requires `mask_length ≥ in_domain_samples + t_ood`. Both sides
+/// move with each iteration (mask drives codeword sizing → effective rate →
+/// in-domain query count), but `next_order` rounding bounds the shift; the
+/// loop converges in 1-2 iterations under all production specs.
+const SOLVE_MAX_ITER: usize = 4;
+
 pub fn solve<M: Embedding + Default>(
     spec: &SecuritySpec,
     ctx: &RoundContext,
@@ -27,30 +34,45 @@ pub fn solve<M: Embedding + Default>(
     let rate = rate(f64::from(ctx.log_inv_rate));
     let interleaving_depth = 1_usize << ctx.folding_factor;
 
-    let mode = match spec.mode {
-        Mode::Standard => IrsMode::Standard,
-        Mode::ZeroKnowledge => {
-            let mask_length = num_in_domain_queries(spec.decoding_regime, security_target, rate)
-                .saturating_add(out_domain_samples.get());
-            IrsMode::ZeroKnowledge { mask_length }
-        }
+    let build = |mode: IrsMode| -> Result<IrsConfig<M>, DeriveError> {
+        Ok(IrsConfig::try_new(IrsParams {
+            security_target,
+            decoding_regime: spec.decoding_regime,
+            hash_id: spec.hash_id,
+            num_vectors: 1,
+            vector_size: ctx.vector_size,
+            interleaving_depth,
+            rate,
+            mode,
+        })?)
     };
 
-    Ok(IrsConfig::try_new(IrsParams {
-        security_target,
-        decoding_regime: spec.decoding_regime,
-        hash_id: spec.hash_id,
-        num_vectors: 1,
-        vector_size: ctx.vector_size,
-        interleaving_depth,
-        rate,
-        mode,
-    })?)
+    if matches!(spec.mode, Mode::Standard) {
+        return build(IrsMode::Standard);
+    }
+
+    // ZK mode: Lemma 9.5 requires `mask_length ≥ in_domain + OOD`.
+    // `in_domain_samples` is computed inside `IrsConfig::try_new` from the
+    // codeword's *effective* rate (which depends on `mask_length` via
+    // `masked_message_length`). Iterate to align the two: pick a mask, build
+    // the config, check whether the effective in_domain exceeds the assumed
+    // query count, and grow if needed. Converges in 1-2 iterations because
+    // rate shifts are small.
+    let mut q = num_in_domain_queries(spec.decoding_regime, security_target, rate);
+    for _ in 0..SOLVE_MAX_ITER {
+        let mask_length = q.saturating_add(out_domain_samples.get());
+        let cfg = build(IrsMode::ZeroKnowledge { mask_length })?;
+        if cfg.in_domain_samples() <= q.get() {
+            return Ok(cfg);
+        }
+        q = std::num::NonZeroUsize::new(cfg.in_domain_samples()).expect("in_domain ≥ 1");
+    }
+    panic!("mask / effective-rate fixpoint did not converge in {SOLVE_MAX_ITER} iterations");
 }
 
 /// Shared C_zk IRS config for mask polynomials.
 ///
-/// - `l_zk`: message length, must be a power of 2.
+/// - `l_zk`: message length (`ℓ_zk` in the paper), must be a power of 2.
 /// - `source_mask_length`: `r` from Theorem 9.6.
 /// - `num_vectors`: `2 * num_masks` (Construction 7.2: originals + fresh).
 pub fn solve_mask_code<M: Embedding + Default>(

--- a/src/protocols/params/layout.rs
+++ b/src/protocols/params/layout.rs
@@ -11,7 +11,12 @@ use crate::{
     algebra::embedding::Embedding,
     protocols::{
         irs_commit::Config as IrsConfig,
-        params::spec::{RoundContext, TuningSpec},
+        params::{
+            adaptive::plan_adaptive_rates,
+            branch::RoundBuildMode,
+            error::DeriveError,
+            spec::{RateSchedule, RoundContext, SecuritySpec, TuningSpec},
+        },
     },
 };
 
@@ -38,6 +43,11 @@ pub(super) struct RoundShape {
     pub(super) source_log_inv_rate: u32,
     pub(super) source_folding_factor: u32,
     pub(super) target_folding_factor: u32,
+    /// Per-round inverse rate for this round's `code_switch.target` IRS.
+    /// Equal to `RateSchedule::step(source_log_inv_rate, source_folding_factor)`
+    /// for `Stepping` / `Capped`; overwritten by [`plan_adaptive_rates`] for
+    /// `Adaptive`.
+    pub(super) target_log_inv_rate: u32,
 }
 
 #[derive(Debug)]
@@ -47,15 +57,20 @@ pub(super) struct RoundLayout {
     pub(super) basecase_log_inv_rate: u32,
 }
 
-pub(super) fn round_layout(tuning: &TuningSpec) -> Result<RoundLayout, LayoutError> {
+pub(super) fn round_layout<M: Embedding + Default>(
+    spec: &SecuritySpec,
+    tuning: &TuningSpec,
+    mode: RoundBuildMode<'_>,
+) -> Result<RoundLayout, DeriveError> {
     if !tuning.vector_size.is_power_of_two() {
         return Err(LayoutError::VectorSizeNotPowerOfTwo {
             vector_size: tuning.vector_size,
-        });
+        }
+        .into());
     }
     let min_folding = tuning.folding_factor.min();
     if min_folding < 1 {
-        return Err(LayoutError::FoldingFactorBelowOne { min: min_folding });
+        return Err(LayoutError::FoldingFactorBelowOne { min: min_folding }.into());
     }
 
     let mut num_vars = tuning.vector_size.trailing_zeros() as usize;
@@ -69,21 +84,61 @@ pub(super) fn round_layout(tuning: &TuningSpec) -> Result<RoundLayout, LayoutErr
         if num_vars < source_folding.saturating_add(target_folding) {
             break;
         }
+        let target_log_inv_rate = tuning
+            .rate_schedule
+            .step(log_inv_rate, source_folding as u32);
         shapes.push(RoundShape {
             round_index: round,
             source_vector_size: 1usize << num_vars,
             source_log_inv_rate: log_inv_rate,
             source_folding_factor: source_folding as u32,
             target_folding_factor: target_folding as u32,
+            target_log_inv_rate,
         });
         num_vars = num_vars.saturating_sub(source_folding);
-        log_inv_rate = log_inv_rate.saturating_add((source_folding as u32).saturating_sub(1));
+        log_inv_rate = target_log_inv_rate;
+    }
+
+    let basecase_vector_size = 1usize << num_vars;
+    // Adaptive: replace stepped per-round rates with the pareto-knee schedule.
+    // `plan_adaptive_rates` returns one rate per round (= per-round target) and
+    // an additional basecase rate is taken from the final entry.
+    let basecase_log_inv_rate = match tuning.rate_schedule {
+        RateSchedule::Adaptive { knee_weight } if !shapes.is_empty() => {
+            let new_rates = plan_adaptive_rates::<M>(
+                spec,
+                tuning,
+                knee_weight,
+                &shapes,
+                basecase_vector_size,
+                mode,
+            )?;
+            for (shape, &t) in shapes.iter_mut().zip(&new_rates) {
+                shape.target_log_inv_rate = t;
+            }
+            for i in 1..shapes.len() {
+                shapes[i].source_log_inv_rate = shapes[i - 1].target_log_inv_rate;
+            }
+            *new_rates
+                .last()
+                .expect("non-empty rounds → non-empty rates")
+        }
+        _ => log_inv_rate,
+    };
+
+    // Force the last round's target IRS to interleaving = 1 so it can serve
+    // directly as the basecase commit — eliminates the recommit of the folded
+    // message in `zook::prove`. `target_folding_factor` only affects the
+    // target IRS shape (it's a hint about the next round's source-folding,
+    // and there is no next round here).
+    if let Some(last) = shapes.last_mut() {
+        last.target_folding_factor = 0;
     }
 
     Ok(RoundLayout {
         shapes,
-        basecase_vector_size: 1usize << num_vars,
-        basecase_log_inv_rate: log_inv_rate,
+        basecase_vector_size,
+        basecase_log_inv_rate,
     })
 }
 
@@ -101,9 +156,7 @@ pub(super) fn target_context<M: Embedding>(
 ) -> RoundContext {
     RoundContext {
         vector_size: source.message_length(),
-        log_inv_rate: shape
-            .source_log_inv_rate
-            .saturating_add(shape.source_folding_factor.saturating_sub(1)),
+        log_inv_rate: shape.target_log_inv_rate,
         folding_factor: shape.target_folding_factor,
     }
 }
@@ -111,10 +164,31 @@ pub(super) fn target_context<M: Embedding>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocols::params::spec::FoldingFactor;
+    use crate::protocols::params::{
+        branch::Branch,
+        spec::{FoldingFactor, Mode, PowBudget, RateSchedule, SecuritySpec},
+        test_utils::TestEmbedding,
+    };
 
     const FIXTURE_FOLDING_FACTOR: usize = 2;
     const FIXTURE_LOG_INV_RATE: u32 = 1;
+
+    /// Spec fixture suitable for Standard-mode layout tests — RateSchedule
+    /// dispatch is exercised here, not security solving, so any feasible
+    /// spec works.
+    fn layout_spec() -> SecuritySpec {
+        SecuritySpec::new(40)
+            .with_mode(Mode::Standard)
+            .with_pow_budget(PowBudget::per_slot(60))
+    }
+
+    /// Convenience wrapper so tests don't repeat the generic + spec + mode
+    /// boilerplate. Standard mode is enough to exercise the layout walk;
+    /// adaptive coverage lives in `derive` tests where the full pipeline
+    /// runs end-to-end.
+    fn layout(tuning: &TuningSpec) -> Result<RoundLayout, DeriveError> {
+        round_layout::<TestEmbedding>(&layout_spec(), tuning, Branch::Standard)
+    }
 
     const LOG_VECTOR_SIZE_NO_ROUNDS: u32 = 3;
     const LOG_VECTOR_SIZE_MULTI_ROUND: u32 = 8;
@@ -130,6 +204,7 @@ mod tests {
             vector_size,
             starting_log_inv_rate: FIXTURE_LOG_INV_RATE,
             folding_factor: FoldingFactor::Constant(FIXTURE_FOLDING_FACTOR),
+            rate_schedule: RateSchedule::Stepping,
         }
     }
 
@@ -142,8 +217,9 @@ mod tests {
                 initial: VARIED_INITIAL_FOLDING,
                 rest: VARIED_STEADY_FOLDING,
             },
+            rate_schedule: RateSchedule::Stepping,
         };
-        let layout = round_layout(&tuning).unwrap();
+        let layout = layout(&tuning).unwrap();
 
         let mut expected_log_inv_rate = RATE_STEPPING_STARTING_LOG_INV_RATE;
         for shape in &layout.shapes {
@@ -162,8 +238,9 @@ mod tests {
                 initial: VARIED_INITIAL_FOLDING,
                 rest: VARIED_STEADY_FOLDING,
             },
+            rate_schedule: RateSchedule::Stepping,
         };
-        let layout = round_layout(&tuning).unwrap();
+        let layout = layout(&tuning).unwrap();
         assert!(
             layout.shapes.len() >= MIN_ROUNDS_FOR_CHAINING_TEST,
             "need ≥ {MIN_ROUNDS_FOR_CHAINING_TEST} rounds to test chaining",
@@ -179,7 +256,7 @@ mod tests {
     #[test]
     fn round_layout_basecase_size_consumes_remaining_num_vars() {
         let tuning = tuning_with(1 << LOG_VECTOR_SIZE_MULTI_ROUND);
-        let layout = round_layout(&tuning).unwrap();
+        let layout = layout(&tuning).unwrap();
         let consumed: u32 = layout.shapes.iter().map(|s| s.source_folding_factor).sum();
         let initial_num_vars = tuning.vector_size.trailing_zeros();
         let remaining = initial_num_vars - consumed;
@@ -190,7 +267,7 @@ mod tests {
     fn round_layout_stops_when_no_room_for_source_plus_target() {
         let vector_size = 1usize << LOG_VECTOR_SIZE_NO_ROUNDS;
         let tuning = tuning_with(vector_size);
-        let layout = round_layout(&tuning).unwrap();
+        let layout = layout(&tuning).unwrap();
         assert!(layout.shapes.is_empty());
         assert_eq!(layout.basecase_vector_size, vector_size);
         assert_eq!(layout.basecase_log_inv_rate, FIXTURE_LOG_INV_RATE);
@@ -202,12 +279,13 @@ mod tests {
             vector_size: 12,
             starting_log_inv_rate: FIXTURE_LOG_INV_RATE,
             folding_factor: FoldingFactor::Constant(FIXTURE_FOLDING_FACTOR),
+            rate_schedule: RateSchedule::Stepping,
         };
-        let err = round_layout(&tuning).expect_err("non-pow2 vector_size must fail");
+        let err = layout(&tuning).expect_err("non-pow2 vector_size must fail");
         assert!(
             matches!(
                 err,
-                LayoutError::VectorSizeNotPowerOfTwo { vector_size: 12 }
+                DeriveError::Layout(LayoutError::VectorSizeNotPowerOfTwo { vector_size: 12 })
             ),
             "got {err:?}",
         );
@@ -219,10 +297,14 @@ mod tests {
             vector_size: 1 << LOG_VECTOR_SIZE_MULTI_ROUND,
             starting_log_inv_rate: FIXTURE_LOG_INV_RATE,
             folding_factor: FoldingFactor::Constant(0),
+            rate_schedule: RateSchedule::Stepping,
         };
-        let err = round_layout(&tuning).expect_err("folding_factor = 0 must fail");
+        let err = layout(&tuning).expect_err("folding_factor = 0 must fail");
         assert!(
-            matches!(err, LayoutError::FoldingFactorBelowOne { min: 0 }),
+            matches!(
+                err,
+                DeriveError::Layout(LayoutError::FoldingFactorBelowOne { min: 0 })
+            ),
             "got {err:?}",
         );
     }

--- a/src/protocols/params/mod.rs
+++ b/src/protocols/params/mod.rs
@@ -4,6 +4,7 @@
 //! "the bounds doc, §N") live at
 //! <https://hackmd.io/@1q1q-TiuQN6fAkxaN41u-Q/ryBoT_UA-e>.
 
+pub(crate) mod adaptive;
 pub(crate) mod basecase;
 pub(crate) mod bounds;
 pub(crate) mod branch;
@@ -31,7 +32,7 @@ pub use protocol_config::{
 };
 pub use solved::Solved;
 pub use spec::{
-    DecodingRegime, FoldingFactor, ListSize, LogInvRate, MaskCodeMessageLen, Mode, OodSampleBudget,
-    ParseDecodingRegimeError, PowBudget, RoundContext, SecuritySpec, TuningSpec, ZkSpec,
-    DEFAULT_POW_BUDGET_BITS,
+    DecodingRegime, FoldingFactor, KneeWeight, ListSize, LogInvRate, MaskCodeMessageLen, Mode,
+    OodSampleBudget, ParseDecodingRegimeError, PowBudget, RateSchedule, RoundContext, SecuritySpec,
+    TuningSpec, ZkSpec, DEFAULT_POW_BUDGET_BITS,
 };

--- a/src/protocols/params/protocol_config.rs
+++ b/src/protocols/params/protocol_config.rs
@@ -3,15 +3,11 @@
 use ark_ff::Field;
 
 use crate::{
-    algebra::{
-        embedding::{Embedding, Identity},
-        fields::FieldWithSize,
-    },
+    algebra::{embedding::Embedding, fields::FieldWithSize},
     bits::Bits,
     protocols::{
         basecase::Config as BasecaseConfig,
         code_switch::Config as CodeSwitchConfig,
-        irs_commit::Config as IrsConfig,
         mask_proximity::Config as MaskProximityConfig,
         params::{
             basecase as basecase_params,
@@ -119,18 +115,25 @@ impl<M: Embedding> ProtocolConfig<M> {
                     mask_info,
                 ),
             };
-            let mask_proximity = r.mask_oracle().map(|mo| PowSlot {
-                kind: Pow::RoundMaskProximity { index },
-                pow: mo.mask_proximity.pow(),
-                recorded: mo.mask_proximity.analytic(),
-                recompute: mask_proximity_params::analytic_error_bits(
-                    mo.mask_proximity.c_zk_commit(),
-                    mo.mask_proximity.num_masks(),
-                ),
-            });
-            [Some(sumcheck), Some(code_switch), mask_proximity]
+            let mask_slots = r
+                .mask_oracle()
+                .map(|mo| {
+                    [mo.sumcheck_masks(), mo.cs_mask()].map(|mp| PowSlot {
+                        kind: Pow::RoundMaskProximity { index },
+                        pow: mp.pow(),
+                        recorded: mp.analytic(),
+                        recompute: mask_proximity_params::analytic_error_bits(
+                            mp.c_zk_commit(),
+                            mp.num_masks(),
+                        ),
+                    })
+                })
+                .into_iter()
+                .flatten();
+            [Some(sumcheck), Some(code_switch)]
                 .into_iter()
                 .flatten()
+                .chain(mask_slots)
         });
 
         let basecase = self.basecase.config();
@@ -465,43 +468,61 @@ impl<M: Embedding> RoundConfig<M> {
     }
 }
 
-/// One round's mask oracle: a C_zk codeword + ℓ_zk + mask-proximity check.
+/// One round's mask oracle, split across two independent C_zk trees:
+///   - `sumcheck_masks`: the `k` sumcheck masks (Lemma 6.4), each of length
+///     `next_pow_2(mask_length)`. Committed BEFORE sumcheck.
+///   - `cs_mask`: the single `(r ‖ s)` code-switch mask (Construction 9.7),
+///     length `ℓ_zk`. Committed AFTER sumcheck so its `r` part can carry the
+///     folded source-IRS randomness.
+///
+/// Both trees share the same C_zk code rate, so `info()` exposes a single
+/// shared list-size to downstream solvers.
 #[derive(Clone, Debug)]
 pub struct MaskOracleConfig<F: Field> {
-    c_zk: IrsConfig<Identity<F>>,
-    /// `next_pow2(r + t_ood)` (Theorem 9.6 + Lemma 9.3).
+    sumcheck_masks: Solved<MaskProximityConfig<F>>,
+    cs_mask: Solved<MaskProximityConfig<F>>,
+    /// `next_pow2(r + t_ood)` for this round (Lemma 9.3).
     l_zk: MaskCodeMessageLen,
-    mask_proximity: Solved<MaskProximityConfig<F>>,
+    /// Lemma 9.9 OOD-sample budget (bounds doc §5.2).
+    t_ood: OodSampleBudget,
 }
 
 impl<F: Field> MaskOracleConfig<F> {
     pub(crate) const fn new(
-        c_zk: IrsConfig<Identity<F>>,
+        sumcheck_masks: Solved<MaskProximityConfig<F>>,
+        cs_mask: Solved<MaskProximityConfig<F>>,
         l_zk: MaskCodeMessageLen,
-        mask_proximity: Solved<MaskProximityConfig<F>>,
+        t_ood: OodSampleBudget,
     ) -> Self {
         Self {
-            c_zk,
+            sumcheck_masks,
+            cs_mask,
             l_zk,
-            mask_proximity,
+            t_ood,
         }
     }
 
-    pub const fn c_zk(&self) -> &IrsConfig<Identity<F>> {
-        &self.c_zk
+    pub const fn sumcheck_masks(&self) -> &Solved<MaskProximityConfig<F>> {
+        &self.sumcheck_masks
+    }
+
+    pub const fn cs_mask(&self) -> &Solved<MaskProximityConfig<F>> {
+        &self.cs_mask
     }
 
     pub const fn l_zk(&self) -> MaskCodeMessageLen {
         self.l_zk
     }
 
-    pub const fn mask_proximity(&self) -> &Solved<MaskProximityConfig<F>> {
-        &self.mask_proximity
+    pub const fn t_ood(&self) -> OodSampleBudget {
+        self.t_ood
     }
 
     pub fn info(&self) -> MaskOracleInfo {
+        // Both sub-trees use the same C_zk rate, so either's list size is the
+        // shared C_zk list size.
         MaskOracleInfo {
-            c_zk_list_size: ListSize::new(self.c_zk.list_size()),
+            c_zk_list_size: ListSize::new(self.cs_mask.c_zk_commit().list_size()),
             l_zk: self.l_zk,
         }
     }
@@ -516,7 +537,8 @@ pub struct MaskOracleInfo {
 
 impl<F: Field> MaskOracleConfig<F> {
     /// Analytic soundness bits (excluding PoW) for this round's mask oracle.
+    /// Returns the minimum of both sub-trees.
     pub fn analytic_bits(&self) -> Bits {
-        self.mask_proximity.analytic_bits()
+        Bits::new(f64::from(self.sumcheck_masks.analytic()).min(f64::from(self.cs_mask.analytic())))
     }
 }

--- a/src/protocols/params/protocol_config.rs
+++ b/src/protocols/params/protocol_config.rs
@@ -1,6 +1,7 @@
 //! Output of [`super::derive`]: the assembled per-round and basecase configs.
 
 use ark_ff::Field;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     algebra::{embedding::Embedding, fields::FieldWithSize},
@@ -24,7 +25,8 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct ProtocolConfig<M: Embedding> {
     security: SecuritySpec,
     tuning: TuningSpec,
@@ -291,7 +293,8 @@ pub struct PowSlot {
 /// `gamma_analytic` is always computed (the Lemma 7.4 formula is well-defined
 /// in both modes) but only enters validation when the basecase is ZK — the
 /// γ slot does not exist otherwise.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct BasecasePlan<F: Field> {
     config: BasecaseConfig<F>,
     sumcheck_analytic: Bits,
@@ -365,7 +368,8 @@ impl<M: Embedding> ProtocolConfig<M> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct RoundConfig<M: Embedding> {
     round_index: usize,
     sumcheck: Solved<SumcheckConfig<M::Target>>,
@@ -423,7 +427,8 @@ impl<M: Embedding> RoundConfig<M> {
 /// The ZK payload owns the round's mask oracle, so a mode/oracle mismatch is
 /// unrepresentable. Boxed to keep the `Standard` variant from paying the
 /// oracle's footprint.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub enum RoundMode<F: Field> {
     Standard,
     ZeroKnowledge {
@@ -477,7 +482,8 @@ impl<M: Embedding> RoundConfig<M> {
 ///
 /// Both trees share the same C_zk code rate, so `info()` exposes a single
 /// shared list-size to downstream solvers.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct MaskOracleConfig<F: Field> {
     sumcheck_masks: Solved<MaskProximityConfig<F>>,
     cs_mask: Solved<MaskProximityConfig<F>>,
@@ -529,7 +535,7 @@ impl<F: Field> MaskOracleConfig<F> {
 }
 
 /// Slim mask-oracle view (C_zk's list size + ℓ_zk).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MaskOracleInfo {
     pub c_zk_list_size: ListSize,
     pub l_zk: MaskCodeMessageLen,

--- a/src/protocols/params/protocol_config.rs
+++ b/src/protocols/params/protocol_config.rs
@@ -4,7 +4,10 @@ use ark_ff::Field;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    algebra::{embedding::Embedding, fields::FieldWithSize},
+    algebra::{
+        embedding::{Embedding, Identity},
+        fields::FieldWithSize,
+    },
     bits::Bits,
     protocols::{
         basecase::Config as BasecaseConfig,
@@ -30,7 +33,10 @@ use crate::{
 pub struct ProtocolConfig<M: Embedding> {
     security: SecuritySpec,
     tuning: TuningSpec,
-    rounds: Vec<RoundConfig<M>>,
+    /// The base→ext first round: its source IRS is over `M::Source`.
+    first_round: Option<RoundConfig<M>>,
+    /// Later rounds, all ext→ext on the code-switch output (`Identity<M::Target>`).
+    tail_rounds: Vec<RoundConfig<Identity<M::Target>>>,
     basecase: BasecasePlan<M::Target>,
 }
 
@@ -38,13 +44,15 @@ impl<M: Embedding> ProtocolConfig<M> {
     pub(crate) const fn new(
         security: SecuritySpec,
         tuning: TuningSpec,
-        rounds: Vec<RoundConfig<M>>,
+        first_round: Option<RoundConfig<M>>,
+        tail_rounds: Vec<RoundConfig<Identity<M::Target>>>,
         basecase: BasecasePlan<M::Target>,
     ) -> Self {
         Self {
             security,
             tuning,
-            rounds,
+            first_round,
+            tail_rounds,
             basecase,
         }
     }
@@ -57,8 +65,34 @@ impl<M: Embedding> ProtocolConfig<M> {
         &self.tuning
     }
 
-    pub fn rounds(&self) -> &[RoundConfig<M>] {
-        &self.rounds
+    /// The base→ext first round, if the plan has any rounds.
+    pub const fn first_round(&self) -> Option<&RoundConfig<M>> {
+        self.first_round.as_ref()
+    }
+
+    /// The ext→ext rounds following the first.
+    pub fn tail_rounds(&self) -> &[RoundConfig<Identity<M::Target>>] {
+        &self.tail_rounds
+    }
+
+    /// `true` if the plan has at least one code-switch round.
+    pub const fn has_rounds(&self) -> bool {
+        self.first_round.is_some()
+    }
+
+    /// Total number of code-switch rounds (`first_round` + `tail_rounds`).
+    pub fn num_rounds(&self) -> usize {
+        usize::from(self.first_round.is_some()) + self.tail_rounds.len()
+    }
+
+    /// Every round, head then tail, as one `&dyn RoundMetrics` stream — the sole
+    /// place the `first_round`/`tail_rounds` type split is bridged for the
+    /// aggregators. Lazy; see [`RoundMetrics`] for the safe-before-validation set.
+    fn round_views(&self) -> impl Iterator<Item = &dyn RoundMetrics> + '_ {
+        self.first_round
+            .iter()
+            .map(|r| r as &dyn RoundMetrics)
+            .chain(self.tail_rounds.iter().map(|r| r as &dyn RoundMetrics))
     }
 
     pub const fn basecase(&self) -> &BasecaseConfig<M::Target> {
@@ -96,47 +130,7 @@ impl<M: Embedding> ProtocolConfig<M> {
     /// target validation, and the per-slot test assertions all iterate this.
     /// A sub-protocol added here is automatically covered by every check.
     pub(crate) fn pow_slots(&self) -> impl Iterator<Item = PowSlot> + '_ {
-        let round_slots = self.rounds.iter().flat_map(|r| {
-            let mask_info = r.mask_oracle_info();
-            let index = r.round_index;
-            let cs = r.code_switch.config();
-            let sumcheck = PowSlot {
-                kind: Pow::RoundSumcheck { index },
-                pow: r.sumcheck.round_pow(),
-                recorded: r.sumcheck.analytic(),
-                recompute: sumcheck_params::analytic_error_bits(cs.source(), mask_info),
-            };
-            let code_switch = PowSlot {
-                kind: Pow::RoundCodeSwitch { index },
-                pow: cs.pow(),
-                recorded: r.code_switch.analytic(),
-                recompute: code_switch_params::analytic_error_bits(
-                    cs.source(),
-                    cs.target(),
-                    cs.out_domain_samples(),
-                    mask_info,
-                ),
-            };
-            let mask_slots = r
-                .mask_oracle()
-                .map(|mo| {
-                    [mo.sumcheck_masks(), mo.cs_mask()].map(|mp| PowSlot {
-                        kind: Pow::RoundMaskProximity { index },
-                        pow: mp.pow(),
-                        recorded: mp.analytic(),
-                        recompute: mask_proximity_params::analytic_error_bits(
-                            mp.c_zk_commit(),
-                            mp.num_masks(),
-                        ),
-                    })
-                })
-                .into_iter()
-                .flatten();
-            [Some(sumcheck), Some(code_switch)]
-                .into_iter()
-                .flatten()
-                .chain(mask_slots)
-        });
+        let round_slots = self.round_views().flat_map(RoundMetrics::pow_slots);
 
         let basecase = self.basecase.config();
         let basecase_sumcheck = PowSlot {
@@ -212,30 +206,29 @@ impl<M: Embedding> ProtocolConfig<M> {
     /// - last round → basecase: `basecase.commit.vector_size == last.target.vector_size`
     /// - no rounds: `basecase.commit.vector_size == tuning.vector_size`
     pub fn validate_round_chaining(&self) -> Result<(), DeriveError> {
-        for window in self.rounds.windows(2) {
-            let prev = &window[0];
-            let next = &window[1];
-            let expected = prev.code_switch.target().vector_size();
-            let found = next.code_switch.source().vector_size();
-            if expected != found {
+        let views: Vec<&dyn RoundMetrics> = self.round_views().collect();
+
+        for window in views.windows(2) {
+            let prev = window[0];
+            let next = window[1];
+            if prev.target_vector_size() != next.source_vector_size() {
                 return Err(DeriveError::RoundChainBroken {
-                    from: ChainSource::Round(prev.round_index),
-                    to: ChainTarget::NextRound(next.round_index),
-                    expected,
-                    found,
+                    from: ChainSource::Round(prev.round_index()),
+                    to: ChainTarget::NextRound(next.round_index()),
+                    expected: prev.target_vector_size(),
+                    found: next.source_vector_size(),
                 });
             }
         }
 
         let basecase_vector_size = self.basecase.commit().vector_size();
-        let expected = self.rounds.last().map_or(self.tuning.vector_size, |last| {
-            last.code_switch.target().vector_size()
-        });
+        let expected = views
+            .last()
+            .map_or(self.tuning.vector_size, |last| last.target_vector_size());
         if expected != basecase_vector_size {
-            let from = self
-                .rounds
+            let from = views
                 .last()
-                .map_or(ChainSource::Tuning, |r| ChainSource::Round(r.round_index));
+                .map_or(ChainSource::Tuning, |r| ChainSource::Round(r.round_index()));
             return Err(DeriveError::RoundChainBroken {
                 from,
                 to: ChainTarget::Basecase,
@@ -252,12 +245,10 @@ impl<M: Embedding> ProtocolConfig<M> {
     pub fn privacy_error_bits(&self) -> Bits {
         let field_bits = <M::Target as FieldWithSize>::field_size_bits();
         let mut total_error = 0.0_f64;
-        for r in &self.rounds {
-            if let RoundMode::ZeroKnowledge { t_ood, .. } = &r.mode {
-                let t = usize_to_f64(t_ood.get());
-                let log_err = f64::midpoint(t * t, t).log2() - field_bits;
-                total_error += 2_f64.powf(log_err);
-            }
+        for t_ood in self.round_views().filter_map(RoundMetrics::t_ood) {
+            let t = usize_to_f64(t_ood);
+            let log_err = f64::midpoint(t * t, t).log2() - field_bits;
+            total_error += 2_f64.powf(log_err);
         }
         if total_error == 0.0 {
             return Bits::new(f64::from(self.security.target_security_bits));
@@ -270,10 +261,19 @@ impl<M: Embedding> ProtocolConfig<M> {
     /// Analytic soundness bits (excluding PoW).
     pub fn analytic_bits(&self) -> Bits {
         let mut min_bits = f64::from(self.basecase.config().analytic_bits());
-        for round in &self.rounds {
-            min_bits = min_bits.min(f64::from(round.analytic_bits()));
+        for v in self.round_views() {
+            min_bits = min_bits.min(f64::from(v.analytic()));
         }
         Bits::new(min_bits.max(0.0))
+    }
+}
+
+#[cfg(test)]
+impl<F: Field> ProtocolConfig<Identity<F>> {
+    /// All rounds as one sequence — test-only, and only for `Identity<F>` where
+    /// head and tail share a type. Generic code uses `first_round`/`tail_rounds`.
+    pub(crate) fn rounds(&self) -> Vec<&RoundConfig<Identity<F>>> {
+        self.first_round.iter().chain(&self.tail_rounds).collect()
     }
 }
 
@@ -342,7 +342,12 @@ impl<M: Embedding> ProtocolConfig<M> {
     }
 
     pub(crate) fn truncate_rounds_for_test(&mut self, len: usize) {
-        self.rounds.truncate(len);
+        if len == 0 {
+            self.first_round = None;
+            self.tail_rounds.clear();
+        } else {
+            self.tail_rounds.truncate(len - 1);
+        }
     }
 
     pub(crate) fn corrupt_round_target_vector_size_for_test(
@@ -350,11 +355,23 @@ impl<M: Embedding> ProtocolConfig<M> {
         round_idx: usize,
         new_size: usize,
     ) {
-        self.rounds[round_idx]
-            .code_switch
-            .config_mut_for_test()
-            .target_mut_for_test()
-            .set_vector_size_for_test(new_size);
+        // Target IRS is `Identity<M::Target>` in both the head and tail; only
+        // the owning `code_switch` type differs, so the mutation is branched.
+        if round_idx == 0 {
+            self.first_round
+                .as_mut()
+                .expect("round 0 must exist")
+                .code_switch
+                .config_mut_for_test()
+                .target_mut_for_test()
+                .set_vector_size_for_test(new_size);
+        } else {
+            self.tail_rounds[round_idx - 1]
+                .code_switch
+                .config_mut_for_test()
+                .target_mut_for_test()
+                .set_vector_size_for_test(new_size);
+        }
     }
 
     pub(crate) fn corrupt_round_sumcheck_analytic_for_test(
@@ -362,9 +379,17 @@ impl<M: Embedding> ProtocolConfig<M> {
         round_idx: usize,
         new_value: Bits,
     ) {
-        self.rounds[round_idx]
-            .sumcheck
-            .set_analytic_for_test(new_value);
+        if round_idx == 0 {
+            self.first_round
+                .as_mut()
+                .expect("round 0 must exist")
+                .sumcheck
+                .set_analytic_for_test(new_value);
+        } else {
+            self.tail_rounds[round_idx - 1]
+                .sumcheck
+                .set_analytic_for_test(new_value);
+        }
     }
 }
 
@@ -419,6 +444,92 @@ impl<M: Embedding> RoundConfig<M> {
     /// Slim mask-oracle view derived from `mask_oracle()`.
     pub fn mask_oracle_info(&self) -> Option<MaskOracleInfo> {
         self.mask_oracle().map(MaskOracleConfig::info)
+    }
+}
+
+/// Field-free view of one round, bridging `first_round` (`M`) and `tail_rounds`
+/// (`Identity<M::Target>`) into one `&dyn` stream for the aggregators.
+///
+/// The shape accessors are always safe; `analytic`/`pow_slots` recompute and
+/// assume shape invariants hold, so call them only after
+/// `validate_round_chaining` (see [`ProtocolConfig::validate`]).
+trait RoundMetrics {
+    fn round_index(&self) -> usize;
+    fn source_vector_size(&self) -> usize;
+    fn target_vector_size(&self) -> usize;
+    /// `t_ood` when the round is ZK, else `None`.
+    fn t_ood(&self) -> Option<usize>;
+    /// Analytic soundness floor (recompute).
+    fn analytic(&self) -> Bits;
+    /// PoW slots: sumcheck, code-switch, and masks when ZK (recompute).
+    fn pow_slots(&self) -> Vec<PowSlot>;
+}
+
+impl<M: Embedding> RoundMetrics for RoundConfig<M> {
+    fn round_index(&self) -> usize {
+        self.round_index
+    }
+
+    fn source_vector_size(&self) -> usize {
+        self.code_switch.source().vector_size()
+    }
+
+    fn target_vector_size(&self) -> usize {
+        self.code_switch.target().vector_size()
+    }
+
+    fn t_ood(&self) -> Option<usize> {
+        match &self.mode {
+            RoundMode::ZeroKnowledge { t_ood, .. } => Some(t_ood.get()),
+            RoundMode::Standard => None,
+        }
+    }
+
+    fn analytic(&self) -> Bits {
+        self.analytic_bits()
+    }
+
+    fn pow_slots(&self) -> Vec<PowSlot> {
+        let mask_info = self.mask_oracle_info();
+        let index = self.round_index;
+        let cs = self.code_switch.config();
+        let sumcheck = PowSlot {
+            kind: Pow::RoundSumcheck { index },
+            pow: self.sumcheck.round_pow(),
+            recorded: self.sumcheck.analytic(),
+            recompute: sumcheck_params::analytic_error_bits(cs.source(), mask_info),
+        };
+        let code_switch = PowSlot {
+            kind: Pow::RoundCodeSwitch { index },
+            pow: cs.pow(),
+            recorded: self.code_switch.analytic(),
+            recompute: code_switch_params::analytic_error_bits(
+                cs.source(),
+                cs.target(),
+                cs.out_domain_samples(),
+                mask_info,
+            ),
+        };
+        let mask_slots = self
+            .mask_oracle()
+            .map(|mo| {
+                [mo.sumcheck_masks(), mo.cs_mask()].map(|mp| PowSlot {
+                    kind: Pow::RoundMaskProximity { index },
+                    pow: mp.pow(),
+                    recorded: mp.analytic(),
+                    recompute: mask_proximity_params::analytic_error_bits(
+                        mp.c_zk_commit(),
+                        mp.num_masks(),
+                    ),
+                })
+            })
+            .into_iter()
+            .flatten();
+        [Some(sumcheck), Some(code_switch)]
+            .into_iter()
+            .flatten()
+            .chain(mask_slots)
+            .collect()
     }
 }
 

--- a/src/protocols/params/regime.rs
+++ b/src/protocols/params/regime.rs
@@ -3,20 +3,10 @@
 //!
 //! # References
 //!
-//! - Johnson proximity-gap error follows the BCHKS25 improvement
+//! - Johnson proximity-gap error follows the BCSS25 improvement
 //!   (`O(n/η^5)`, m=10 at canonical slack) over BCIKS '20.
 //! - Capacity bound follows STIR Conjecture 5.6: `(1 − ρ − η, d/(ρ·η))`-list
 //!   decodability for RS codes.
-//!
-//! - `BCHKS25`: Ben-Sasson, Carmon, Haböck, Kopparty, Saraf, *On Proximity
-//!   Gaps for Reed–Solomon Codes*, IACR ePrint 2025/2055 (Theorem 1.5).
-//!   <https://eprint.iacr.org/2025/2055>
-//! - `BCIKS '20`: Ben-Sasson, Carmon, Ishai, Kopparty, Saraf, *Proximity Gaps
-//!   for Reed–Solomon Codes*, FOCS 2020, IACR ePrint 2020/654.
-//!   <https://eprint.iacr.org/2020/654>
-//! - `STIR`: Arnon, Chiesa, Fenzi, Yogev, *STIR: Reed–Solomon Proximity Testing
-//!   with Fewer Queries*, CRYPTO 2024, IACR ePrint 2024/390 (Conjecture 5.6).
-//!   <https://eprint.iacr.org/2024/390>
 
 use std::f64::consts::LOG2_10;
 
@@ -112,7 +102,7 @@ impl DecodingRegimeParams {
     /// `log₂ ε_mca(C, δ)` for the per-step proximity-gaps error.
     ///
     /// - Unique: `(k − 1) / |F|`, log = `log k − |F|` (with `+ log ρ⁻¹`).
-    /// - Johnson: BCHKS25 Theorem 1.5 at canonical `η = √ρ/20`, `m = 10`:
+    /// - Johnson: BCSS25 Theorem 1.5 at canonical `η = √ρ/20`, `m = 10`:
     ///   `ε ≈ (2·10.5⁵/3) · n · ρ^{−3/2} / |F|`.
     /// - Capacity: STIR Conj 5.6, `ε ≈ d / (η · ρ²) / |F|`.
     pub fn eps_mca_log2(self, log_inv_rate: f64, message_length: usize, field_bits: f64) -> f64 {
@@ -120,20 +110,15 @@ impl DecodingRegimeParams {
         let error = match self {
             Self::Unique => log_k + log_inv_rate,
             Self::Johnson { slack } => {
-                // η lower bound from BCHKS25; below it the closed form understates
-                // ε_mca. Hard assert (not debug): the variants are `pub`, so an
-                // external caller can pick η, and an over-optimistic soundness
-                // bound must not survive into release builds. Cold path, two
-                // float ops.
                 assert!(
                     slack.into_inner().log2() >= -(0.5 * log_inv_rate + LOG2_10 + 1.0) - 1e-6,
-                    "Johnson slack η below BCHKS25 lower bound; ε_mca would be over-optimistic",
+                    "Johnson slack η below BCSS25 lower bound; ε_mca would be over-optimistic",
                 );
-                // BCHKS25 with m = 10: log_2(2·10.5⁵/3) + log n + 1.5·log ρ⁻¹.
+                // BCSS25 with m = 10: log_2(2·10.5⁵/3) + log n + 1.5·log ρ⁻¹.
                 // Substituting n = k/ρ (codeword length) gives the `log_k`
                 // (message length) + 2.5·log ρ⁻¹ form below.
-                let bchks25_const = (2.0 * 10.5_f64.powi(5) / 3.0).log2();
-                bchks25_const + log_k + 2.5 * log_inv_rate
+                let bcss25_const = (2.0 * 10.5_f64.powi(5) / 3.0).log2();
+                bcss25_const + log_k + 2.5 * log_inv_rate
             }
             Self::Capacity { slack } => {
                 // η lower bound from STIR Conj 5.6; see the Johnson arm for why
@@ -330,7 +315,7 @@ mod tests {
         assert_close(got, expected);
     }
 
-    /// MCA error, Johnson (BCHKS25): `log₂(2·10.5⁵/3) + log k + 2.5·log_inv_rate − field_bits`.
+    /// MCA error, Johnson (BCSS25): `log₂(2·10.5⁵/3) + log k + 2.5·log_inv_rate − field_bits`.
     #[test]
     fn eps_mca_log2_johnson_formula() {
         let canonical_slack = 2_f64.powf(-MCA_LOG_INV_RATE).sqrt() / 20.0;
@@ -340,8 +325,8 @@ mod tests {
             MCA_MESSAGE_LENGTH,
             MCA_FIELD_BITS,
         );
-        let bchks25_const = (2.0 * 10.5_f64.powi(5) / 3.0).log2();
-        let expected = bchks25_const + (MCA_MESSAGE_LENGTH as f64).log2() + 2.5 * MCA_LOG_INV_RATE
+        let bcss25_const = (2.0 * 10.5_f64.powi(5) / 3.0).log2();
+        let expected = bcss25_const + (MCA_MESSAGE_LENGTH as f64).log2() + 2.5 * MCA_LOG_INV_RATE
             - MCA_FIELD_BITS;
         assert_close(got, expected);
     }
@@ -362,15 +347,6 @@ mod tests {
         assert_close(got, expected);
     }
 
-    // --- Theorem anchors -----------------------------------------------------
-    //
-    // The `*_formula` tests above re-evaluate the same expression as the
-    // implementation, so a wrong constant or exponent updates both sides and
-    // the test stays green. The tests below instead assert against literals
-    // hand-derived from the theorem statements (independently of the collapsed
-    // implementation form), so a transcription error in `eps_mca_log2` is
-    // caught. Fixed inputs: k = 16 (log k = 4), ρ = 1/4 (log ρ⁻¹ = 2), |F| = 2⁶⁴.
-
     /// Unique: ε ≈ k/|F| · ρ⁻¹ ⇒ log₂ε = log₂16 + 2 − 64 = 4 + 2 − 64 = −58.
     #[test]
     fn eps_mca_log2_unique_theorem_anchor() {
@@ -382,7 +358,7 @@ mod tests {
         assert_close(got, -58.0);
     }
 
-    /// Johnson (BCHKS25 Theorem 1.5, η = √ρ/20, m = 10):
+    /// Johnson (BCSS25 Thm 1.5, η = √ρ/20, m = 10):
     /// `ε = (2·10.5⁵/3) · n · ρ^{−3/2} / |F|` with codeword length n = k/ρ = 64.
     /// log₂ε = log₂(2·10.5⁵/3) + log₂64 + log₂(ρ^{−3/2}) − 64
     ///       = 16.376624613… + 6 + 3 − 64 = −38.623375386…

--- a/src/protocols/params/regime.rs
+++ b/src/protocols/params/regime.rs
@@ -358,7 +358,7 @@ mod tests {
         assert_close(got, -58.0);
     }
 
-    /// Johnson (BCSS25 Thm 1.5, η = √ρ/20, m = 10):
+    /// Johnson (BCSS25 Theorem 1.5, η = √ρ/20, m = 10):
     /// `ε = (2·10.5⁵/3) · n · ρ^{−3/2} / |F|` with codeword length n = k/ρ = 64.
     /// log₂ε = log₂(2·10.5⁵/3) + log₂64 + log₂(ρ^{−3/2}) − 64
     ///       = 16.376624613… + 6 + 3 − 64 = −38.623375386…

--- a/src/protocols/params/solved.rs
+++ b/src/protocols/params/solved.rs
@@ -2,6 +2,8 @@
 
 use std::ops::Deref;
 
+use serde::{Deserialize, Serialize};
+
 use crate::bits::Bits;
 
 /// A sub-protocol config paired with the analytic-error floor the params
@@ -12,7 +14,7 @@ use crate::bits::Bits;
 /// config. Drift checks in
 /// [`super::protocol_config::ProtocolConfig::validate`] compare the recorded
 /// floor against a fresh recompute.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Solved<C> {
     config: C,
     analytic: Bits,

--- a/src/protocols/params/spec.rs
+++ b/src/protocols/params/spec.rs
@@ -201,6 +201,93 @@ pub struct TuningSpec {
     pub vector_size: usize,
     pub starting_log_inv_rate: u32,
     pub folding_factor: FoldingFactor,
+    /// Per-round inverse-rate schedule (see [`RateSchedule`]).
+    pub rate_schedule: RateSchedule,
+}
+
+/// Pareto-knee bias for [`RateSchedule::Adaptive`]'s planner. Controls the
+/// tradeoff between prover-time and proof-size axes when picking per-round
+/// inverse rates. Clamped to `[0, 1]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct KneeWeight(OrderedFloat<f64>);
+
+impl KneeWeight {
+    /// Pure geometric knee — equal weighting on both axes.
+    pub const DEFAULT: Self = Self(OrderedFloat(0.5));
+
+    /// Build a `KneeWeight`, clamping `value` to `[0, 1]`. Out-of-range
+    /// inputs (including NaN) are silently corrected — the planner has no
+    /// meaningful behavior outside `[0, 1]`, so reject-by-clamp at the API
+    /// boundary rather than propagating a `Result`.
+    pub const fn new(value: f64) -> Self {
+        let clamped = if value.is_nan() {
+            0.5
+        } else {
+            value.clamp(0.0, 1.0)
+        };
+        Self(OrderedFloat(clamped))
+    }
+
+    pub const fn get(self) -> f64 {
+        self.0 .0
+    }
+}
+
+impl Default for KneeWeight {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Per-round inverse-rate schedule.
+///
+/// The Section 10 code-switching IOPP (Theorem 10.2) commits a fresh codeword
+/// each round, so the per-round rate is a free parameter — the only structural
+/// constraint is on message lengths (`2^{k_{i+1}} · ℓ_{i+1} ≥ ℓ_i`).
+///
+/// Capping the inverse rate trades a small increase in per-round query count
+/// (cheap on tiny late-round Merkle trees) for dramatically smaller late-round
+/// and basecase NTTs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RateSchedule {
+    /// Step `log_inv_rate += folding − 1` per round, unbounded — the
+    /// canonical legacy in-place WHIR behavior. Late-round and basecase NTTs
+    /// grow with depth.
+    Stepping,
+    /// Step like [`Self::Stepping`], then clamp at `max_log_inv_rate`. Set
+    /// `max_log_inv_rate == tuning.starting_log_inv_rate` for a constant-rate
+    /// schedule.
+    Capped { max_log_inv_rate: u32 },
+    /// Per-round rates chosen at `derive` time by a planner that minimises a
+    /// `(prover_time_proxy, proof_size_proxy)` pareto knee under the security
+    /// target. No user-supplied budget; the knee is scale-free. The
+    /// [`KneeWeight`] biases the picker between the two axes.
+    Adaptive { knee_weight: KneeWeight },
+}
+
+impl RateSchedule {
+    /// Compute the next round's inverse rate from the current one and the
+    /// current round's folding factor.
+    ///
+    /// `Adaptive` returns the unbounded step here; the planner runs after the
+    /// skeleton is built and overwrites every per-round rate.
+    pub const fn step(self, current_log_inv_rate: u32, folding_factor: u32) -> u32 {
+        let stepped = current_log_inv_rate.saturating_add(folding_factor.saturating_sub(1));
+        match self {
+            Self::Stepping | Self::Adaptive { .. } => stepped,
+            Self::Capped { max_log_inv_rate } => {
+                if stepped < max_log_inv_rate {
+                    stepped
+                } else {
+                    max_log_inv_rate
+                }
+            }
+        }
+    }
+
+    pub const fn is_adaptive(self) -> bool {
+        matches!(self, Self::Adaptive { .. })
+    }
 }
 
 /// Per-round context handed to a sub-protocol builder.
@@ -410,6 +497,39 @@ mod tests {
         assert_eq!(
             spec(PowBudget::per_slot(pow_over_target)).protocol_security_target_bits(),
             Bits::new(0.0),
+        );
+    }
+
+    #[test]
+    fn rate_schedule_stepping_unbounded() {
+        // Stepping adds `folding − 1` per round regardless of magnitude
+        // (legacy unbounded-stepping behavior).
+        assert_eq!(RateSchedule::Stepping.step(2, 3), 4);
+        assert_eq!(RateSchedule::Stepping.step(100, 5), 104);
+    }
+
+    #[test]
+    fn rate_schedule_capped_clamps_above_cap() {
+        let cap = RateSchedule::Capped {
+            max_log_inv_rate: 5,
+        };
+        assert_eq!(cap.step(2, 3), 4); // below cap → step normally
+        assert_eq!(cap.step(4, 3), 5); // would step to 6 → clamp to 5
+        assert_eq!(cap.step(5, 3), 5); // already at cap → stays
+        assert_eq!(cap.step(10, 3), 5); // above cap → snaps back to cap
+    }
+
+    #[test]
+    fn rate_schedule_folding_factor_one_never_steps() {
+        // folding == 1 means rate step is `1 − 1 = 0`. The IRS layer disallows
+        // folding < 1, but the math here should still be consistent.
+        assert_eq!(RateSchedule::Stepping.step(2, 1), 2);
+        assert_eq!(
+            RateSchedule::Capped {
+                max_log_inv_rate: 5
+            }
+            .step(2, 1),
+            2,
         );
     }
 }

--- a/src/protocols/params/spec.rs
+++ b/src/protocols/params/spec.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use ordered_float::OrderedFloat;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 use crate::{bits::Bits, engines::EngineId, hash};
@@ -94,7 +94,19 @@ impl<T: Hash, Tag> Hash for Tagged<T, Tag> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+impl<T: Serialize, Tag> Serialize for Tagged<T, Tag> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>, Tag> Deserialize<'de> for Tagged<T, Tag> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        T::deserialize(deserializer).map(|value| Self(value, PhantomData))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SecuritySpec {
     pub mode: Mode,
     pub decoding_regime: DecodingRegime,
@@ -196,7 +208,7 @@ impl FoldingFactor {
 }
 
 /// Proof-size / prover-time / soundness-margin tradeoffs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TuningSpec {
     pub vector_size: usize,
     pub starting_log_inv_rate: u32,
@@ -416,7 +428,7 @@ pub type MaskCodeMessageLen = Tagged<usize, MaskCodeMessageLenTag>;
 pub type LogInvRate = Tagged<u32, LogInvRateTag>;
 
 /// Reed–Solomon list-decoding ball size `|Λ(C, δ)|`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ListSize(OrderedFloat<f64>);
 
 impl ListSize {

--- a/src/protocols/params/sumcheck.rs
+++ b/src/protocols/params/sumcheck.rs
@@ -82,7 +82,7 @@ const fn num_sumcheck_rounds(ctx: &RoundContext) -> usize {
 /// Construction 6.3 step 4(a) sends `h_j ∈ F^{<max{2, ℓ_zk}}[X]`. WHIR's round
 /// polynomial is degree-2, so 3 coefficients suffice; `ℓ_zk = 3` is the
 /// smallest value that masks it (Lemma 6.4 requires only `ℓ_zk ≥ 2`).
-const fn zk_mask_length() -> SumcheckMaskLen {
+pub const fn zk_mask_length() -> SumcheckMaskLen {
     SumcheckMaskLen::new(3)
 }
 

--- a/src/protocols/whir/mod.rs
+++ b/src/protocols/whir/mod.rs
@@ -149,16 +149,35 @@ impl<M: Embedding> Config<M> {
         Ok(Commitment { irs, out_of_domain })
     }
 
-    /// Disable proof-of-work for test.
+    /// Disable proof-of-work for test. Sets every per-slot threshold to
+    /// `u64::MAX` so any nonce passes immediately.
+    ///
+    /// Note: `sumcheck::Config::round_pow` returns by value (Config is Copy),
+    /// so mutating through the getter would silently no-op. Sumcheck slots
+    /// are reset via the dedicated `override_round_pow_for_test` helper;
+    /// PoW fields with pub access (`initial_skip_pow`, round/final `pow`)
+    /// are reset directly.
     #[cfg(test)]
     pub(crate) fn disable_pow(&mut self) {
-        self.initial_sumcheck.round_pow().threshold = u64::MAX;
+        let off = proof_of_work::Config {
+            hash_id: self.initial_sumcheck.round_pow().hash_id,
+            threshold: u64::MAX,
+        };
+        self.initial_sumcheck.override_round_pow_for_test(off);
         self.initial_skip_pow.threshold = u64::MAX;
         for round in &mut self.round_configs {
-            round.sumcheck.round_pow().threshold = u64::MAX;
+            let off = proof_of_work::Config {
+                hash_id: round.sumcheck.round_pow().hash_id,
+                threshold: u64::MAX,
+            };
+            round.sumcheck.override_round_pow_for_test(off);
             round.pow.threshold = u64::MAX;
         }
-        self.final_sumcheck.round_pow().threshold = u64::MAX;
+        let off = proof_of_work::Config {
+            hash_id: self.final_sumcheck.round_pow().hash_id,
+            threshold: u64::MAX,
+        };
+        self.final_sumcheck.override_round_pow_for_test(off);
         self.final_pow.threshold = u64::MAX;
     }
 }

--- a/src/protocols/whir_zk/mod.rs
+++ b/src/protocols/whir_zk/mod.rs
@@ -587,4 +587,83 @@ mod tests {
             );
         }
     }
+
+    /// 1 polynomial of size 2^19 with 3 multilinear-extension claims on BN254,
+    /// target_security 128 with a 10-bit PoW budget. Used to compare
+    /// prove/verify wall-clock against the zook orchestrator under the same
+    /// workload shape.
+    ///
+    /// Run with: `cargo test --release --features tracing,rs_in_order --lib \
+    /// protocols::whir_zk::tests::roundtrip_2_pow_20_three_claims_whir_zk -- --nocapture`
+    #[test]
+    fn roundtrip_2_pow_20_three_claims_whir_zk() {
+        use crate::algebra::fields::Field256;
+        type FB = Field256;
+
+        const NV: usize = 19;
+        const NC: usize = 1 << NV;
+
+        let mut rng = ark_std::test_rng();
+
+        let whir_params = ProtocolParameters {
+            decoding_regime: DecodingRegime::Johnson,
+            security_level: 128,
+            pow_bits: 10,
+            initial_folding_factor: 3,
+            folding_factor: 3,
+            starting_log_inv_rate: 2,
+            batch_size: 1,
+            hash_id: hash::SHA2,
+        };
+        let params = Config::<FB>::new(1 << NV, &whir_params, 1);
+
+        let vector: Vec<FB> = random_vector(&mut rng, NC);
+        let f0 = MultilinearExtension {
+            point: random_vector::<FB>(&mut rng, NV),
+        };
+        let f1 = MultilinearExtension {
+            point: random_vector::<FB>(&mut rng, NV),
+        };
+        let f2 = MultilinearExtension {
+            point: random_vector::<FB>(&mut rng, NV),
+        };
+        let embedding = params.blinded_commitment.embedding();
+        let evaluations = vec![
+            f0.evaluate(embedding, &vector),
+            f1.evaluate(embedding, &vector),
+            f2.evaluate(embedding, &vector),
+        ];
+
+        let forms: Vec<Box<dyn LinearForm<FB>>> = vec![Box::new(f0), Box::new(f1), Box::new(f2)];
+        let refs: Vec<&dyn LinearForm<FB>> = forms.iter().map(|w| w.as_ref()).collect();
+        let prove_forms: Vec<Box<dyn LinearForm<FB>>> = forms
+            .iter()
+            .map(|f| {
+                let mut cv = vec![FB::ZERO; params.blinded_commitment.initial_size()];
+                f.accumulate(&mut cv, FB::ONE);
+                Box::new(Covector { vector: cv }) as Box<dyn LinearForm<FB>>
+            })
+            .collect();
+
+        let ds = DomainSeparator::protocol(&params)
+            .session(&format!("whir-zk-bench-2^20 {}:{}", file!(), line!()))
+            .instance(&Empty);
+        let mut prover_state = ProverState::new_std(&ds);
+        let witness = params.commit(&mut prover_state, &[&vector[..]]);
+        let _ = params.prove(
+            &mut prover_state,
+            vec![Cow::Borrowed(&vector[..])],
+            witness,
+            prove_forms,
+            Cow::Borrowed(&evaluations),
+        );
+        let proof = prover_state.proof();
+        let mut verifier_state = VerifierState::new_std(&ds, &proof);
+        let commitment = params
+            .receive_commitments(&mut verifier_state, 1)
+            .expect("receive_commitments");
+        params
+            .verify(&mut verifier_state, &refs, &evaluations, &commitment)
+            .expect("verify");
+    }
 }

--- a/src/protocols/whir_zk/mod.rs
+++ b/src/protocols/whir_zk/mod.rs
@@ -651,10 +651,11 @@ mod tests {
             .session(&format!("whir-zk-bench-2^20 {}:{}", file!(), line!()))
             .instance(&Empty);
         let mut prover_state = ProverState::new_std(&ds);
-        let witness = params.commit(&mut prover_state, &[&vector[..]]);
+        let vector_buffer = Buffer::from(vector.as_slice());
+        let witness = params.commit(&mut prover_state, &[&vector_buffer]);
         let _ = params.prove(
             &mut prover_state,
-            vec![Cow::Borrowed(&vector[..])],
+            &[&vector_buffer],
             witness,
             prove_forms,
             Cow::Borrowed(&evaluations),

--- a/src/protocols/zook/commit.rs
+++ b/src/protocols/zook/commit.rs
@@ -1,0 +1,239 @@
+//! Initial witness commitment for zook.
+//!
+//! Goes through `rounds[0].code_switch.source` when the plan has rounds;
+//! through `basecase.commit` when it doesn't.
+
+use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
+
+use crate::{
+    algebra::{embedding::Embedding, lift},
+    hash::Hash,
+    protocols::{
+        irs_commit::{Commitment as IrsCommitment, Witness as IrsWitness},
+        params::protocol_config::ProtocolConfig,
+    },
+    transcript::{
+        Codec, DuplexSpongeInterface, ProverMessage, ProverState, VerificationResult, VerifierState,
+    },
+};
+
+/// Prover handle from [`ProtocolConfig::commit`]; consumed by `prove`.
+#[must_use]
+#[derive(Clone, Debug)]
+pub struct CommittedWitness<M: Embedding> {
+    pub(crate) state: CommittedState<M>,
+}
+
+/// Internal: the two branches differ in their IRS witness field type.
+#[derive(Clone, Debug)]
+pub(crate) enum CommittedState<M: Embedding> {
+    /// Plan has ≥ 1 round; committed through `rounds[0].code_switch.source`.
+    Round {
+        message: Vec<M::Target>,
+        irs_witness: IrsWitness<M::Source>,
+    },
+    /// Basecase-only plan; witness was lifted into `M::Target` first.
+    Basecase {
+        message: Vec<M::Target>,
+        irs_witness: IrsWitness<M::Target>,
+    },
+}
+
+/// Verifier handle from [`ProtocolConfig::receive_commitment`]; consumed by `verify`.
+#[must_use]
+#[derive(Clone, Debug)]
+pub struct Commitment {
+    pub(crate) irs_commitment: IrsCommitment,
+}
+
+impl<M: Embedding + Default> ProtocolConfig<M> {
+    /// Commit the initial witness to the protocol's first IRS codeword.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::commit", fields(vector_size = self.tuning().vector_size, num_rounds = self.rounds().len())))]
+    pub fn commit<H, R>(
+        &self,
+        ps: &mut ProverState<H, R>,
+        witness: &[M::Source],
+    ) -> CommittedWitness<M>
+    where
+        Standard: Distribution<M::Source> + Distribution<M::Target>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        M::Target: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        assert_eq!(
+            witness.len(),
+            self.tuning().vector_size,
+            "zook witness length",
+        );
+
+        let state = if let Some(round) = self.rounds().first() {
+            let irs_witness = round.code_switch().source().commit(ps, &[witness]);
+            let message = lift(round.code_switch().source().embedding(), witness);
+            CommittedState::Round {
+                message,
+                irs_witness,
+            }
+        } else {
+            // Basecase IRS is over `M::Target`; lift before committing.
+            let embedding = M::default();
+            let message = lift(&embedding, witness);
+            let irs_witness = self.basecase().commit().commit(ps, &[&message]);
+            CommittedState::Basecase {
+                message,
+                irs_witness,
+            }
+        };
+        CommittedWitness { state }
+    }
+
+    /// Verifier mirror of [`Self::commit`].
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::receive_commitment", fields(vector_size = self.tuning().vector_size, num_rounds = self.rounds().len())))]
+    pub fn receive_commitment<H>(&self, vs: &mut VerifierState<H>) -> VerificationResult<Commitment>
+    where
+        H: DuplexSpongeInterface,
+        M::Target: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let irs_commitment = match self.rounds().first() {
+            Some(round) => round.code_switch().source().receive_commitment(vs)?,
+            None => self.basecase().commit().receive_commitment(vs)?,
+        };
+        Ok(Commitment { irs_commitment })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
+    use crate::{
+        algebra::random_vector,
+        hash,
+        protocols::params::{
+            spec::{
+                DecodingRegime, FoldingFactor, Mode, PowBudget, RateSchedule, SecuritySpec,
+                TuningSpec,
+            },
+            test_utils::TestEmbedding,
+        },
+        transcript::{codecs::Empty, DomainSeparator},
+    };
+
+    type F = <TestEmbedding as Embedding>::Source;
+
+    /// Keep PoW below the 60-bit cap during `derive` for small test tunings.
+    const TEST_TARGET_BITS: u32 = 40;
+
+    fn test_spec(mode: Mode) -> SecuritySpec {
+        SecuritySpec {
+            mode,
+            decoding_regime: DecodingRegime::Johnson,
+            target_security_bits: TEST_TARGET_BITS,
+            pow_budget: PowBudget::per_slot(10),
+            hash_id: hash::BLAKE3,
+        }
+    }
+
+    /// Vector size large enough for ≥ 1 round under folding_factor 2.
+    fn tuning_with_rounds() -> TuningSpec {
+        TuningSpec {
+            vector_size: 1 << 8,
+            starting_log_inv_rate: 1,
+            folding_factor: FoldingFactor::Constant(2),
+            rate_schedule: RateSchedule::Stepping,
+        }
+    }
+
+    /// Vector size below `2 · folding_factor`; `round_layout` admits 0 rounds.
+    fn tuning_basecase_only() -> TuningSpec {
+        TuningSpec {
+            vector_size: 1 << 3,
+            starting_log_inv_rate: 1,
+            folding_factor: FoldingFactor::Constant(2),
+            rate_schedule: RateSchedule::Stepping,
+        }
+    }
+
+    fn roundtrip(
+        config: &ProtocolConfig<TestEmbedding>,
+        seed: u64,
+    ) -> CommittedWitness<TestEmbedding> {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let witness = random_vector::<F>(&mut rng, config.tuning().vector_size);
+
+        let ds = DomainSeparator::protocol(&"zook-commit-test")
+            .session(&format!("commit roundtrip {}:{}", file!(), line!()))
+            .instance(&Empty);
+
+        let mut prover_state = ProverState::new_std(&ds);
+        let committed = config.commit(&mut prover_state, &witness);
+        let proof = prover_state.proof();
+
+        let mut verifier_state = VerifierState::new_std(&ds, &proof);
+        let _ = config
+            .receive_commitment(&mut verifier_state)
+            .expect("receive_commitment");
+        verifier_state
+            .check_eof()
+            .expect("transcript fully consumed");
+
+        committed
+    }
+
+    #[test]
+    fn commit_receive_roundtrip_with_rounds_zk() {
+        let config = ProtocolConfig::<TestEmbedding>::derive(
+            test_spec(Mode::ZeroKnowledge),
+            tuning_with_rounds(),
+        )
+        .unwrap();
+        assert!(!config.rounds().is_empty());
+        let committed = roundtrip(&config, 0);
+        assert!(matches!(committed.state, CommittedState::Round { .. }));
+    }
+
+    #[test]
+    fn commit_receive_roundtrip_with_rounds_standard() {
+        let config = ProtocolConfig::<TestEmbedding>::derive(
+            test_spec(Mode::Standard),
+            tuning_with_rounds(),
+        )
+        .unwrap();
+        let committed = roundtrip(&config, 1);
+        assert!(matches!(committed.state, CommittedState::Round { .. }));
+    }
+
+    #[test]
+    fn commit_receive_roundtrip_basecase_only() {
+        let config = ProtocolConfig::<TestEmbedding>::derive(
+            test_spec(Mode::ZeroKnowledge),
+            tuning_basecase_only(),
+        )
+        .unwrap();
+        assert!(config.rounds().is_empty());
+        let committed = roundtrip(&config, 2);
+        assert!(matches!(committed.state, CommittedState::Basecase { .. }));
+    }
+
+    #[test]
+    #[should_panic(expected = "zook witness length")]
+    fn commit_rejects_wrong_witness_size() {
+        let config = ProtocolConfig::<TestEmbedding>::derive(
+            test_spec(Mode::ZeroKnowledge),
+            tuning_with_rounds(),
+        )
+        .unwrap();
+        let mut rng = StdRng::seed_from_u64(3);
+        let too_short = random_vector::<F>(&mut rng, config.tuning().vector_size - 1);
+
+        let ds = DomainSeparator::protocol(&"zook-commit-test")
+            .session(&format!("wrong size {}:{}", file!(), line!()))
+            .instance(&Empty);
+        let mut prover_state = ProverState::new_std(&ds);
+        let _ = config.commit(&mut prover_state, &too_short);
+    }
+}

--- a/src/protocols/zook/commit.rs
+++ b/src/protocols/zook/commit.rs
@@ -72,10 +72,7 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
 
         let state = if let Some(round) = self.rounds().first() {
             let witness_buffer = Buffer::from(witness);
-            let irs_witness = round
-                .code_switch()
-                .source()
-                .commit(ps, &[&witness_buffer]);
+            let irs_witness = round.code_switch().source().commit(ps, &[&witness_buffer]);
             let message = lift(round.code_switch().source().embedding(), witness);
             CommittedState::Round {
                 message,

--- a/src/protocols/zook/commit.rs
+++ b/src/protocols/zook/commit.rs
@@ -51,7 +51,7 @@ pub struct Commitment {
 
 impl<M: Embedding + Default> ProtocolConfig<M> {
     /// Commit the initial witness to the protocol's first IRS codeword.
-    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::commit", fields(vector_size = self.tuning().vector_size, num_rounds = self.rounds().len())))]
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::commit", fields(vector_size = self.tuning().vector_size, num_rounds = self.num_rounds())))]
     pub fn commit<H, R>(
         &self,
         ps: &mut ProverState<H, R>,
@@ -70,7 +70,7 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
             "zook witness length",
         );
 
-        let state = if let Some(round) = self.rounds().first() {
+        let state = if let Some(round) = self.first_round() {
             let witness_buffer = Buffer::from(witness);
             let irs_witness = round.code_switch().source().commit(ps, &[&witness_buffer]);
             let message = lift(round.code_switch().source().embedding(), witness);
@@ -93,14 +93,14 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
     }
 
     /// Verifier mirror of [`Self::commit`].
-    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::receive_commitment", fields(vector_size = self.tuning().vector_size, num_rounds = self.rounds().len())))]
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::receive_commitment", fields(vector_size = self.tuning().vector_size, num_rounds = self.num_rounds())))]
     pub fn receive_commitment<H>(&self, vs: &mut VerifierState<H>) -> VerificationResult<Commitment>
     where
         H: DuplexSpongeInterface,
         M::Target: Codec<[H::U]>,
         Hash: ProverMessage<[H::U]>,
     {
-        let irs_commitment = match self.rounds().first() {
+        let irs_commitment = match self.first_round() {
             Some(round) => round.code_switch().source().receive_commitment(vs)?,
             None => self.basecase().commit().receive_commitment(vs)?,
         };

--- a/src/protocols/zook/mod.rs
+++ b/src/protocols/zook/mod.rs
@@ -1,0 +1,515 @@
+//! Zook ZK protocol — Construction 9.7.
+
+pub mod commit;
+pub mod prover;
+pub mod verifier;
+
+pub use commit::{Commitment, CommittedWitness};
+
+pub use crate::protocols::params::protocol_config::ProtocolConfig;
+use crate::{algebra::linear_form::LinearForm, transcript::VerificationResult, verify};
+
+/// Output of [`ProtocolConfig::verify`].
+///
+/// The verifier has completed all round checks. The caller must finish
+/// verification by checking that the input forms evaluate to the claimed value:
+///
+/// ```text
+/// initial_claim_scale × Σ_j rlc_coefficients[j] × form_j.mle_evaluate(evaluation_point) == linear_forms_contribution
+/// ```
+#[must_use]
+#[derive(Clone, Debug)]
+pub struct FinalClaim<F: ark_ff::Field> {
+    /// All sumcheck challenges from all rounds concatenated with basecase
+    /// evaluation points. Length = log2(vector_size).
+    pub evaluation_point: Vec<F>,
+    /// Cumulative product of all code-switch `original_sl_coeff` values.
+    pub initial_claim_scale: F,
+    /// `opening.linear_form_evaluation − Σ_c constraint_contributions`.
+    /// The portion of the protocol sum attributable to the input linear forms.
+    pub linear_forms_contribution: F,
+    /// Fiat-Shamir RLC coefficients for each input form.
+    /// `rlc_coefficients[0] == F::ONE` always.
+    pub rlc_coefficients: Vec<F>,
+}
+
+impl<F: ark_ff::Field> FinalClaim<F> {
+    /// Complete the verification started by [`ProtocolConfig::verify`].
+    ///
+    /// Checks `initial_claim_scale × Σ_j rlc_coefficients[j] × form_j.mle_evaluate(evaluation_point) == linear_forms_contribution`.
+    ///
+    /// For `MultilinearExtension` forms this runs in O(num_forms × log N).
+    /// For `Covector` forms the default `mle_evaluate` is O(N).
+    pub fn verify(&self, linear_forms: &[&dyn LinearForm<F>]) -> VerificationResult<()>
+    where
+        F: Default,
+    {
+        assert_eq!(
+            linear_forms.len(),
+            self.rlc_coefficients.len(),
+            "linear_forms.len() must match rlc_coefficients.len()"
+        );
+        let form_mle_sum: F = linear_forms
+            .iter()
+            .zip(&self.rlc_coefficients)
+            .map(|(form, &g)| g * form.mle_evaluate(&self.evaluation_point))
+            .sum();
+        verify!(self.initial_claim_scale * form_mle_sum == self.linear_forms_contribution);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
+
+    use super::ProtocolConfig;
+    use crate::{
+        algebra::{
+            embedding::Identity,
+            fields::{Field256, Field64},
+            linear_form::{Evaluate, LinearForm, MultilinearExtension},
+            random_vector,
+        },
+        hash,
+        protocols::params::spec::{
+            DecodingRegime, FoldingFactor, Mode, PowBudget, RateSchedule, SecuritySpec, TuningSpec,
+        },
+        transcript::{codecs::Empty, DomainSeparator, ProverState, VerifierState},
+    };
+
+    // ── Small-test field and config (Field64, λ=40, fast) ───────────────────
+
+    type SmallF = Field64;
+    type SmallEmbed = Identity<SmallF>;
+
+    fn small_spec(mode: Mode) -> SecuritySpec {
+        SecuritySpec {
+            mode,
+            decoding_regime: DecodingRegime::Johnson,
+            target_security_bits: 40,
+            pow_budget: PowBudget::per_slot(10),
+            hash_id: hash::BLAKE3,
+        }
+    }
+
+    /// 2^8 witness, folding_factor 2 → multiple rounds.
+    fn multi_round_tuning() -> TuningSpec {
+        TuningSpec {
+            vector_size: 1 << 8,
+            starting_log_inv_rate: 1,
+            folding_factor: FoldingFactor::Constant(2),
+            rate_schedule: RateSchedule::Stepping,
+        }
+    }
+
+    /// 2^3 witness → basecase-only (too small for any round).
+    fn basecase_tuning() -> TuningSpec {
+        TuningSpec {
+            vector_size: 1 << 3,
+            starting_log_inv_rate: 1,
+            folding_factor: FoldingFactor::Constant(2),
+            rate_schedule: RateSchedule::Stepping,
+        }
+    }
+
+    // ── Test helpers ─────────────────────────────────────────────────────────
+
+    /// A shared `&'static Empty` so that the returned `DomainSeparator` carries
+    /// a `'static` lifetime (required by `VerifierState::new_std`).
+    static EMPTY: Empty = Empty;
+
+    /// Construct a deterministic `DomainSeparator` for the given label.
+    fn make_ds(label: &str) -> DomainSeparator<'static, Empty> {
+        DomainSeparator::protocol(&"zook-test")
+            .session(&label.to_string())
+            .instance(&EMPTY)
+    }
+
+    /// Build a witness, compute true evaluations, prove, and return the proof
+    /// along with the domain separator, forms, and values for further checks.
+    fn build_and_prove(
+        config: &ProtocolConfig<SmallEmbed>,
+        num_claims: usize,
+        seed: u64,
+        label: &str,
+    ) -> (
+        crate::transcript::Proof,
+        DomainSeparator<'static, Empty>,
+        Vec<MultilinearExtension<SmallF>>,
+        Vec<SmallF>,
+    ) {
+        let embedding = <SmallEmbed as Default>::default();
+        let mut rng = StdRng::seed_from_u64(seed);
+        let witness: Vec<SmallF> = random_vector(&mut rng, config.tuning().vector_size);
+        let mu = config.tuning().vector_size.trailing_zeros() as usize;
+
+        let forms: Vec<MultilinearExtension<SmallF>> = (0..num_claims)
+            .map(|_| MultilinearExtension {
+                point: random_vector::<SmallF>(&mut rng, mu),
+            })
+            .collect();
+        let values: Vec<SmallF> = forms
+            .iter()
+            .map(|f| f.evaluate(&embedding, &witness))
+            .collect();
+        let form_refs: Vec<&dyn LinearForm<SmallF>> =
+            forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
+
+        let ds = make_ds(label);
+        let mut ps = ProverState::new_std(&ds);
+        let committed = config.commit(&mut ps, &witness);
+        config.prove(&mut ps, committed, &form_refs, &values);
+        let proof = ps.proof();
+
+        (proof, ds, forms, values)
+    }
+
+    /// Run a full roundtrip: commit → prove → verify → FinalClaim::verify.
+    /// Panics if anything fails.
+    fn full_roundtrip(
+        config: &ProtocolConfig<SmallEmbed>,
+        num_claims: usize,
+        seed: u64,
+        label: &str,
+    ) {
+        let (proof, ds, forms, values) = build_and_prove(config, num_claims, seed, label);
+        let form_refs: Vec<&dyn LinearForm<SmallF>> =
+            forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
+
+        let mut vs = VerifierState::new_std(&ds, &proof);
+        let commitment = config.receive_commitment(&mut vs).unwrap();
+        let claim = config
+            .verify(&mut vs, commitment, &form_refs, &values)
+            .unwrap();
+        claim.verify(&form_refs).expect("FinalClaim::verify failed");
+        vs.check_eof().unwrap();
+    }
+
+    /// Expect verification to fail (handles both `verifier_panics` and normal builds).
+    fn assert_verify_rejected(verify: impl FnOnce() -> crate::transcript::VerificationResult<()>) {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(verify));
+        match result {
+            Err(_) | Ok(Err(_)) => {} // panicked or returned Err — failure as expected
+            Ok(Ok(())) => panic!("expected verification to fail but it succeeded"),
+        }
+    }
+
+    // ── Positive tests: happy paths ──────────────────────────────────────────
+
+    #[test]
+    fn roundtrip_zk_with_rounds() {
+        let config = ProtocolConfig::<SmallEmbed>::derive(
+            small_spec(Mode::ZeroKnowledge),
+            multi_round_tuning(),
+        )
+        .unwrap();
+        assert!(!config.rounds().is_empty(), "expected at least one round");
+        full_roundtrip(&config, 1, 0, "roundtrip_zk_with_rounds");
+    }
+
+    #[test]
+    fn roundtrip_standard_with_rounds() {
+        let config =
+            ProtocolConfig::<SmallEmbed>::derive(small_spec(Mode::Standard), multi_round_tuning())
+                .unwrap();
+        assert!(!config.rounds().is_empty(), "expected at least one round");
+        full_roundtrip(&config, 1, 1, "roundtrip_standard_with_rounds");
+    }
+
+    #[test]
+    fn roundtrip_zk_basecase_only() {
+        let config = ProtocolConfig::<SmallEmbed>::derive(
+            small_spec(Mode::ZeroKnowledge),
+            basecase_tuning(),
+        )
+        .unwrap();
+        assert!(config.rounds().is_empty(), "expected basecase-only plan");
+        full_roundtrip(&config, 1, 2, "roundtrip_zk_basecase_only");
+    }
+
+    #[test]
+    fn roundtrip_standard_basecase_only() {
+        let config =
+            ProtocolConfig::<SmallEmbed>::derive(small_spec(Mode::Standard), basecase_tuning())
+                .unwrap();
+        assert!(config.rounds().is_empty(), "expected basecase-only plan");
+        full_roundtrip(&config, 1, 3, "roundtrip_standard_basecase_only");
+    }
+
+    #[test]
+    fn roundtrip_multiple_claims_zk() {
+        let config = ProtocolConfig::<SmallEmbed>::derive(
+            small_spec(Mode::ZeroKnowledge),
+            multi_round_tuning(),
+        )
+        .unwrap();
+        full_roundtrip(&config, 4, 4, "roundtrip_multiple_claims_zk");
+    }
+
+    #[test]
+    fn roundtrip_multiple_claims_standard() {
+        let config =
+            ProtocolConfig::<SmallEmbed>::derive(small_spec(Mode::Standard), multi_round_tuning())
+                .unwrap();
+        full_roundtrip(&config, 4, 5, "roundtrip_multiple_claims_standard");
+    }
+
+    // ── Negative tests: input validation ─────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "linear_forms.len() != evaluations.len()")]
+    fn prove_rejects_form_evaluation_count_mismatch() {
+        let config =
+            ProtocolConfig::<SmallEmbed>::derive(small_spec(Mode::Standard), multi_round_tuning())
+                .unwrap();
+        let mut rng = StdRng::seed_from_u64(0);
+        let witness: Vec<SmallF> = random_vector(&mut rng, config.tuning().vector_size);
+        let mu = config.tuning().vector_size.trailing_zeros() as usize;
+        let form: MultilinearExtension<SmallF> = MultilinearExtension {
+            point: random_vector(&mut rng, mu),
+        };
+        let ds = DomainSeparator::protocol(&"zook-test")
+            .session(&"count-mismatch".to_string())
+            .instance(&Empty);
+        let mut ps = ProverState::new_std(&ds);
+        let committed = config.commit(&mut ps, &witness);
+        // 1 form but 2 values — should panic
+        config.prove(
+            &mut ps,
+            committed,
+            &[&form as &dyn LinearForm<SmallF>],
+            &[SmallF::from(1u64), SmallF::from(2u64)],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "zook requires ≥ 1")]
+    fn prove_rejects_empty_forms() {
+        let config =
+            ProtocolConfig::<SmallEmbed>::derive(small_spec(Mode::Standard), multi_round_tuning())
+                .unwrap();
+        let mut rng = StdRng::seed_from_u64(0);
+        let witness: Vec<SmallF> = random_vector(&mut rng, config.tuning().vector_size);
+        let ds = DomainSeparator::protocol(&"zook-test")
+            .session(&"empty-forms".to_string())
+            .instance(&Empty);
+        let mut ps = ProverState::new_std(&ds);
+        let committed = config.commit(&mut ps, &witness);
+        // No forms at all — should panic
+        config.prove(&mut ps, committed, &[], &[]);
+    }
+
+    // ── Negative tests: wrong claimed values ──────────────────────────────────
+
+    #[test]
+    fn verify_rejects_wrong_evaluation_zk() {
+        let config = ProtocolConfig::<SmallEmbed>::derive(
+            small_spec(Mode::ZeroKnowledge),
+            multi_round_tuning(),
+        )
+        .unwrap();
+        let (proof, ds, forms, true_values) =
+            build_and_prove(&config, 1, 10, "verify_rejects_wrong_evaluation_zk");
+
+        let form_refs: Vec<&dyn LinearForm<SmallF>> =
+            forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
+        // Shift the claimed value by 1 — the proof is now inconsistent with this claim
+        let wrong_values = vec![true_values[0] + SmallF::from(1u64)];
+
+        assert_verify_rejected(|| {
+            let mut vs = VerifierState::new_std(&ds, &proof);
+            let commitment = config.receive_commitment(&mut vs)?;
+            let claim = config.verify(&mut vs, commitment, &form_refs, &wrong_values)?;
+            claim.verify(&form_refs)?;
+            vs.check_eof()
+        });
+    }
+
+    #[test]
+    fn verify_rejects_wrong_evaluation_standard() {
+        let config =
+            ProtocolConfig::<SmallEmbed>::derive(small_spec(Mode::Standard), multi_round_tuning())
+                .unwrap();
+        let (proof, ds, forms, true_values) =
+            build_and_prove(&config, 1, 11, "verify_rejects_wrong_evaluation_standard");
+
+        let form_refs: Vec<&dyn LinearForm<SmallF>> =
+            forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
+        let wrong_values = vec![true_values[0] + SmallF::from(1u64)];
+
+        assert_verify_rejected(|| {
+            let mut vs = VerifierState::new_std(&ds, &proof);
+            let commitment = config.receive_commitment(&mut vs)?;
+            let claim = config.verify(&mut vs, commitment, &form_refs, &wrong_values)?;
+            claim.verify(&form_refs)?;
+            vs.check_eof()
+        });
+    }
+
+    #[test]
+    fn verify_rejects_wrong_evaluation_multiple_claims() {
+        let config = ProtocolConfig::<SmallEmbed>::derive(
+            small_spec(Mode::ZeroKnowledge),
+            multi_round_tuning(),
+        )
+        .unwrap();
+        let (proof, ds, forms, mut values) = build_and_prove(
+            &config,
+            3,
+            12,
+            "verify_rejects_wrong_evaluation_multiple_claims",
+        );
+
+        let form_refs: Vec<&dyn LinearForm<SmallF>> =
+            forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
+        // Corrupt the second claim
+        values[1] += SmallF::from(42u64);
+
+        assert_verify_rejected(|| {
+            let mut vs = VerifierState::new_std(&ds, &proof);
+            let commitment = config.receive_commitment(&mut vs)?;
+            let claim = config.verify(&mut vs, commitment, &form_refs, &values)?;
+            claim.verify(&form_refs)?;
+            vs.check_eof()
+        });
+    }
+
+    #[test]
+    fn final_claim_rejects_wrong_form() {
+        // Correct proof + correct verify, but FinalClaim::verify called with a
+        // different form → must be detected.
+        let config = ProtocolConfig::<SmallEmbed>::derive(
+            small_spec(Mode::ZeroKnowledge),
+            multi_round_tuning(),
+        )
+        .unwrap();
+        let (proof, ds, forms, values) =
+            build_and_prove(&config, 1, 20, "final_claim_rejects_wrong_form");
+
+        let form_refs: Vec<&dyn LinearForm<SmallF>> =
+            forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
+
+        let mut vs = VerifierState::new_std(&ds, &proof);
+        let commitment = config.receive_commitment(&mut vs).unwrap();
+        let claim = config
+            .verify(&mut vs, commitment, &form_refs, &values)
+            .unwrap();
+
+        // Construct a different form at a different evaluation point
+        let mut rng = StdRng::seed_from_u64(999);
+        let mu = config.tuning().vector_size.trailing_zeros() as usize;
+        let wrong_form: MultilinearExtension<SmallF> = MultilinearExtension {
+            point: random_vector(&mut rng, mu),
+        };
+
+        assert_verify_rejected(|| claim.verify(&[&wrong_form as &dyn LinearForm<SmallF>]));
+    }
+
+    // ── Negative tests: tampered proof ────────────────────────────────────────
+
+    #[test]
+    fn verify_rejects_tampered_proof() {
+        let config = ProtocolConfig::<SmallEmbed>::derive(
+            small_spec(Mode::ZeroKnowledge),
+            multi_round_tuning(),
+        )
+        .unwrap();
+        let (mut proof, ds, forms, values) =
+            build_and_prove(&config, 1, 30, "verify_rejects_tampered_proof");
+
+        let form_refs: Vec<&dyn LinearForm<SmallF>> =
+            forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
+
+        // Flip a byte in the middle of the transcript to corrupt the proof
+        let mid = proof.narg_string.len() / 2;
+        proof.narg_string[mid] ^= 0xff;
+
+        assert_verify_rejected(|| {
+            let mut vs = VerifierState::new_std(&ds, &proof);
+            let commitment = config.receive_commitment(&mut vs)?;
+            let claim = config.verify(&mut vs, commitment, &form_refs, &values)?;
+            claim.verify(&form_refs)?;
+            vs.check_eof()
+        });
+    }
+
+    // ── Large integration tests (Field256, λ=128, realistic) ─────────────────
+    // These cover the full security target with a 2^19 witness and multiple
+    // folding rounds. Kept for end-to-end regression coverage.
+
+    type LargeF = Field256;
+    type LargeEmbed = Identity<LargeF>;
+
+    fn large_spec(mode: Mode) -> SecuritySpec {
+        SecuritySpec {
+            mode,
+            decoding_regime: DecodingRegime::Johnson,
+            target_security_bits: 128,
+            pow_budget: PowBudget::per_slot(10),
+            hash_id: hash::SHA2,
+        }
+    }
+
+    fn large_tuning() -> TuningSpec {
+        TuningSpec {
+            vector_size: 1 << 19,
+            starting_log_inv_rate: 2,
+            folding_factor: FoldingFactor::ConstantFromSecondRound {
+                initial: 3,
+                rest: 3,
+            },
+            rate_schedule: RateSchedule::Stepping,
+        }
+    }
+
+    fn large_roundtrip(mode: Mode, seed: u64) {
+        crate::tests::init();
+        let config =
+            ProtocolConfig::<LargeEmbed>::derive(large_spec(mode), large_tuning()).unwrap();
+
+        let mut rng = StdRng::seed_from_u64(seed);
+        let witness: Vec<LargeF> = random_vector(&mut rng, config.tuning().vector_size);
+        let mu = config.tuning().vector_size.trailing_zeros() as usize;
+        let embedding = <LargeEmbed as Default>::default();
+
+        let forms: Vec<MultilinearExtension<LargeF>> = (0..3)
+            .map(|_| MultilinearExtension {
+                point: random_vector::<LargeF>(&mut rng, mu),
+            })
+            .collect();
+        let values: Vec<LargeF> = forms
+            .iter()
+            .map(|f| f.evaluate(&embedding, &witness))
+            .collect();
+        let form_refs: Vec<&dyn LinearForm<LargeF>> =
+            forms.iter().map(|f| f as &dyn LinearForm<LargeF>).collect();
+
+        let ds = DomainSeparator::protocol(&"zook-large-test")
+            .session(&format!("three-claims mode={mode:?} seed={seed}"))
+            .instance(&Empty);
+
+        let mut ps = ProverState::new_std(&ds);
+        let committed = config.commit(&mut ps, &witness);
+        config.prove(&mut ps, committed, &form_refs, &values);
+        let proof = ps.proof();
+
+        let mut vs = VerifierState::new_std(&ds, &proof);
+        let commitment = config.receive_commitment(&mut vs).unwrap();
+        let claim = config
+            .verify(&mut vs, commitment, &form_refs, &values)
+            .unwrap();
+        claim.verify(&form_refs).expect("FinalClaim::verify failed");
+        vs.check_eof().unwrap();
+    }
+
+    #[test]
+    fn roundtrip_2_pow_20_three_claims_zk() {
+        large_roundtrip(Mode::ZeroKnowledge, 0);
+    }
+
+    #[test]
+    fn roundtrip_2_pow_20_three_claims_standard() {
+        large_roundtrip(Mode::Standard, 1);
+    }
+}

--- a/src/protocols/zook/mod.rs
+++ b/src/protocols/zook/mod.rs
@@ -66,8 +66,8 @@ mod tests {
     use super::ProtocolConfig;
     use crate::{
         algebra::{
-            embedding::Identity,
-            fields::{Field256, Field64},
+            embedding::{Basefield, Embedding, Identity},
+            fields::{Field256, Field64, Field64_2},
             linear_form::{Evaluate, LinearForm, MultilinearExtension},
             random_vector,
         },
@@ -186,6 +186,54 @@ mod tests {
         vs.check_eof().unwrap();
     }
 
+    // ── Base-field embedding (witness over base prime field, claims over ext) ──
+
+    /// `Basefield<Field64_2>`: base prime field `Field64` → degree-2 extension.
+    /// Exercises round 0's base→ext code-switch end to end.
+    type MixedField = Field64_2;
+    type MixedEmbed = Basefield<MixedField>;
+    type MixedSource = <MixedEmbed as Embedding>::Source;
+
+    /// `full_roundtrip` with the witness over `M::Source` (base) and forms/values
+    /// over `M::Target` (ext).
+    fn full_roundtrip_mixed(
+        config: &ProtocolConfig<MixedEmbed>,
+        num_claims: usize,
+        seed: u64,
+        label: &str,
+    ) {
+        let embedding = <MixedEmbed as Default>::default();
+        let mut rng = StdRng::seed_from_u64(seed);
+        let witness: Vec<MixedSource> = random_vector(&mut rng, config.tuning().vector_size);
+        let mu = config.tuning().vector_size.trailing_zeros() as usize;
+
+        let forms: Vec<MultilinearExtension<MixedField>> = (0..num_claims)
+            .map(|_| MultilinearExtension {
+                point: random_vector::<MixedField>(&mut rng, mu),
+            })
+            .collect();
+        let values: Vec<MixedField> = forms
+            .iter()
+            .map(|f| f.evaluate(&embedding, &witness))
+            .collect();
+        let form_refs: Vec<&dyn LinearForm<MixedField>> =
+            forms.iter().map(|f| f as &dyn LinearForm<MixedField>).collect();
+
+        let ds = make_ds(label);
+        let mut ps = ProverState::new_std(&ds);
+        let committed = config.commit(&mut ps, &witness);
+        config.prove(&mut ps, committed, &form_refs, &values);
+        let proof = ps.proof();
+
+        let mut vs = VerifierState::new_std(&ds, &proof);
+        let commitment = config.receive_commitment(&mut vs).unwrap();
+        let claim = config
+            .verify(&mut vs, commitment, &form_refs, &values)
+            .unwrap();
+        claim.verify(&form_refs).expect("FinalClaim::verify failed");
+        vs.check_eof().unwrap();
+    }
+
     /// Expect verification to fail (handles both `verifier_panics` and normal builds).
     fn assert_verify_rejected(verify: impl FnOnce() -> crate::transcript::VerificationResult<()>) {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(verify));
@@ -215,6 +263,26 @@ mod tests {
                 .unwrap();
         assert!(!config.rounds().is_empty(), "expected at least one round");
         full_roundtrip(&config, 1, 1, "roundtrip_standard_with_rounds");
+    }
+
+    #[test]
+    fn roundtrip_standard_with_rounds_basefield() {
+        let config =
+            ProtocolConfig::<MixedEmbed>::derive(small_spec(Mode::Standard), multi_round_tuning())
+                .unwrap();
+        assert!(config.has_rounds(), "expected at least one round");
+        full_roundtrip_mixed(&config, 1, 10, "roundtrip_standard_with_rounds_basefield");
+    }
+
+    #[test]
+    fn roundtrip_zk_with_rounds_basefield() {
+        let config = ProtocolConfig::<MixedEmbed>::derive(
+            small_spec(Mode::ZeroKnowledge),
+            multi_round_tuning(),
+        )
+        .unwrap();
+        assert!(config.has_rounds(), "expected at least one round");
+        full_roundtrip_mixed(&config, 3, 11, "roundtrip_zk_with_rounds_basefield");
     }
 
     #[test]

--- a/src/protocols/zook/mod.rs
+++ b/src/protocols/zook/mod.rs
@@ -216,8 +216,10 @@ mod tests {
             .iter()
             .map(|f| f.evaluate(&embedding, &witness))
             .collect();
-        let form_refs: Vec<&dyn LinearForm<MixedField>> =
-            forms.iter().map(|f| f as &dyn LinearForm<MixedField>).collect();
+        let form_refs: Vec<&dyn LinearForm<MixedField>> = forms
+            .iter()
+            .map(|f| f as &dyn LinearForm<MixedField>)
+            .collect();
 
         let ds = make_ds(label);
         let mut ps = ProverState::new_std(&ds);

--- a/src/protocols/zook/prover.rs
+++ b/src/protocols/zook/prover.rs
@@ -146,9 +146,9 @@ impl<F: Field + Default + Zeroize> ProtocolConfig<Identity<F>> {
         // end-to-end hiding is required.
         let _ = self.basecase().prove(
             ps,
-            Buffer::from(message.as_slice()),
+            Buffer::from(message),
             &basecase_witness,
-            Buffer::from(covector.as_slice()),
+            Buffer::from(covector),
             sum,
         );
     }
@@ -191,11 +191,12 @@ where
     // cs_fresh_padding is pre-sampled here because it does not depend on folding randomness.
     let mut masker = RoundMaskOracle::begin(round, ps);
 
-    // Sumcheck folds its buffers in place. Upload the host-side round state,
-    // fold, and read the folded result back into the `Vec` state (which
-    // downstream steps resize/truncate/index directly).
-    let mut message_buf = Buffer::from(state.message.as_slice());
-    let mut covector_buf = Buffer::from(state.covector.as_slice());
+    // Sumcheck folds its buffers in place. Move the host-side round state into
+    // buffers, fold, and move the folded result back into the `Vec` state
+    // (which downstream steps resize/truncate/index directly). Both hops are
+    // zero-copy on the CPU backend.
+    let mut message_buf = Buffer::from(std::mem::take(&mut state.message));
+    let mut covector_buf = Buffer::from(std::mem::take(&mut state.covector));
     let opening = round.sumcheck().prove(
         ps,
         &mut message_buf,
@@ -203,8 +204,8 @@ where
         &mut state.sum,
         masker.sumcheck_blinding(),
     );
-    state.message = message_buf.to_slice().to_vec();
-    state.covector = covector_buf.to_slice().to_vec();
+    state.message = message_buf.into_vec();
+    state.covector = covector_buf.into_vec();
 
     // Build cs_mask = (folded_irs_masks ‖ cs_fresh_padding), commit its tree,
     // send mask_eval_sum cleartext, reconcile sum to the unmasked dot.

--- a/src/protocols/zook/prover.rs
+++ b/src/protocols/zook/prover.rs
@@ -1,0 +1,581 @@
+//! Zook prover — Construction 9.7 (ZK Code-Switching).
+//!
+//! Per ZK round, the orchestrator wraps three sub-protocols:
+//!   - **ZK sumcheck** (Lemma 6.5): reduces `<message, covector> = sum`,
+//!     consuming `k` short (degree-2) mask polynomials for hiding.
+//!   - **Code-switch** (Construction 9.7): reduces source IRS to a target
+//!     IRS, consuming one `cs_mask = (r ‖ s)` mask oracle of length ℓ_zk.
+//!   - **Mask proximity** (Construction 7.2): proves the committed masks are
+//!     close to C_zk codewords.
+//!
+//! The mask oracle is split across **two** C_zk trees:
+//!   - `sumcheck_masks` tree: k masks at vector_size = next_pow_2(mask_length)
+//!     (= 4 for degree-2 round polys). Committed BEFORE sumcheck — standard
+//!     ZK-sumcheck discipline.
+//!   - `cs_mask` tree: 1 mask at vector_size = ℓ_zk. Committed AFTER sumcheck
+//!     so cs_mask's `r` part can carry `fold(source.masks, folding_randomness)`
+//!     (Construction 9.7 `(r ‖ s)` structure).
+//!
+//! Splitting avoids padding the tiny sumcheck masks up to ℓ_zk; the NTT and
+//! Merkle work at C_zk's rate drops by ~4× in typical configurations.
+//!
+//! Per-round flow:
+//!   1. Sample sumcheck masks `M_0..M_{k−1}` (length `mask_length` each) and
+//!      `cs_fresh_padding` of length `l_zk − source.mask_length()`.
+//!   2. Commit `sumcheck_masks` tree (k masks padded to next_pow_2(mask_length)).
+//!   3. Run ZK sumcheck. Post-sumcheck `state.sum = δ + γ_sumcheck · dot`,
+//!      where `δ = Σ M_i(r_i)`.
+//!   4. Derive `folded_irs_masks = fold(source.masks, r_0..r_{k−1})` (Identity<F>:
+//!      no lift needed), assemble `cs_mask = (folded_irs_masks ‖ cs_fresh_padding)`,
+//!      commit `cs_mask` tree.
+//!   5. Send `δ` cleartext and reconcile
+//!      `state.sum := (sum − δ) · γ_sumcheck⁻¹` so the claim entering
+//!      code-switch is the unmasked `dot(folded_a, post_sumcheck_cov)`.
+//!   6. Code-switch updates `state.{message, irs_witness, covector, sum}`.
+//!   7. Prove sumcheck masks at `[1, r_i, …, r_i^{sumcheck_vec_size−1}]`
+//!      (gives X_i = M_i(r_i)); prove cs_mask at the post-cs covector mask
+//!      region (gives X_cs). The verifier checks `Σ X_{i<k} == δ` (binds δ);
+//!      both sides subtract X_cs to project sum to f-only.
+//!
+//! After all rounds: commit the final folded message via `basecase.commit`
+//! and run `basecase.prove`. Basecase-only plans skip the loop.
+
+use ark_ff::Field;
+use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
+use zeroize::Zeroize;
+
+use crate::{
+    algebra::{
+        dot, embedding::Identity, geometric_sequence, linear_form::LinearForm, random_vector,
+        univariate_evaluate,
+    },
+    hash::Hash,
+    protocols::{
+        code_switch::{self, fold_chunks},
+        irs_commit::Witness as IrsWitness,
+        mask_proximity,
+        mask_proximity::Config as MaskProximityConfig,
+        params::protocol_config::{MaskOracleConfig, ProtocolConfig, RoundConfig},
+        sumcheck::{SumcheckMode, SumcheckOpening},
+        zook::commit::{CommittedState, CommittedWitness},
+    },
+    transcript::{
+        codecs::U64, Codec, Decoding, DuplexSpongeInterface, ProverMessage, ProverState,
+        VerifierMessage,
+    },
+};
+
+impl<F: Field + Default + Zeroize> ProtocolConfig<Identity<F>> {
+    /// Prove `f(witness) == evaluations[j]` for every linear_form `f = linear_forms[j]` against
+    /// the committed witness. Consumes `committed`.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::prove", fields(vector_size = self.tuning().vector_size, num_rounds = self.rounds().len(), num_claims = linear_forms.len())))]
+    pub fn prove<H, R>(
+        &self,
+        ps: &mut ProverState<H, R>,
+        committed: CommittedWitness<Identity<F>>,
+        linear_forms: &[&dyn LinearForm<F>],
+        evaluations: &[F],
+    ) where
+        Standard: Distribution<F>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        F: Codec<[H::U]>,
+        u8: Decoding<[H::U]>,
+        [u8; 32]: Decoding<[H::U]>,
+        U64: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        assert_eq!(
+            linear_forms.len(),
+            evaluations.len(),
+            "linear_forms.len() != evaluations.len()"
+        );
+        assert!(
+            !linear_forms.is_empty(),
+            "zook requires ≥ 1 (form, value) pair"
+        );
+
+        // RLC challenge binds the form/value set to the commitment.
+        let batching_challenge: F = ps.verifier_message();
+        let claim_weights = geometric_sequence(batching_challenge, linear_forms.len());
+
+        // Materialize the combined covector = Σ γ^j · form_j and combined value.
+        let mut covector = vec![F::ZERO; self.tuning().vector_size];
+        for (form, &weight) in linear_forms.iter().zip(&claim_weights) {
+            form.accumulate(&mut covector, weight);
+        }
+        let batched_evaluation: F = evaluations
+            .iter()
+            .zip(&claim_weights)
+            .map(|(v, weight)| *v * weight)
+            .sum();
+
+        // Reduce to basecase inputs `(message, witness, covector, sum)`. The
+        // two arms differ only in how those are obtained.
+        let (message, basecase_witness, covector, sum) = match committed.state {
+            // Basecase-only plan: use the committed witness directly.
+            CommittedState::Basecase {
+                message,
+                irs_witness,
+            } => (message, irs_witness, covector, batched_evaluation),
+            CommittedState::Round {
+                message,
+                irs_witness,
+            } => {
+                let mut state = ProverRoundState {
+                    message,
+                    irs_witness,
+                    covector,
+                    sum: batched_evaluation,
+                };
+                for round in self.rounds() {
+                    state = prove_round(round, state, ps);
+                }
+                // After per-round reconciliation, state.sum is bound to
+                // dot(state.message, state.covector) — no extra transcript
+                // send needed entering basecase.
+                (state.message, state.irs_witness, state.covector, state.sum)
+            }
+        };
+
+        // Standard mode (BasecaseMode::Standard) sends the full witness vector
+        // and IRS randomness cleartext. Only call with Mode::ZeroKnowledge if
+        // end-to-end hiding is required.
+        let _ = self
+            .basecase()
+            .prove(ps, message, &basecase_witness, covector, sum);
+    }
+}
+
+/// Per-round transient state. `irs_witness` is `IrsWitness<F>` throughout
+/// because we restrict to `Identity<F>` embeddings (M::Source = M::Target = F).
+struct ProverRoundState<F: Field> {
+    message: Vec<F>,
+    irs_witness: IrsWitness<F>,
+    covector: Vec<F>,
+    sum: F,
+}
+
+#[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::prove_round", fields(msg_len = round.code_switch().source().message_length(), message_len = state.message.len())))]
+fn prove_round<F, H, R>(
+    round: &RoundConfig<Identity<F>>,
+    mut state: ProverRoundState<F>,
+    ps: &mut ProverState<H, R>,
+) -> ProverRoundState<F>
+where
+    F: Field + Default + Zeroize + Codec<[H::U]>,
+    Standard: Distribution<F>,
+    H: DuplexSpongeInterface,
+    R: RngCore + CryptoRng,
+    u8: Decoding<[H::U]>,
+    [u8; 32]: Decoding<[H::U]>,
+    U64: Codec<[H::U]>,
+    Hash: ProverMessage<[H::U]>,
+{
+    let msg_len = round.code_switch().source().message_length();
+
+    debug_assert_eq!(
+        dot(&state.message, &state.covector),
+        state.sum,
+        "prove_round entry: dot(message, covector) must equal sum"
+    );
+
+    // Samples and commits the sumcheck-masks tree (ZK) or is a no-op (Standard).
+    // cs_fresh_padding is pre-sampled here because it does not depend on folding randomness.
+    let mut masker = RoundMaskOracle::begin(round, ps);
+
+    let opening = round.sumcheck().prove(
+        ps,
+        &mut state.message,
+        &mut state.covector,
+        &mut state.sum,
+        masker.sumcheck_blinding(),
+    );
+
+    // Build cs_mask = (folded_irs_masks ‖ cs_fresh_padding), commit its tree,
+    // send mask_eval_sum cleartext, reconcile sum to the unmasked dot.
+    masker.bind_code_switch_mask(&state.irs_witness, &opening, &mut state.sum, ps);
+
+    debug_assert_eq!(
+        dot(&state.message, &state.covector),
+        state.sum,
+        "post-reconcile: dot(message, covector) must equal sum"
+    );
+
+    // Extend covector for ZK mask region; +0 in Standard mode.
+    state
+        .covector
+        .resize(msg_len + masker.covector_extension(), F::ZERO);
+    let cs_witness = round.code_switch().prove(
+        ps,
+        state.message,
+        std::mem::take(&mut state.irs_witness),
+        code_switch::Claim {
+            covector: &mut state.covector,
+            sum: &mut state.sum,
+        },
+        &opening.round_challenges,
+        masker.code_switch_blinding(),
+    );
+
+    // Prove both mask trees; subtract cs_mask contribution to project sum to f-only.
+    masker.finish(
+        &opening.round_challenges,
+        &state.covector[msg_len..],
+        &mut state.sum,
+        ps,
+    );
+    drop(opening);
+
+    state.message = cs_witness.message;
+    state.irs_witness = cs_witness.target_witness;
+    state.covector.truncate(state.message.len());
+
+    debug_assert_eq!(
+        dot(&state.message, &state.covector),
+        state.sum,
+        "prove_round exit: dot(message, covector) must equal sum"
+    );
+
+    state
+}
+
+/// The committed mask tree for the sumcheck sub-protocol.
+/// Holds k blinding polynomials sampled before sumcheck and opened after code-switch.
+struct SumcheckMaskTree<'a, F: Field> {
+    cfg: &'a MaskProximityConfig<F>,
+    padded_masks: Vec<Vec<F>>,
+    flat_coefficients: Vec<F>,
+    tree_witness: mask_proximity::Witness<F>,
+    padded_vec_size: usize,
+}
+
+impl<'a, F: Field + Zeroize> SumcheckMaskTree<'a, F> {
+    fn sample_and_commit<H, R>(
+        cfg: &'a MaskProximityConfig<F>,
+        num_masks: usize,
+        mask_poly_len: usize,
+        ps: &mut ProverState<H, R>,
+    ) -> Self
+    where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Standard: Distribution<F>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let padded_vec_size = cfg.c_zk_commit().vector_size();
+        let flat_coefficients: Vec<F> = random_vector(ps.rng(), num_masks * mask_poly_len);
+        let padded_masks: Vec<Vec<F>> = (0..num_masks)
+            .map(|i| {
+                let mut padded = vec![F::ZERO; padded_vec_size];
+                padded[..mask_poly_len].copy_from_slice(
+                    &flat_coefficients[i * mask_poly_len..(i + 1) * mask_poly_len],
+                );
+                padded
+            })
+            .collect();
+        let padded_mask_refs: Vec<&[F]> = padded_masks.iter().map(Vec::as_slice).collect();
+        let tree_witness = cfg.commit(ps, &padded_mask_refs);
+        Self {
+            cfg,
+            padded_masks,
+            flat_coefficients,
+            tree_witness,
+            padded_vec_size,
+        }
+    }
+
+    /// Input to sumcheck.prove(): the flat blinding coefficients.
+    fn blinding(&self) -> &[F] {
+        &self.flat_coefficients
+    }
+
+    /// Zeroize the flat blinding coefficients once sumcheck no longer needs them.
+    fn wipe_blinding(&mut self) {
+        self.flat_coefficients.zeroize();
+    }
+
+    /// δ = Σ_i evaluate(padded_masks[i], challenges[i])
+    fn eval_sum(&self, challenges: &[F]) -> F {
+        challenges
+            .iter()
+            .zip(self.padded_masks.iter())
+            .map(|(&c, mask)| univariate_evaluate(mask, c))
+            .sum()
+    }
+
+    /// Open the sumcheck-masks tree at the per-mask geometric covectors.
+    /// Zeroizes padded_masks before returning.
+    fn prove<H, R>(mut self, round_challenges: &[F], ps: &mut ProverState<H, R>)
+    where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Standard: Distribution<F>,
+        u8: Decoding<[H::U]>,
+        [u8; 32]: Decoding<[H::U]>,
+        U64: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let evaluation_covectors: Vec<Vec<F>> = round_challenges
+            .iter()
+            .map(|&c| geometric_sequence(c, self.padded_vec_size))
+            .collect();
+        let covector_refs: Vec<&[F]> = evaluation_covectors.iter().map(Vec::as_slice).collect();
+        let padded_mask_refs: Vec<&[F]> = self.padded_masks.iter().map(Vec::as_slice).collect();
+        self.cfg.prove(
+            ps,
+            self.tree_witness,
+            &padded_mask_refs,
+            Some(&covector_refs),
+        );
+        for mask in &mut self.padded_masks {
+            mask.zeroize();
+        }
+    }
+}
+
+/// The committed mask tree for the code-switch sub-protocol.
+/// Holds the single (r_folded ‖ fresh_padding) polynomial, built after sumcheck.
+struct CodeSwitchMask<'a, F: Field> {
+    cfg: &'a MaskProximityConfig<F>,
+    poly: Vec<F>,
+    tree_witness: mask_proximity::Witness<F>,
+}
+
+impl<'a, F: Field + Zeroize> CodeSwitchMask<'a, F> {
+    /// Assemble poly = (r_folded ‖ fresh_padding) and commit the cs-mask tree.
+    fn build_and_commit<H, R>(
+        r_folded: &[F],
+        mut fresh_padding: Vec<F>,
+        cfg: &'a MaskProximityConfig<F>,
+        ps: &mut ProverState<H, R>,
+    ) -> Self
+    where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Standard: Distribution<F>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let mut poly = Vec::with_capacity(r_folded.len() + fresh_padding.len());
+        poly.extend_from_slice(r_folded);
+        poly.append(&mut fresh_padding);
+        let tree_witness = cfg.commit(ps, &[&poly[..]]);
+        Self {
+            cfg,
+            poly,
+            tree_witness,
+        }
+    }
+
+    /// Code-switch blinding input: the full polynomial coefficients.
+    fn blinding(&self) -> &[F] {
+        &self.poly
+    }
+
+    /// Length of the mask oracle polynomial.
+    const fn len(&self) -> usize {
+        self.poly.len()
+    }
+
+    /// Open the cs-mask tree at `covector_region`; returns X_cs = ⟨poly, covector_region⟩.
+    /// Zeroizes poly before returning.
+    fn prove<H, R>(mut self, covector_region: &[F], ps: &mut ProverState<H, R>) -> F
+    where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Standard: Distribution<F>,
+        u8: Decoding<[H::U]>,
+        [u8; 32]: Decoding<[H::U]>,
+        U64: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let x_cs = dot(&self.poly, covector_region);
+        self.cfg.prove(
+            ps,
+            self.tree_witness,
+            &[&self.poly[..]],
+            Some(&[covector_region]),
+        );
+        self.poly.zeroize();
+        x_cs
+    }
+}
+
+/// Manages all ZK mask oracle state for one round.
+///
+/// Transitions: Disabled (Standard) or BeforeCodeSwitch → AfterCodeSwitch.
+/// The Disabled variant is the Null Object: all methods on it are no-ops or
+/// return empty slices, so prove_round has no ZK-specific branches.
+enum RoundMaskOracle<'a, F: Field> {
+    /// Standard mode or basecase-only round: no mask oracle.
+    Disabled,
+    /// ZK round — sumcheck-masks tree committed, cs_mask not yet built.
+    BeforeCodeSwitch {
+        mask_oracle: &'a MaskOracleConfig<F>,
+        sc_tree: SumcheckMaskTree<'a, F>,
+        cs_fresh_padding: Vec<F>,
+    },
+    /// ZK round — cs_mask tree committed, ready to discharge.
+    AfterCodeSwitch {
+        sc_tree: SumcheckMaskTree<'a, F>,
+        cs_mask: CodeSwitchMask<'a, F>,
+    },
+}
+
+impl<'a, F: Field + Default + Zeroize> RoundMaskOracle<'a, F> {
+    /// Construct the oracle for this round: Disabled if no mask oracle, otherwise
+    /// sample and commit the sumcheck-masks tree (BeforeCodeSwitch).
+    fn begin<H, R>(round: &'a RoundConfig<Identity<F>>, ps: &mut ProverState<H, R>) -> Self
+    where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Standard: Distribution<F>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let Some(mo) = round.mask_oracle() else {
+            return Self::Disabled;
+        };
+        let num_masks = round.sumcheck().num_rounds();
+        let mask_poly_len = match round.sumcheck().mode() {
+            SumcheckMode::ZeroKnowledge { mask_length } => mask_length.get(),
+            SumcheckMode::Standard => 0,
+        };
+        let sc_tree =
+            SumcheckMaskTree::sample_and_commit(mo.sumcheck_masks(), num_masks, mask_poly_len, ps);
+        // cs_fresh_padding is the `s` in cs_mask = (r_folded ‖ s). Sampled here because
+        // it does not depend on folding randomness, preserving the Fiat–Shamir RNG ordering.
+        let cs_fresh_padding_len = mo.l_zk().get() - round.code_switch().source().mask_length();
+        let cs_fresh_padding: Vec<F> = random_vector(ps.rng(), cs_fresh_padding_len);
+        Self::BeforeCodeSwitch {
+            mask_oracle: mo,
+            sc_tree,
+            cs_fresh_padding,
+        }
+    }
+
+    /// Flat sumcheck blinding coefficients. Returns &[] for Disabled.
+    fn sumcheck_blinding(&self) -> &[F] {
+        match self {
+            Self::BeforeCodeSwitch { sc_tree, .. } => sc_tree.blinding(),
+            _ => &[],
+        }
+    }
+
+    /// Build and commit the cs_mask tree, send δ cleartext, reconcile *sum.
+    /// Transitions BeforeCodeSwitch → AfterCodeSwitch in place.
+    /// No-op for Disabled.
+    fn bind_code_switch_mask<H, R>(
+        &mut self,
+        irs_witness: &IrsWitness<F>,
+        opening: &SumcheckOpening<F>,
+        sum: &mut F,
+        ps: &mut ProverState<H, R>,
+    ) where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Standard: Distribution<F>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let (mask_oracle, mut sc_tree, cs_fresh_padding) =
+            match std::mem::replace(self, Self::Disabled) {
+                Self::BeforeCodeSwitch {
+                    mask_oracle,
+                    sc_tree,
+                    cs_fresh_padding,
+                } => (mask_oracle, sc_tree, cs_fresh_padding),
+                other => {
+                    *self = other;
+                    return;
+                }
+            };
+
+        // Blinding coefficients are no longer needed after sumcheck.
+        sc_tree.wipe_blinding();
+
+        // cs_mask = (r_folded ‖ s): r folds the source IRS randomness by the sumcheck challenges.
+        let source_mask_len = mask_oracle.l_zk().get() - cs_fresh_padding.len();
+        let r_folded = fold_chunks(
+            &irs_witness.masks,
+            source_mask_len,
+            &opening.round_challenges,
+        );
+
+        // Build and commit the cs-mask tree (transcript: commitment hash).
+        let cs_mask = CodeSwitchMask::build_and_commit(
+            &r_folded,
+            cs_fresh_padding,
+            mask_oracle.cs_mask(),
+            ps,
+        );
+
+        // Send δ = Σ Mᵢ(rᵢ) cleartext AFTER committing the cs-mask tree (Constr. 9.7 order).
+        let delta = sc_tree.eval_sum(&opening.round_challenges);
+        ps.prover_message(&delta);
+
+        // Reconcile sum to the unmasked dot product.
+        // mask_rlc is Fiat–Shamir; zero has negligible probability for large fields.
+        let mask_rlc_inv = opening
+            .mask_rlc
+            .inverse()
+            .expect("mask_rlc non-zero (negligible probability for large fields)");
+        *sum = (*sum - delta) * mask_rlc_inv;
+
+        *self = Self::AfterCodeSwitch { sc_tree, cs_mask };
+    }
+
+    /// Number of elements to extend the covector by for the ZK region.
+    /// Returns 0 for Disabled.
+    const fn covector_extension(&self) -> usize {
+        match self {
+            Self::AfterCodeSwitch { cs_mask, .. } => cs_mask.len(),
+            _ => 0,
+        }
+    }
+
+    /// Code-switch mask polynomial coefficients. Returns &[] for Disabled.
+    fn code_switch_blinding(&self) -> &[F] {
+        match self {
+            Self::AfterCodeSwitch { cs_mask, .. } => cs_mask.blinding(),
+            Self::Disabled => &[],
+            Self::BeforeCodeSwitch { .. } => {
+                debug_assert!(
+                    false,
+                    "code_switch_blinding called before bind_code_switch_mask"
+                );
+                &[]
+            }
+        }
+    }
+
+    /// Prove both mask trees and subtract the cs_mask contribution from *sum.
+    /// No-op for Disabled.
+    fn finish<H, R>(
+        self,
+        round_challenges: &[F],
+        cs_mask_covector: &[F],
+        sum: &mut F,
+        ps: &mut ProverState<H, R>,
+    ) where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        R: RngCore + CryptoRng,
+        Standard: Distribution<F>,
+        u8: Decoding<[H::U]>,
+        [u8; 32]: Decoding<[H::U]>,
+        U64: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        if let Self::AfterCodeSwitch { sc_tree, cs_mask } = self {
+            sc_tree.prove(round_challenges, ps);
+            *sum -= cs_mask.prove(cs_mask_covector, ps);
+        }
+    }
+}

--- a/src/protocols/zook/prover.rs
+++ b/src/protocols/zook/prover.rs
@@ -40,7 +40,7 @@
 //! After all rounds: commit the final folded message via `basecase.commit`
 //! and run `basecase.prove`. Basecase-only plans skip the loop.
 
-use ark_ff::Field;
+use ark_ff::{AdditiveGroup, Field};
 use ark_std::rand::{distributions::Standard, prelude::Distribution, CryptoRng, RngCore};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
@@ -48,13 +48,16 @@ use zeroize::Zeroize;
 
 use crate::{
     algebra::{
-        dot, embedding::Identity, geometric_sequence, linear_form::LinearForm, random_vector,
-        univariate_evaluate,
+        dot,
+        embedding::{Embedding, Identity},
+        geometric_sequence,
+        linear_form::LinearForm,
+        random_vector, univariate_evaluate,
     },
     buffer::{Buffer, BufferOps},
     hash::Hash,
     protocols::{
-        code_switch::{self, fold_chunks},
+        code_switch::{self, mixed_fold_chunks},
         irs_commit::Witness as IrsWitness,
         mask_proximity,
         mask_proximity::Config as MaskProximityConfig,
@@ -68,21 +71,25 @@ use crate::{
     },
 };
 
-impl<F: Field + Default + Zeroize> ProtocolConfig<Identity<F>> {
+impl<M: Embedding + Default> ProtocolConfig<M> {
     /// Prove `f(witness) == evaluations[j]` for every linear_form `f = linear_forms[j]` against
     /// the committed witness. Consumes `committed`.
-    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::prove", fields(vector_size = self.tuning().vector_size, num_rounds = self.rounds().len(), num_claims = linear_forms.len())))]
+    ///
+    /// Round 0's code-switch folds the base witness (`IrsWitness<M::Source>`)
+    /// into an ext IRS, so only it is embedding-aware; later rounds are ext→ext.
+    /// Message, covector, and sum are in `M::Target` throughout.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::prove", fields(vector_size = self.tuning().vector_size, num_rounds = self.num_rounds(), num_claims = linear_forms.len())))]
     pub fn prove<H, R>(
         &self,
         ps: &mut ProverState<H, R>,
-        committed: CommittedWitness<Identity<F>>,
-        linear_forms: &[&dyn LinearForm<F>],
-        evaluations: &[F],
+        committed: CommittedWitness<M>,
+        linear_forms: &[&dyn LinearForm<M::Target>],
+        evaluations: &[M::Target],
     ) where
-        Standard: Distribution<F>,
+        M::Target: Field + Default + Zeroize + Codec<[H::U]>,
+        Standard: Distribution<M::Target>,
         H: DuplexSpongeInterface,
         R: RngCore + CryptoRng,
-        F: Codec<[H::U]>,
         u8: Decoding<[H::U]>,
         [u8; 32]: Decoding<[H::U]>,
         U64: Codec<[H::U]>,
@@ -99,15 +106,16 @@ impl<F: Field + Default + Zeroize> ProtocolConfig<Identity<F>> {
         );
 
         // RLC challenge binds the form/value set to the commitment.
-        let batching_challenge: F = ps.verifier_message();
-        let claim_weights = geometric_sequence(F::ONE, batching_challenge, linear_forms.len());
+        let batching_challenge: M::Target = ps.verifier_message();
+        let claim_weights =
+            geometric_sequence(M::Target::ONE, batching_challenge, linear_forms.len());
 
         // Materialize the combined covector = Σ γ^j · form_j and combined value.
-        let mut covector = vec![F::ZERO; self.tuning().vector_size];
+        let mut covector = vec![M::Target::ZERO; self.tuning().vector_size];
         for (form, &weight) in linear_forms.iter().zip(&claim_weights) {
             form.accumulate(&mut covector, weight);
         }
-        let batched_evaluation: F = evaluations
+        let batched_evaluation: M::Target = evaluations
             .iter()
             .zip(&claim_weights)
             .map(|(v, weight)| *v * weight)
@@ -125,14 +133,18 @@ impl<F: Field + Default + Zeroize> ProtocolConfig<Identity<F>> {
                 message,
                 irs_witness,
             } => {
-                let mut state = ProverRoundState {
+                let entry = ProverRoundState::<M> {
                     message,
                     irs_witness,
                     covector,
                     sum: batched_evaluation,
                 };
-                for round in self.rounds() {
-                    state = prove_round(round, state, ps);
+                let first = self
+                    .first_round()
+                    .expect("CommittedState::Round implies at least one round");
+                let mut state = prove_round::<M, _, _>(first, entry, ps);
+                for round in self.tail_rounds() {
+                    state = prove_round::<Identity<M::Target>, _, _>(round, state, ps);
                 }
                 // After per-round reconciliation, state.sum is bound to
                 // dot(state.message, state.covector) — no extra transcript
@@ -154,24 +166,27 @@ impl<F: Field + Default + Zeroize> ProtocolConfig<Identity<F>> {
     }
 }
 
-/// Per-round transient state. `irs_witness` is `IrsWitness<F>` throughout
-/// because we restrict to `Identity<F>` embeddings (M::Source = M::Target = F).
-struct ProverRoundState<F: Field> {
-    message: Vec<F>,
-    irs_witness: IrsWitness<F>,
-    covector: Vec<F>,
-    sum: F,
+/// Per-round transient state: `message`/`covector`/`sum` in `M::Target`, the
+/// witness in `M::Source`. The code-switch turns the source witness into an
+/// `M::Target` one, so [`prove_round`] maps `ProverRoundState<M>` to
+/// `ProverRoundState<Identity<M::Target>>`.
+struct ProverRoundState<M: Embedding> {
+    message: Vec<M::Target>,
+    irs_witness: IrsWitness<M::Source>,
+    covector: Vec<M::Target>,
+    sum: M::Target,
 }
 
 #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::prove_round", fields(msg_len = round.code_switch().source().message_length(), message_len = state.message.len())))]
-fn prove_round<F, H, R>(
-    round: &RoundConfig<Identity<F>>,
-    mut state: ProverRoundState<F>,
+fn prove_round<M, H, R>(
+    round: &RoundConfig<M>,
+    state: ProverRoundState<M>,
     ps: &mut ProverState<H, R>,
-) -> ProverRoundState<F>
+) -> ProverRoundState<Identity<M::Target>>
 where
-    F: Field + Default + Zeroize + Codec<[H::U]>,
-    Standard: Distribution<F>,
+    M: Embedding,
+    M::Target: Field + Default + Zeroize + Codec<[H::U]>,
+    Standard: Distribution<M::Target>,
     H: DuplexSpongeInterface,
     R: RngCore + CryptoRng,
     u8: Decoding<[H::U]>,
@@ -181,9 +196,18 @@ where
 {
     let msg_len = round.code_switch().source().message_length();
 
+    // The witness type changes across the code-switch (`M::Source` → `M::Target`),
+    // so we consume the state into owned locals and build a fresh return value.
+    let ProverRoundState {
+        message,
+        irs_witness,
+        covector,
+        mut sum,
+    } = state;
+
     debug_assert_eq!(
-        dot(&state.message, &state.covector),
-        state.sum,
+        dot(&message, &covector),
+        sum,
         "prove_round entry: dot(message, covector) must equal sum"
     );
 
@@ -195,39 +219,43 @@ where
     // buffers, fold, and move the folded result back into the `Vec` state
     // (which downstream steps resize/truncate/index directly). Both hops are
     // zero-copy on the CPU backend.
-    let mut message_buf = Buffer::from(std::mem::take(&mut state.message));
-    let mut covector_buf = Buffer::from(std::mem::take(&mut state.covector));
+    let mut message_buf = Buffer::from(message);
+    let mut covector_buf = Buffer::from(covector);
     let opening = round.sumcheck().prove(
         ps,
         &mut message_buf,
         &mut covector_buf,
-        &mut state.sum,
+        &mut sum,
         masker.sumcheck_blinding(),
     );
-    state.message = message_buf.into_vec();
-    state.covector = covector_buf.into_vec();
+    let message = message_buf.into_vec();
+    let mut covector = covector_buf.into_vec();
 
     // Build cs_mask = (folded_irs_masks ‖ cs_fresh_padding), commit its tree,
     // send mask_eval_sum cleartext, reconcile sum to the unmasked dot.
-    masker.bind_code_switch_mask(&state.irs_witness, &opening, &mut state.sum, ps);
+    masker.bind_code_switch_mask(
+        round.code_switch().source().embedding(),
+        &irs_witness,
+        &opening,
+        &mut sum,
+        ps,
+    );
 
     debug_assert_eq!(
-        dot(&state.message, &state.covector),
-        state.sum,
+        dot(&message, &covector),
+        sum,
         "post-reconcile: dot(message, covector) must equal sum"
     );
 
     // Extend covector for ZK mask region; +0 in Standard mode.
-    state
-        .covector
-        .resize(msg_len + masker.covector_extension(), F::ZERO);
+    covector.resize(msg_len + masker.covector_extension(), M::Target::ZERO);
     let cs_witness = round.code_switch().prove(
         ps,
-        state.message,
-        std::mem::take(&mut state.irs_witness),
+        message,
+        irs_witness,
         code_switch::Claim {
-            covector: &mut state.covector,
-            sum: &mut state.sum,
+            covector: &mut covector,
+            sum: &mut sum,
         },
         &opening.round_challenges,
         masker.code_switch_blinding(),
@@ -236,23 +264,27 @@ where
     // Prove both mask trees; subtract cs_mask contribution to project sum to f-only.
     masker.finish(
         &opening.round_challenges,
-        &state.covector[msg_len..],
-        &mut state.sum,
+        &covector[msg_len..],
+        &mut sum,
         ps,
     );
     drop(opening);
 
-    state.message = cs_witness.message;
-    state.irs_witness = cs_witness.target_witness;
-    state.covector.truncate(state.message.len());
+    let message = cs_witness.message;
+    covector.truncate(message.len());
 
     debug_assert_eq!(
-        dot(&state.message, &state.covector),
-        state.sum,
+        dot(&message, &covector),
+        sum,
         "prove_round exit: dot(message, covector) must equal sum"
     );
 
-    state
+    ProverRoundState {
+        message,
+        irs_witness: cs_witness.target_witness,
+        covector,
+        sum,
+    }
 }
 
 /// The committed mask tree for the sumcheck sub-protocol.
@@ -444,8 +476,9 @@ enum RoundMaskOracle<'a, F: Field> {
 impl<'a, F: Field + Default + Zeroize> RoundMaskOracle<'a, F> {
     /// Construct the oracle for this round: Disabled if no mask oracle, otherwise
     /// sample and commit the sumcheck-masks tree (BeforeCodeSwitch).
-    fn begin<H, R>(round: &'a RoundConfig<Identity<F>>, ps: &mut ProverState<H, R>) -> Self
+    fn begin<M, H, R>(round: &'a RoundConfig<M>, ps: &mut ProverState<H, R>) -> Self
     where
+        M: Embedding<Target = F>,
         F: Codec<[H::U]>,
         H: DuplexSpongeInterface,
         R: RngCore + CryptoRng,
@@ -484,13 +517,15 @@ impl<'a, F: Field + Default + Zeroize> RoundMaskOracle<'a, F> {
     /// Build and commit the cs_mask tree, send δ cleartext, reconcile *sum.
     /// Transitions BeforeCodeSwitch → AfterCodeSwitch in place.
     /// No-op for Disabled.
-    fn bind_code_switch_mask<H, R>(
+    fn bind_code_switch_mask<M, H, R>(
         &mut self,
-        irs_witness: &IrsWitness<F>,
+        embedding: &M,
+        irs_witness: &IrsWitness<M::Source>,
         opening: &SumcheckOpening<F>,
         sum: &mut F,
         ps: &mut ProverState<H, R>,
     ) where
+        M: Embedding<Target = F>,
         F: Codec<[H::U]>,
         H: DuplexSpongeInterface,
         R: RngCore + CryptoRng,
@@ -513,9 +548,11 @@ impl<'a, F: Field + Default + Zeroize> RoundMaskOracle<'a, F> {
         // Blinding coefficients are no longer needed after sumcheck.
         sc_tree.wipe_blinding();
 
-        // cs_mask = (r_folded ‖ s): r folds the source IRS randomness by the sumcheck challenges.
+        // cs_mask = (r_folded ‖ s): r folds the source IRS randomness by the
+        // sumcheck challenges (embedding-aware — see `mixed_fold_chunks`).
         let source_mask_len = mask_oracle.l_zk().get() - cs_fresh_padding.len();
-        let r_folded = fold_chunks(
+        let r_folded = mixed_fold_chunks(
+            embedding,
             irs_witness.masks.to_slice(),
             source_mask_len,
             &opening.round_challenges,

--- a/src/protocols/zook/verifier.rs
+++ b/src/protocols/zook/verifier.rs
@@ -1,0 +1,484 @@
+//! Zook verifier — mirror of [`super::prover`] (Construction 9.7).
+//!
+//! Per ZK round, the verifier:
+//!   1. Receives the **sumcheck-masks tree** commitment (pre-sumcheck — binds
+//!      each round poly's mask via Fiat-Shamir).
+//!   2. Runs `sumcheck.verify` (orchestrator tracks sumcheck challenges implicitly).
+//!      Post-sumcheck `state.sum = δ + γ_sumcheck · dot`.
+//!   3. Receives the **cs_mask tree** commitment (post-sumcheck — cs_mask
+//!      carries `r_folded` from source IRS randomness) and reads `δ`
+//!      cleartext, reconciling `state.sum := (sum − δ) · γ_sumcheck⁻¹`.
+//!   4. Runs `code_switch.verify_for_implicit` — accumulates OOD/in-domain
+//!      constraints as `ImplicitConstraint` entries instead of updating an
+//!      explicit covector.
+//!   5. Verifies sumcheck masks at `[1, r_i, …, r_i^{vec_size_A−1}]` (gives
+//!      X_i = M_i(r_i)); verifies cs_mask at the post-cs covector mask
+//!      region (gives X_cs). Checks `Σ X_i == δ` to bind δ; subtracts X_cs
+//!      to project to f-only.
+//!
+//! After all rounds: receives the basecase IRS commitment, runs
+//! `basecase.verify`, constructs `full_eval_point = all_round_challenges ++ evaluation_points`,
+//! and checks that the implicit covector evaluates to `basecase.linear_form_evaluation`
+//! in O((num_constraints + log N)) operations — eliminating the O(N) per-round
+//! covector update bottleneck.
+
+use ark_ff::Field;
+use ark_std::rand::{distributions::Standard, prelude::Distribution};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
+
+use crate::{
+    algebra::{
+        embedding::Identity,
+        geometric_sequence,
+        linear_form::{LinearForm, UnivariateEvaluation},
+    },
+    hash::Hash,
+    protocols::{
+        code_switch::CovectorUpdateParams,
+        irs_commit::Commitment as IrsCommitment,
+        mask_proximity,
+        params::protocol_config::{MaskOracleConfig, ProtocolConfig, RoundConfig},
+        sumcheck::SumcheckOpening,
+        zook::{commit::Commitment, FinalClaim},
+    },
+    transcript::{
+        codecs::U64, Codec, Decoding, DuplexSpongeInterface, ProverMessage, VerificationResult,
+        VerifierMessage, VerifierState,
+    },
+    verify,
+};
+
+impl<F: Field + Default> ProtocolConfig<Identity<F>> {
+    /// Verify `f(witness) == evaluations[j]` for every linear_form `f = linear_forms[j]` against
+    /// the received commitment.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::verify", fields(vector_size = self.tuning().vector_size, num_rounds = self.rounds().len(), num_claims = linear_forms.len())))]
+    pub fn verify<H>(
+        &self,
+        vs: &mut VerifierState<H>,
+        commitment: Commitment,
+        linear_forms: &[&dyn LinearForm<F>],
+        evaluations: &[F],
+    ) -> VerificationResult<FinalClaim<F>>
+    where
+        Standard: Distribution<F>,
+        H: DuplexSpongeInterface,
+        F: Codec<[H::U]>,
+        u8: Decoding<[H::U]>,
+        [u8; 32]: Decoding<[H::U]>,
+        U64: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        assert_eq!(
+            linear_forms.len(),
+            evaluations.len(),
+            "linear_forms.len() != evaluations.len()"
+        );
+        assert!(
+            !linear_forms.is_empty(),
+            "zook requires ≥ 1 (form, value) pair"
+        );
+
+        // RLC challenge binds the form/value set to the commitment.
+        let batching_challenge: F = vs.verifier_message();
+        let claim_weights = geometric_sequence(batching_challenge, linear_forms.len());
+        let batched_evaluation: F = evaluations
+            .iter()
+            .zip(&claim_weights)
+            .map(|(v, weight)| *v * weight)
+            .sum();
+
+        // Basecase-only path: no rounds, evaluate directly.
+        if self.rounds().is_empty() {
+            let opening =
+                self.basecase()
+                    .verify(vs, &commitment.irs_commitment, batched_evaluation)?;
+            // No constraint terms, no round scalings: linear_forms_contribution = opening.linear_form_evaluation,
+            // initial_claim_scale = F::ONE. The caller checks:
+            // F::ONE × Σ_j claim_weight_j × form_j.mle_at(evaluation_point) == linear_forms_contribution
+            return Ok(FinalClaim {
+                evaluation_point: opening.evaluation_points,
+                initial_claim_scale: F::ONE,
+                linear_forms_contribution: opening.linear_form_evaluation,
+                rlc_coefficients: claim_weights,
+            });
+        }
+
+        // Multi-round path: accumulate constraints implicitly, no initial_covector.
+        let mut state = VerifierRoundState {
+            irs_commitment: commitment.irs_commitment,
+            constraints: Vec::new(),
+            all_round_challenges: Vec::new(),
+            challenges_at: vec![0],
+            round_scale_factors: Vec::new(),
+            current_msg_len: self.tuning().vector_size,
+            sum: batched_evaluation,
+        };
+        for round in self.rounds() {
+            state = verify_round(round, state, vs)?;
+        }
+
+        let opening = self
+            .basecase()
+            .verify(vs, &state.irs_commitment, state.sum)?;
+
+        // full_eval_point = all round challenges ++ basecase evaluation points.
+        let full_eval_point: Vec<F> = state
+            .all_round_challenges
+            .iter()
+            .chain(opening.evaluation_points.iter())
+            .copied()
+            .collect();
+        debug_assert_eq!(
+            full_eval_point.len(),
+            self.tuning().vector_size.trailing_zeros() as usize,
+            "full_eval_point length must equal log2(vector_size)"
+        );
+
+        // Compute scale_suffixes[round_idx] = Π_{r'=round_idx..num_completed_rounds-1} round_scale_factors[r'].
+        let num_completed_rounds = state.round_scale_factors.len();
+        let mut scale_suffixes = vec![F::ONE; num_completed_rounds + 1];
+        for round_idx in (0..num_completed_rounds).rev() {
+            scale_suffixes[round_idx] =
+                state.round_scale_factors[round_idx] * scale_suffixes[round_idx + 1];
+        }
+
+        // Compute constraint contributions (O(num_constraints × log N)).
+        // constraint_sum = Σ_c c.batching_weight × scale_suffixes[c.round+1] × mle_of_geom(c.eval_point, z_suffix)
+        let constraint_sum: F = state
+            .constraints
+            .iter()
+            .map(|c| {
+                let z_suffix_start = state.challenges_at[c.added_at_round + 1];
+                let z_suffix =
+                    &full_eval_point[z_suffix_start..z_suffix_start + c.domain_bits as usize];
+                c.batching_weight
+                    * scale_suffixes[c.added_at_round + 1]
+                    * UnivariateEvaluation::new(c.eval_point, 1usize << c.domain_bits)
+                        .mle_evaluate(z_suffix)
+            })
+            .sum();
+
+        // linear_forms_contribution is what scale_suffixes[0] × initial_forms_mle must equal.
+        // The caller verifies: scale_suffixes[0] × Σ_j γ^j × form_j.mle_at(full_eval_point) == linear_forms_contribution
+        let linear_forms_contribution = opening.linear_form_evaluation - constraint_sum;
+
+        Ok(FinalClaim {
+            evaluation_point: full_eval_point,
+            initial_claim_scale: scale_suffixes[0],
+            linear_forms_contribution,
+            rlc_coefficients: claim_weights,
+        })
+    }
+}
+
+struct VerifierRoundState<F: Field> {
+    irs_commitment: IrsCommitment,
+    /// Deferred constraint terms from code_switch OOD and in-domain constraints.
+    constraints: Vec<ImplicitConstraint<F>>,
+    /// All sumcheck round challenges seen so far, in order.
+    all_round_challenges: Vec<F>,
+    /// `challenges_at[r]` = number of cumulative challenges before round r.
+    /// Length = number of rounds processed + 1 (initial entry is 0).
+    challenges_at: Vec<usize>,
+    /// `original_sl_coeff` from each round's code_switch, in order.
+    round_scale_factors: Vec<F>,
+    /// Current message length (size of post-fold covector this round).
+    current_msg_len: usize,
+    sum: F,
+}
+
+struct ImplicitConstraint<F: Field> {
+    /// OOD alpha or in-domain omega.
+    eval_point: F,
+    /// RLC coefficient at the time this constraint was added.
+    batching_weight: F,
+    /// log2 of the effective domain size = log2(msg_len when added).
+    /// The final contribution is batching_weight * mle_evaluate(eval_point, z_suffix)
+    /// where z_suffix has exactly this many elements.
+    domain_bits: u32,
+    /// Index into `round_scale_factors`: which round added this constraint.
+    /// `scale_suffixes[added_at_round + 1]` is the product of all round_scale_factors
+    /// from the round after this one to the end.
+    added_at_round: usize,
+}
+
+/// Manages ZK mask verification state for one round.
+/// Mirrors `RoundMaskOracle` in `prover.rs` on the receive side.
+/// `Disabled` is the Null Object for Standard mode — all methods return Ok(()) / &[].
+enum RoundMaskOracleCheck<'a, F: Field> {
+    /// Standard mode: no mask oracle.
+    Disabled,
+    /// ZK — sumcheck-masks commitment received; awaiting cs_mask.
+    SumcheckCommitmentReceived {
+        mo: &'a MaskOracleConfig<F>,
+        sc_commitment: mask_proximity::Commitment,
+        /// source IRS randomness length — needed for zk_tail in verify_and_discharge.
+        source_mask_len: usize,
+    },
+    /// ZK — both commitments received, sum reconciled; ready to verify and discharge.
+    ReadyForDischarge {
+        mo: &'a MaskOracleConfig<F>,
+        sc_commitment: mask_proximity::Commitment,
+        cs_commitment: mask_proximity::Commitment,
+        /// δ = Σ Mᵢ(rᵢ) received from transcript; bound by the sumcheck-mask opening check.
+        mask_eval_sum: F,
+        source_mask_len: usize,
+    },
+}
+
+impl<'a, F: Field + Default> RoundMaskOracleCheck<'a, F> {
+    /// Receive the sumcheck-masks commitment (ZK) or construct Disabled (Standard).
+    fn begin<H>(
+        round: &'a RoundConfig<Identity<F>>,
+        vs: &mut VerifierState<H>,
+    ) -> VerificationResult<Self>
+    where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        Hash: ProverMessage<[H::U]>,
+    {
+        match round.mask_oracle() {
+            None => Ok(Self::Disabled),
+            Some(mo) => {
+                let sc_commitment = mo.sumcheck_masks().receive_commitment(vs)?;
+                let source_mask_len = round.code_switch().source().mask_length();
+                Ok(Self::SumcheckCommitmentReceived {
+                    mo,
+                    sc_commitment,
+                    source_mask_len,
+                })
+            }
+        }
+    }
+
+    /// Receive the cs_mask commitment + mask_eval_sum (δ) cleartext, then reconcile *sum.
+    /// Transitions SumcheckCommitmentReceived → ReadyForDischarge in place.
+    /// No-op for Disabled.
+    fn receive_cs_mask_and_reconcile<H>(
+        &mut self,
+        opening: &SumcheckOpening<F>,
+        vs: &mut VerifierState<H>,
+        sum: &mut F,
+    ) -> VerificationResult<()>
+    where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let (mo, sc_commitment, source_mask_len) = match std::mem::replace(self, Self::Disabled) {
+            Self::SumcheckCommitmentReceived {
+                mo,
+                sc_commitment,
+                source_mask_len,
+            } => (mo, sc_commitment, source_mask_len),
+            other => {
+                *self = other;
+                return Ok(());
+            }
+        };
+
+        let cs_commitment = mo.cs_mask().receive_commitment(vs)?;
+        let mask_eval_sum: F = vs.prover_message()?;
+
+        // Reconcile: sum was (mask_eval_sum + mask_rlc · dot), now (sum − δ)/mask_rlc = dot.
+        // mask_rlc is Fiat–Shamir; zero has negligible probability for large fields.
+        let mask_rlc_inv = opening
+            .mask_rlc
+            .inverse()
+            .expect("mask_rlc non-zero (negligible probability for large fields)");
+        *sum = (*sum - mask_eval_sum) * mask_rlc_inv;
+
+        *self = Self::ReadyForDischarge {
+            mo,
+            sc_commitment,
+            cs_commitment,
+            mask_eval_sum,
+            source_mask_len,
+        };
+        Ok(())
+    }
+
+    /// Verify both mask trees and subtract the cs_mask contribution from *sum.
+    /// No-op for Disabled.
+    ///
+    /// Soundness: `code_switch.verify_for_implicit` (step 4) checked OOD/in-domain
+    /// consistency of the target codeword but did NOT verify the masks are close to
+    /// C_zk. Both checks are load-bearing per Theorem 9.10 / Construction 7.2.
+    fn verify_and_discharge<H>(
+        self,
+        round_challenges: &[F],
+        msg_len: usize,
+        update_params: &CovectorUpdateParams<F>,
+        vs: &mut VerifierState<H>,
+        sum: &mut F,
+    ) -> VerificationResult<()>
+    where
+        F: Codec<[H::U]>,
+        H: DuplexSpongeInterface,
+        u8: Decoding<[H::U]>,
+        [u8; 32]: Decoding<[H::U]>,
+        U64: Codec<[H::U]>,
+        Hash: ProverMessage<[H::U]>,
+    {
+        let (mo, sc_commitment, cs_commitment, mask_eval_sum, source_mask_len) = match self {
+            Self::ReadyForDischarge {
+                mo,
+                sc_commitment,
+                cs_commitment,
+                mask_eval_sum,
+                source_mask_len,
+            } => (
+                mo,
+                sc_commitment,
+                cs_commitment,
+                mask_eval_sum,
+                source_mask_len,
+            ),
+            Self::Disabled => return Ok(()),
+            Self::SumcheckCommitmentReceived { .. } => {
+                debug_assert!(
+                    false,
+                    "verify_and_discharge called before receive_cs_mask_and_reconcile"
+                );
+                return Ok(());
+            }
+        };
+
+        // --- Sumcheck-masks tree ---
+        // Verify each mask at its geometric covector [1, rᵢ, rᵢ², …]; check Σ Xᵢ == mask_eval_sum.
+        let sumcheck_vec_size = mo.sumcheck_masks().c_zk_commit().vector_size();
+        let sm_covectors: Vec<Vec<F>> = round_challenges
+            .iter()
+            .map(|&r| geometric_sequence(r, sumcheck_vec_size))
+            .collect();
+        let sm_refs: Vec<&[F]> = sm_covectors.iter().map(Vec::as_slice).collect();
+        let sm_x_values = mo
+            .sumcheck_masks()
+            .verify(vs, &sc_commitment, Some(&sm_refs))?
+            .expect("sumcheck-mask values always returned when covectors passed");
+        let sumcheck_x_sum: F = sm_x_values.iter().copied().sum();
+        verify!(sumcheck_x_sum == mask_eval_sum);
+
+        // --- cs_mask tree ---
+        // Reconstruct zk_tail: the covector region [msg_len .. msg_len + l_zk].
+        // OOD points contribute over the full l_zk; in-domain only over source_mask_len.
+        let l_zk = mo.l_zk().get();
+        let mut zk_tail = vec![F::ZERO; l_zk];
+
+        for (coeff, alpha) in update_params
+            .ood_rlc_coeffs
+            .iter()
+            .zip(&update_params.ood_eval_points)
+        {
+            let alpha_msg_pow = alpha.pow([msg_len as u64]);
+            let mut alpha_l = alpha_msg_pow;
+            for entry in &mut zk_tail {
+                *entry += *coeff * alpha_l;
+                alpha_l *= *alpha;
+            }
+        }
+        for (coeff, omega) in update_params
+            .in_domain_rlc_coeffs
+            .iter()
+            .zip(&update_params.in_domain_eval_points)
+        {
+            let omega_msg_pow = omega.pow([msg_len as u64]);
+            let mut omega_l = omega_msg_pow;
+            for entry in &mut zk_tail[..source_mask_len] {
+                *entry += *coeff * omega_l;
+                omega_l *= *omega;
+            }
+        }
+
+        let cs_cov: [&[F]; 1] = [&zk_tail];
+        let cs_x_values = mo
+            .cs_mask()
+            .verify(vs, &cs_commitment, Some(&cs_cov))?
+            .expect("cs_mask value always returned when covector passed");
+        *sum -= cs_x_values[0];
+
+        Ok(())
+    }
+}
+
+#[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::verify_round", fields(msg_len = round.code_switch().source().message_length())))]
+fn verify_round<F, H>(
+    round: &RoundConfig<Identity<F>>,
+    mut state: VerifierRoundState<F>,
+    vs: &mut VerifierState<H>,
+) -> VerificationResult<VerifierRoundState<F>>
+where
+    F: Field + Default + Codec<[H::U]>,
+    Standard: Distribution<F>,
+    H: DuplexSpongeInterface,
+    u8: Decoding<[H::U]>,
+    [u8; 32]: Decoding<[H::U]>,
+    U64: Codec<[H::U]>,
+    Hash: ProverMessage<[H::U]>,
+{
+    let msg_len = round.code_switch().source().message_length();
+
+    // Receive sumcheck-masks commitment (ZK) or construct Disabled (Standard).
+    let mut masker = RoundMaskOracleCheck::begin(round, vs)?;
+
+    // Sumcheck: mutates sum, records round challenges for full_eval_point reconstruction.
+    let opening = round.sumcheck().verify(vs, &mut state.sum)?;
+    state
+        .all_round_challenges
+        .extend_from_slice(&opening.round_challenges);
+    state.current_msg_len = msg_len;
+
+    // Receive cs_mask commitment + mask_eval_sum (δ), reconcile sum to the unmasked dot.
+    masker.receive_cs_mask_and_reconcile(&opening, vs, &mut state.sum)?;
+
+    // Code-switch: accumulate implicit constraints; no explicit covector update.
+    let (target_commitment, update_params) = round.code_switch().verify_for_implicit(
+        vs,
+        &mut state.sum,
+        &opening.round_challenges,
+        &state.irs_commitment,
+    )?;
+    let current_round = state.round_scale_factors.len();
+    let domain_bits = msg_len.trailing_zeros();
+    for (batching_weight, eval_point) in update_params
+        .ood_rlc_coeffs
+        .iter()
+        .zip(&update_params.ood_eval_points)
+    {
+        state.constraints.push(ImplicitConstraint {
+            eval_point: *eval_point,
+            batching_weight: *batching_weight,
+            domain_bits,
+            added_at_round: current_round,
+        });
+    }
+    for (batching_weight, eval_point) in update_params
+        .in_domain_rlc_coeffs
+        .iter()
+        .zip(&update_params.in_domain_eval_points)
+    {
+        state.constraints.push(ImplicitConstraint {
+            eval_point: *eval_point,
+            batching_weight: *batching_weight,
+            domain_bits,
+            added_at_round: current_round,
+        });
+    }
+    state
+        .round_scale_factors
+        .push(update_params.original_sl_coeff);
+    state.challenges_at.push(state.all_round_challenges.len());
+    state.irs_commitment = target_commitment;
+
+    // Verify both mask trees and subtract cs_mask contribution from sum.
+    masker.verify_and_discharge(
+        &opening.round_challenges,
+        msg_len,
+        &update_params,
+        vs,
+        &mut state.sum,
+    )?;
+
+    Ok(state)
+}

--- a/src/protocols/zook/verifier.rs
+++ b/src/protocols/zook/verifier.rs
@@ -29,7 +29,7 @@ use tracing::instrument;
 
 use crate::{
     algebra::{
-        embedding::Identity,
+        embedding::{Embedding, Identity},
         geometric_sequence,
         linear_form::{LinearForm, UnivariateEvaluation},
     },
@@ -49,21 +49,24 @@ use crate::{
     verify,
 };
 
-impl<F: Field + Default> ProtocolConfig<Identity<F>> {
+impl<M: Embedding + Default> ProtocolConfig<M> {
     /// Verify `f(witness) == evaluations[j]` for every linear_form `f = linear_forms[j]` against
     /// the received commitment.
-    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::verify", fields(vector_size = self.tuning().vector_size, num_rounds = self.rounds().len(), num_claims = linear_forms.len())))]
+    ///
+    /// The verifier holds no base-field state — all arithmetic is in `M::Target`
+    /// — so only round 0's dispatch (over embedding `M`) is embedding-aware.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::verify", fields(vector_size = self.tuning().vector_size, num_rounds = self.num_rounds(), num_claims = linear_forms.len())))]
     pub fn verify<H>(
         &self,
         vs: &mut VerifierState<H>,
         commitment: Commitment,
-        linear_forms: &[&dyn LinearForm<F>],
-        evaluations: &[F],
-    ) -> VerificationResult<FinalClaim<F>>
+        linear_forms: &[&dyn LinearForm<M::Target>],
+        evaluations: &[M::Target],
+    ) -> VerificationResult<FinalClaim<M::Target>>
     where
-        Standard: Distribution<F>,
+        M::Target: Default + Codec<[H::U]>,
+        Standard: Distribution<M::Target>,
         H: DuplexSpongeInterface,
-        F: Codec<[H::U]>,
         u8: Decoding<[H::U]>,
         [u8; 32]: Decoding<[H::U]>,
         U64: Codec<[H::U]>,
@@ -79,26 +82,28 @@ impl<F: Field + Default> ProtocolConfig<Identity<F>> {
             "zook requires ≥ 1 (form, value) pair"
         );
 
+        let one = <M::Target as Field>::ONE;
+
         // RLC challenge binds the form/value set to the commitment.
-        let batching_challenge: F = vs.verifier_message();
-        let claim_weights = geometric_sequence(F::ONE, batching_challenge, linear_forms.len());
-        let batched_evaluation: F = evaluations
+        let batching_challenge: M::Target = vs.verifier_message();
+        let claim_weights = geometric_sequence(one, batching_challenge, linear_forms.len());
+        let batched_evaluation: M::Target = evaluations
             .iter()
             .zip(&claim_weights)
             .map(|(v, weight)| *v * weight)
             .sum();
 
         // Basecase-only path: no rounds, evaluate directly.
-        if self.rounds().is_empty() {
+        if !self.has_rounds() {
             let opening =
                 self.basecase()
                     .verify(vs, &commitment.irs_commitment, batched_evaluation)?;
             // No constraint terms, no round scalings: linear_forms_contribution = opening.linear_form_evaluation,
-            // initial_claim_scale = F::ONE. The caller checks:
-            // F::ONE × Σ_j claim_weight_j × form_j.mle_at(evaluation_point) == linear_forms_contribution
+            // initial_claim_scale = ONE. The caller checks:
+            // ONE × Σ_j claim_weight_j × form_j.mle_at(evaluation_point) == linear_forms_contribution
             return Ok(FinalClaim {
                 evaluation_point: opening.evaluation_points,
-                initial_claim_scale: F::ONE,
+                initial_claim_scale: one,
                 linear_forms_contribution: opening.linear_form_evaluation,
                 rlc_coefficients: claim_weights,
             });
@@ -114,8 +119,11 @@ impl<F: Field + Default> ProtocolConfig<Identity<F>> {
             current_msg_len: self.tuning().vector_size,
             sum: batched_evaluation,
         };
-        for round in self.rounds() {
-            state = verify_round(round, state, vs)?;
+        if let Some(first) = self.first_round() {
+            state = verify_round::<M, H>(first, state, vs)?;
+        }
+        for round in self.tail_rounds() {
+            state = verify_round::<Identity<M::Target>, H>(round, state, vs)?;
         }
 
         let opening = self
@@ -123,7 +131,7 @@ impl<F: Field + Default> ProtocolConfig<Identity<F>> {
             .verify(vs, &state.irs_commitment, state.sum)?;
 
         // full_eval_point = all round challenges ++ basecase evaluation points.
-        let full_eval_point: Vec<F> = state
+        let full_eval_point: Vec<M::Target> = state
             .all_round_challenges
             .iter()
             .chain(opening.evaluation_points.iter())
@@ -137,7 +145,7 @@ impl<F: Field + Default> ProtocolConfig<Identity<F>> {
 
         // Compute scale_suffixes[round_idx] = Π_{r'=round_idx..num_completed_rounds-1} round_scale_factors[r'].
         let num_completed_rounds = state.round_scale_factors.len();
-        let mut scale_suffixes = vec![F::ONE; num_completed_rounds + 1];
+        let mut scale_suffixes = vec![one; num_completed_rounds + 1];
         for round_idx in (0..num_completed_rounds).rev() {
             scale_suffixes[round_idx] =
                 state.round_scale_factors[round_idx] * scale_suffixes[round_idx + 1];
@@ -145,7 +153,7 @@ impl<F: Field + Default> ProtocolConfig<Identity<F>> {
 
         // Compute constraint contributions (O(num_constraints × log N)).
         // constraint_sum = Σ_c c.batching_weight × scale_suffixes[c.round+1] × mle_of_geom(c.eval_point, z_suffix)
-        let constraint_sum: F = state
+        let constraint_sum: M::Target = state
             .constraints
             .iter()
             .map(|c| {
@@ -229,11 +237,12 @@ enum RoundMaskOracleCheck<'a, F: Field> {
 
 impl<'a, F: Field + Default> RoundMaskOracleCheck<'a, F> {
     /// Receive the sumcheck-masks commitment (ZK) or construct Disabled (Standard).
-    fn begin<H>(
-        round: &'a RoundConfig<Identity<F>>,
+    fn begin<M, H>(
+        round: &'a RoundConfig<M>,
         vs: &mut VerifierState<H>,
     ) -> VerificationResult<Self>
     where
+        M: Embedding<Target = F>,
         F: Codec<[H::U]>,
         H: DuplexSpongeInterface,
         Hash: ProverMessage<[H::U]>,
@@ -403,14 +412,15 @@ impl<'a, F: Field + Default> RoundMaskOracleCheck<'a, F> {
 }
 
 #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::verify_round", fields(msg_len = round.code_switch().source().message_length())))]
-fn verify_round<F, H>(
-    round: &RoundConfig<Identity<F>>,
-    mut state: VerifierRoundState<F>,
+fn verify_round<M, H>(
+    round: &RoundConfig<M>,
+    mut state: VerifierRoundState<M::Target>,
     vs: &mut VerifierState<H>,
-) -> VerificationResult<VerifierRoundState<F>>
+) -> VerificationResult<VerifierRoundState<M::Target>>
 where
-    F: Field + Default + Codec<[H::U]>,
-    Standard: Distribution<F>,
+    M: Embedding,
+    M::Target: Field + Default + Codec<[H::U]>,
+    Standard: Distribution<M::Target>,
     H: DuplexSpongeInterface,
     u8: Decoding<[H::U]>,
     [u8; 32]: Decoding<[H::U]>,

--- a/src/protocols/zook/verifier.rs
+++ b/src/protocols/zook/verifier.rs
@@ -237,10 +237,7 @@ enum RoundMaskOracleCheck<'a, F: Field> {
 
 impl<'a, F: Field + Default> RoundMaskOracleCheck<'a, F> {
     /// Receive the sumcheck-masks commitment (ZK) or construct Disabled (Standard).
-    fn begin<M, H>(
-        round: &'a RoundConfig<M>,
-        vs: &mut VerifierState<H>,
-    ) -> VerificationResult<Self>
+    fn begin<M, H>(round: &'a RoundConfig<M>, vs: &mut VerifierState<H>) -> VerificationResult<Self>
     where
         M: Embedding<Target = F>,
         F: Codec<[H::U]>,


### PR DESCRIPTION
## Summary

Adds the Zook zero-knowledge protocol (Construction 9.7) end-to-end, along with the supporting protocol and parameter-selection changes it needs. Added adaptive rate planning for optimised proving schedule.

### Changes

- **Zook protocol** (`protocols/zook/`) : new module implementing the Construction 9.7 ZK flow: commit → per-round (sumcheck → code-switch → mask discharge) → basecase, closed out via `FinalClaim`.
- **Code-switch** : threads a mutable `Claim { covector, sum }` keeping `μ == ⟨vector, covector⟩` across rounds; adds `verify_for_implicit`/`CovectorUpdateParams` for implicit covector accumulation.
- **Mask proximity** : per-mask discharge (`mask_contribution_covectors`) running the Construction 7.2 target check, with claims bound before γ.
- **NTT** : masks moved out of the engine: `interleaved_encode` is now a pure encoder over `message ‖ mask` slices (`&[&[F]] → Buffer<F>`); drops the `Messages`/`masks` API.
- **Adaptive rate scheduling** (`params/`) : new `RateSchedule` (`Stepping`/`Capped`/`Adaptive`) and a Pareto-knee planner (`adaptive.rs`) choosing per-round inverse rates under the security target.
- **Buffer** : adds `wipe()` (zeroize secret buffers) and `into_vec()` (zero-copy readback for in-place sumcheck/basecase folds).
- **Mask Machinery** : adds a proper mask discharge and generate machinery.

### Zook protocol flow

```mermaid
flowchart TD
    A["commit(witness)<br/>→ CommittedWitness"] --> B["γ ← verifier<br/>(RLC challenge)"]
    B --> C["covector = Σ γ·formⱼ<br/>sum = Σ γ·evalⱼ"]
    C --> D{"CommittedState?"}

    D -->|Basecase-only| BC
    D -->|Round| L

    subgraph L["per round: reduce (message, covector, sum)"]
        direction TB
        R0["RoundMaskOracle::begin<br/>sample + commit sumcheck-mask tree"]
        R1["sumcheck.prove(message, covector, sum, blinding)<br/>→ opening (round challenges)"]
        R2["bind_code_switch_mask<br/>build cs_mask, commit, send mask_eval_sum<br/>reconcile sum → unmasked dot"]
        R3["extend covector for ZK mask region"]
        R4["code_switch.prove(message, irs_witness,<br/>Claim{covector, sum}, challenges, cs_mask)<br/>→ cs_witness"]
        R5["masker.finish<br/>prove both mask trees<br/>subtract cs_mask contribution from sum"]
        R6["message ← cs_witness.message<br/>irs_witness ← cs_witness.target_witness<br/>truncate covector"]
        R0 --> R1 --> R2 --> R3 --> R4 --> R5 --> R6
    end

    L -->|"loops over self.rounds()<br/>invariant: sum == ⟨message, covector⟩"| BC

    BC["basecase.prove(message, witness, covector, sum)"] --> F["FinalClaim<br/>verifier checks:<br/>scale · Σ rlcⱼ · formⱼ(eval_pt) == contribution"]
```