### PR TITLE
Zook : Delay the witness lift to the first sumcheck fold

### DIFF
--- a/src/algebra/sumcheck.rs
+++ b/src/algebra/sumcheck.rs
@@ -1,8 +1,8 @@
-use ark_ff::Field;
+use ark_ff::{AdditiveGroup, Field};
 #[cfg(feature = "parallel")]
-use rayon::join;
+use rayon::{join, prelude::*};
 
-use crate::algebra::{dot, embedding::Embedding, scalar_mul};
+use crate::algebra::{dot, embedding::Embedding, mixed_dot, scalar_mul};
 #[cfg(feature = "parallel")]
 use crate::utils::workload_size;
 
@@ -110,6 +110,113 @@ pub fn fold_and_compute_polynomial<F: Field>(a: &mut Vec<F>, b: &mut Vec<F>, wei
     compute_sumcheck_polynomial(a, b)
 }
 
+/// Embedding-aware [`compute_sumcheck_polynomial`]: `a` lives in the source
+/// field, `b` in the target field.
+///
+/// Computes the same `(c0, c2)` as `compute_sumcheck_polynomial(lift(a), b)`
+/// (the embedding is a ring homomorphism) without materializing the lift.
+pub fn mixed_compute_sumcheck_polynomial<M: Embedding>(
+    embedding: &M,
+    a: &[M::Source],
+    b: &[M::Target],
+) -> (M::Target, M::Target) {
+    fn recurse<M: Embedding>(
+        embedding: &M,
+        a0: &[M::Source],
+        a1: &[M::Source],
+        b0: &[M::Target],
+        b1: &[M::Target],
+    ) -> (M::Target, M::Target) {
+        debug_assert_eq!(a0.len(), b0.len());
+        debug_assert_eq!(a1.len(), b1.len());
+        debug_assert_eq!(a0.len(), a1.len());
+
+        #[cfg(feature = "parallel")]
+        if a0.len() * 4 > workload_size::<M::Target>() {
+            let mid = a0.len() / 2;
+            let (a0l, a0r) = a0.split_at(mid);
+            let (b0l, b0r) = b0.split_at(mid);
+            let (a1l, a1r) = a1.split_at(mid);
+            let (b1l, b1r) = b1.split_at(mid);
+            let (left, right) = join(
+                || recurse(embedding, a0l, a1l, b0l, b1l),
+                || recurse(embedding, a0r, a1r, b0r, b1r),
+            );
+            return (left.0 + right.0, left.1 + right.1);
+        }
+        let mut acc0 = M::Target::ZERO;
+        let mut acc2 = M::Target::ZERO;
+        for ((&a0, &a1), (&b0, &b1)) in a0.iter().zip(a1).zip(b0.iter().zip(b1)) {
+            acc0 += embedding.mixed_mul(b0, a0);
+            acc2 += embedding.mixed_mul(b1 - b0, a1 - a0);
+        }
+        (acc0, acc2)
+    }
+
+    let non_padded = a.len().min(b.len());
+    let a = &a[..non_padded];
+    let b = &b[..non_padded];
+    if a.is_empty() {
+        return (M::Target::ZERO, M::Target::ZERO);
+    }
+    if a.len() == 1 {
+        return (embedding.mixed_mul(b[0], a[0]), M::Target::ZERO);
+    }
+
+    let half = a.len().next_power_of_two() >> 1;
+    let (a0, a1) = a.split_at(half);
+    let (b0, b1) = b.split_at(half);
+    debug_assert!(a0.len() >= a1.len());
+    let (a0, a0_tail) = a0.split_at(a1.len());
+    let (b0, b0_tail) = b0.split_at(a1.len());
+    let (acc0, acc2) = recurse(embedding, a0, a1, b0, b1);
+
+    // Handle the tail part where a1, b1 is implicit zero padding,
+    // When a1, b1 = 0, then acc0 = acc2 = a0 * b0:
+    let acc = mixed_dot(embedding, b0_tail, a0_tail);
+
+    (acc0 + acc, acc2 + acc)
+}
+
+/// Embedding-aware [`fold`]: folds source-field `values` at a target-field
+/// `weight`, lifting the result into the target field.
+///
+/// Returns the same vector as `fold(lift(values), weight)` (the embedding is a
+/// ring homomorphism) without materializing the lift. Like [`fold`], `values`
+/// is implicitly zero-padded to the next power of two and the output length is
+/// always a power of two (or zero).
+pub fn mixed_fold<M: Embedding>(
+    embedding: &M,
+    values: &[M::Source],
+    weight: M::Target,
+) -> Vec<M::Target> {
+    if values.len() <= 1 {
+        return values.iter().map(|&v| embedding.map(v)).collect();
+    }
+
+    let half = values.len().next_power_of_two() >> 1;
+    let (low, high) = values.split_at(half);
+    debug_assert!(low.len() >= high.len());
+    let (low, tail) = low.split_at(high.len());
+
+    let folded = |(&low, &high): (&M::Source, &M::Source)| {
+        embedding.mixed_add(embedding.mixed_mul(weight, high - low), low)
+    };
+    // Tail part where `high` is implicit zero padding: low * (1 - weight).
+    let tail_folded = |&low: &M::Source| embedding.mixed_mul(M::Target::ONE - weight, low);
+
+    #[cfg(feature = "parallel")]
+    if half > workload_size::<M::Target>() {
+        let mut out: Vec<M::Target> = low.par_iter().zip(high).map(folded).collect();
+        out.par_extend(tail.par_iter().map(tail_folded));
+        return out;
+    }
+
+    let mut out: Vec<M::Target> = low.iter().zip(high).map(folded).collect();
+    out.extend(tail.iter().map(tail_folded));
+    out
+}
+
 /// Evaluate a coefficient vector at a multilinear point in the target field.
 pub fn mixed_eval<M: Embedding>(
     embedding: &M,
@@ -169,6 +276,36 @@ pub(crate) mod tests {
             assert_eq!(compute_sumcheck_polynomial(&vector, &covector), expected);
             assert_eq!(compute_sumcheck_polynomial(&extended_vector, &covector), expected);
             assert_eq!(compute_sumcheck_polynomial(&vector, &extended_covector), expected);
+        });
+    }
+
+    #[test]
+    fn mixed_sumcheck_poly_matches_lifted() {
+        use crate::algebra::{embedding::Basefield, fields::Field64_3, lift};
+        let embedding = Basefield::<Field64_3>::new();
+        proptest!(|(seed: u64, length in 0_usize..(1 << 10))| {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let a: Vec<F> = random_vector(&mut rng, length);
+            let b: Vec<Field64_3> = random_vector(&mut rng, length);
+            let expected = compute_sumcheck_polynomial(&lift(&embedding, &a), &b);
+            assert_eq!(
+                mixed_compute_sumcheck_polynomial(&embedding, &a, &b),
+                expected
+            );
+        });
+    }
+
+    #[test]
+    fn mixed_fold_matches_lifted() {
+        use crate::algebra::{embedding::Basefield, fields::Field64_3, lift};
+        let embedding = Basefield::<Field64_3>::new();
+        proptest!(|(seed: u64, length in 0_usize..(1 << 10))| {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let a: Vec<F> = random_vector(&mut rng, length);
+            let weight = rng.gen::<Field64_3>();
+            let mut lifted = lift(&embedding, &a);
+            fold(&mut lifted, weight);
+            assert_eq!(mixed_fold(&embedding, &a, weight), lifted);
         });
     }
 

--- a/src/buffer/cpu.rs
+++ b/src/buffer/cpu.rs
@@ -244,6 +244,28 @@ impl<F: Field> BufferMath<F> for CpuBuffer<F> {
         crate::algebra::mixed_dot(embedding, &other.data, &self.data)
     }
 
+    fn mixed_sumcheck_polynomial<M: Embedding<Source = F>>(
+        &self,
+        embedding: &M,
+        other: &CpuBuffer<M::Target>,
+    ) -> (M::Target, M::Target) {
+        crate::algebra::sumcheck::mixed_compute_sumcheck_polynomial(
+            embedding,
+            &self.data,
+            &other.data,
+        )
+    }
+
+    fn mixed_fold<M: Embedding<Source = F>>(
+        &self,
+        embedding: &M,
+        weight: M::Target,
+    ) -> CpuBuffer<M::Target> {
+        CpuBuffer {
+            data: crate::algebra::sumcheck::mixed_fold(embedding, &self.data, weight),
+        }
+    }
+
     fn mixed_scalar_mul_add_to<M: Embedding<Source = F>>(
         &self,
         embedding: &M,

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -173,6 +173,29 @@ pub trait BufferMath<F: Field>: Clone {
         other: &Self::TargetBuffer<M::Target>,
     ) -> M::Target;
 
+    /// Sumcheck round coefficients `(c0, c2)` for the mixed inner product of
+    /// source-field `self` against a target-field covector.
+    ///
+    /// Embedding-aware [`Self::sumcheck_polynomial`]: same result as lifting
+    /// `self` first, without materializing the lift.
+    fn mixed_sumcheck_polynomial<M: Embedding<Source = F>>(
+        &self,
+        embedding: &M,
+        other: &Self::TargetBuffer<M::Target>,
+    ) -> (M::Target, M::Target);
+
+    /// Fold source-field `self` at a target-field weight, lifting the result
+    /// into the target field.
+    ///
+    /// Embedding-aware [`Self::fold`]: same result as lifting `self` first,
+    /// without materializing the lift.
+    #[must_use]
+    fn mixed_fold<M: Embedding<Source = F>>(
+        &self,
+        embedding: &M,
+        weight: M::Target,
+    ) -> Self::TargetBuffer<M::Target>;
+
     /// `accumulator += weight * self`, lifted into the target field.
     fn mixed_scalar_mul_add_to<M: Embedding<Source = F>>(
         &self,

--- a/src/protocols/basecase.rs
+++ b/src/protocols/basecase.rs
@@ -132,10 +132,15 @@ impl<F: Field> Config<F> {
             .map_or_else(|| vec![witness], |b| vec![b, witness]);
         let _ = self.commit.open(prover_state, &witnesses);
 
-        let point = self
-            .sumcheck
-            .prove(prover_state, &mut vector, &mut covector, &mut sum, &[])
-            .round_challenges;
+        let (vector, opening) = self.sumcheck.prove(
+            prover_state,
+            &Identity::new(),
+            &vector,
+            &mut covector,
+            &mut sum,
+            &[],
+        );
+        let point = opening.round_challenges;
 
         // Negligible event over a challenge-sized field; without it the verifier
         // cannot derive `l(r) = sum / vector_mle(r)`.

--- a/src/protocols/basecase.rs
+++ b/src/protocols/basecase.rs
@@ -135,7 +135,7 @@ impl<F: Field> Config<F> {
         let (vector, opening) = self.sumcheck.prove(
             prover_state,
             &Identity::new(),
-            &vector,
+            vector,
             &mut covector,
             &mut sum,
             &[],

--- a/src/protocols/sumcheck.rs
+++ b/src/protocols/sumcheck.rs
@@ -527,6 +527,63 @@ mod tests {
         });
     }
 
+    /// The delayed lift's core claim: proving with a source-field `a` through
+    /// a real embedding is byte-identical (proof and outputs) to lifting `a`
+    /// up front and proving through `Identity`.
+    #[test]
+    fn mixed_prove_matches_lifted_transcript() {
+        use crate::algebra::{embedding::Basefield, fields::Field64_3, lift};
+        crate::tests::init();
+        let embedding = Basefield::<Field64_3>::new();
+        proptest!(|(seed: u64, config in Config::<Field64_3>::arbitrary())| {
+            let instance = U64(seed);
+            let ds = DomainSeparator::protocol(&config)
+                .session(&format!("Mixed vs lifted at {}:{}", file!(), line!()))
+                .instance(&instance);
+            let mut rng = StdRng::seed_from_u64(seed);
+            let a_source: Vec<Field64> = random_vector(&mut rng, config.initial_size);
+            let covector: Vec<Field64_3> = random_vector(&mut rng, config.initial_size);
+            let masks: Vec<Field64_3> =
+                random_vector(&mut rng, config.mask_length() * config.num_rounds);
+            let a_lifted = lift(&embedding, &a_source);
+            let initial_sum = dot(&a_lifted, &covector);
+
+            let run = |mixed: bool| {
+                let mut b = Buffer::from(covector.as_slice());
+                let mut sum = initial_sum;
+                let mut prover_state = ProverState::new_std(&ds);
+                let (folded, opening) = if mixed {
+                    config.prove(
+                        &mut prover_state,
+                        &embedding,
+                        &Buffer::from(a_source.as_slice()),
+                        &mut b,
+                        &mut sum,
+                        &masks,
+                    )
+                } else {
+                    config.prove(
+                        &mut prover_state,
+                        &Identity::new(),
+                        &Buffer::from(a_lifted.as_slice()),
+                        &mut b,
+                        &mut sum,
+                        &masks,
+                    )
+                };
+                (
+                    prover_state.proof(),
+                    folded.into_vec(),
+                    b.into_vec(),
+                    sum,
+                    opening.round_challenges,
+                    opening.mask_rlc,
+                )
+            };
+            assert_eq!(run(true), run(false));
+        });
+    }
+
     #[test]
     fn test_single_round() {
         test_config(

--- a/src/protocols/sumcheck.rs
+++ b/src/protocols/sumcheck.rs
@@ -1,6 +1,6 @@
 //! Quadratic sumcheck protocol.
 
-use std::fmt;
+use std::{any::Any, fmt};
 
 use ark_ff::Field;
 use ark_std::rand::{CryptoRng, RngCore};
@@ -144,8 +144,9 @@ impl<F: Field> Config<F> {
     /// its target field `F`; pass `&Identity::new()` when both coincide. `a`
     /// stays in the source field until the first fold lifts it into the target
     /// field, so the first round's polynomial and fold run as source × target
-    /// products. The transcript is bit-identical to lifting `a` up front (the
-    /// embedding is a ring homomorphism).
+    /// products. When the fields coincide the first fold happens in place, so
+    /// no second buffer is held alongside `a`. The transcript is bit-identical
+    /// to lifting `a` up front (the embedding is a ring homomorphism).
     ///
     /// This function:
     /// - Samples random values to progressively reduce the polynomial.
@@ -156,7 +157,7 @@ impl<F: Field> Config<F> {
         &self,
         prover_state: &mut ProverState<H, R>,
         embedding: &M,
-        a: &Buffer<M::Source>,
+        a: Buffer<M::Source>,
         b: &mut Buffer<F>,
         sum: &mut F,
         masks: &[F],
@@ -179,13 +180,28 @@ impl<F: Field> Config<F> {
         let half = F::from(2).inverse().unwrap();
         let polynomial_len = self.mask_length().max(3);
 
+        // First fold: `a` crosses from the source to the target field. When
+        // the fields coincide (`Identity`) fold in place; only a genuine
+        // base → ext crossing allocates the target buffer while the source
+        // one is still alive.
+        let first_fold = |a: Buffer<M::Source>, w: F| -> Buffer<F> {
+            match same_field_buffer::<M>(a) {
+                Ok(mut same_field) => {
+                    same_field.fold(w);
+                    same_field
+                }
+                Err(a) => a.mixed_fold(embedding, w),
+            }
+        };
+
         let (mut mask_sum, mask_rlc) = self.maybe_send_initial_mask_sum(prover_state, masks);
 
         let mut univariate = Vec::with_capacity(polynomial_len);
         let mut round_challenges = Vec::with_capacity(self.num_rounds);
         let mut prev_round_challenge = None;
-        // `a` remains in the source field until the first fold; `a_folded`
-        // holds the target-field buffer from then on.
+        // `a` remains in the source field until the first fold consumes it;
+        // `a_folded` holds the target-field buffer from then on.
+        let mut a = Some(a);
         let mut a_folded: Option<Buffer<F>> = None;
         for (round, mask) in
             chunks_exact_or_empty(masks, self.mask_length(), self.num_rounds).enumerate()
@@ -195,13 +211,15 @@ impl<F: Field> Config<F> {
                 let w = prev_round_challenge.expect("folded buffer implies a prior challenge");
                 folded.fold_pair_sumcheck_polynomial(b, w)
             } else if let Some(w) = prev_round_challenge {
-                // First fold: `a` crosses from the source to the target field.
-                let folded = a.mixed_fold(embedding, w);
+                let folded = first_fold(a.take().expect("source buffer consumed once"), w);
                 b.fold(w);
                 let coefficients = folded.sumcheck_polynomial(b);
                 a_folded = Some(folded);
                 coefficients
             } else {
+                let a = a
+                    .as_ref()
+                    .expect("source buffer available before the first fold");
                 a.mixed_sumcheck_polynomial(embedding, b)
             };
             let c1 = *sum - c0.double() - c2;
@@ -239,13 +257,16 @@ impl<F: Field> Config<F> {
             }
             (None, Some(w)) => {
                 // Single-round case: the only fold is the source → target one.
-                let folded = a.mixed_fold(embedding, w);
+                let folded = first_fold(a.take().expect("source buffer consumed once"), w);
                 b.fold(w);
                 folded
             }
             // No rounds: nothing folds, but the caller still expects a
-            // target-field buffer.
-            (None, None) => Buffer::from(lift(embedding, a.to_slice())),
+            // target-field buffer. Cold path; a plain lift is fine.
+            (None, None) => {
+                let a = a.take().expect("source buffer consumed once");
+                Buffer::from(lift(embedding, a.to_slice()))
+            }
             (Some(_), None) => unreachable!("folded buffer implies a prior challenge"),
         };
 
@@ -378,6 +399,18 @@ impl<F: Field> fmt::Display for Config<F> {
 }
 
 // Evaluated a univariate as p(0) + p(1)
+/// If the embedding's source and target fields coincide (e.g. `Identity`),
+/// recover the source buffer as a target-field buffer without copying;
+/// otherwise hand the buffer back.
+fn same_field_buffer<M: Embedding>(
+    a: Buffer<M::Source>,
+) -> Result<Buffer<M::Target>, Buffer<M::Source>> {
+    match (Box::new(a) as Box<dyn Any>).downcast::<Buffer<M::Target>>() {
+        Ok(same_field) => Ok(*same_field),
+        Err(a) => Err(*a.downcast::<Buffer<M::Source>>().expect("roundtrip")),
+    }
+}
+
 fn eval_01<F: Field>(coefficients: &[F]) -> F {
     if coefficients.is_empty() {
         return F::ZERO;
@@ -465,7 +498,7 @@ mod tests {
         ) = config.prove(
             &mut prover_state,
             &Identity::new(),
-            &vector,
+            vector,
             &mut covector,
             &mut sum,
             &masks,
@@ -556,7 +589,7 @@ mod tests {
                     config.prove(
                         &mut prover_state,
                         &embedding,
-                        &Buffer::from(a_source.as_slice()),
+                        Buffer::from(a_source.as_slice()),
                         &mut b,
                         &mut sum,
                         &masks,
@@ -565,7 +598,7 @@ mod tests {
                     config.prove(
                         &mut prover_state,
                         &Identity::new(),
-                        &Buffer::from(a_lifted.as_slice()),
+                        Buffer::from(a_lifted.as_slice()),
                         &mut b,
                         &mut sum,
                         &masks,

--- a/src/protocols/sumcheck.rs
+++ b/src/protocols/sumcheck.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::{
-    algebra::univariate_evaluate,
+    algebra::{embedding::Embedding, lift, univariate_evaluate},
     buffer::{Buffer, BufferMath, BufferOps},
     protocols::proof_of_work,
     transcript::{
@@ -137,23 +137,32 @@ impl<F: Field> Config<F> {
     /// Runs the quadratic sumcheck protocol as configured.
     ///
     /// It reduces a claim of the form `dot(a, b) == sum` to an exponentially
-    /// smaller claim `dot(a', b') == sum'` where `a'` is `a` folded in place
-    /// and similarly for `b`.
+    /// smaller claim `dot(a', b') == sum'`, returning the folded `a'` (with
+    /// `b` folded in place).
+    ///
+    /// `a` lives in the embedding's source field, `b` (and the transcript) in
+    /// its target field `F`; pass `&Identity::new()` when both coincide. `a`
+    /// stays in the source field until the first fold lifts it into the target
+    /// field, so the first round's polynomial and fold run as source × target
+    /// products. The transcript is bit-identical to lifting `a` up front (the
+    /// embedding is a ring homomorphism).
     ///
     /// This function:
     /// - Samples random values to progressively reduce the polynomial.
     /// - Applies proof-of-work grinding if required.
     /// - Returns the sampled folding randomness values used in each reduction step.
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
-    pub fn prove<H, R>(
+    pub fn prove<M, H, R>(
         &self,
         prover_state: &mut ProverState<H, R>,
-        a: &mut Buffer<F>,
+        embedding: &M,
+        a: &Buffer<M::Source>,
         b: &mut Buffer<F>,
         sum: &mut F,
         masks: &[F],
-    ) -> SumcheckOpening<F>
+    ) -> (Buffer<F>, SumcheckOpening<F>)
     where
+        M: Embedding<Target = F>,
         H: DuplexSpongeInterface,
         R: CryptoRng + RngCore,
         F: Codec<[H::U]>,
@@ -165,7 +174,7 @@ impl<F: Field> Config<F> {
         );
         assert_eq!(a.len(), self.initial_size);
         assert_eq!(b.len(), self.initial_size);
-        debug_assert_eq!(a.dot(b), *sum);
+        debug_assert_eq!(a.mixed_dot(embedding, b), *sum);
         assert_eq!(masks.len(), self.num_rounds * self.mask_length());
         let half = F::from(2).inverse().unwrap();
         let polynomial_len = self.mask_length().max(3);
@@ -175,14 +184,25 @@ impl<F: Field> Config<F> {
         let mut univariate = Vec::with_capacity(polynomial_len);
         let mut round_challenges = Vec::with_capacity(self.num_rounds);
         let mut prev_round_challenge = None;
+        // `a` remains in the source field until the first fold; `a_folded`
+        // holds the target-field buffer from then on.
+        let mut a_folded: Option<Buffer<F>> = None;
         for (round, mask) in
             chunks_exact_or_empty(masks, self.mask_length(), self.num_rounds).enumerate()
         {
             // Fold and compute sumcheck polynomial in one pass.
-            let (c0, c2) = if let Some(w) = prev_round_challenge {
-                a.fold_pair_sumcheck_polynomial(b, w)
+            let (c0, c2) = if let Some(folded) = a_folded.as_mut() {
+                let w = prev_round_challenge.expect("folded buffer implies a prior challenge");
+                folded.fold_pair_sumcheck_polynomial(b, w)
+            } else if let Some(w) = prev_round_challenge {
+                // First fold: `a` crosses from the source to the target field.
+                let folded = a.mixed_fold(embedding, w);
+                b.fold(w);
+                let coefficients = folded.sumcheck_polynomial(b);
+                a_folded = Some(folded);
+                coefficients
             } else {
-                a.sumcheck_polynomial(b)
+                a.mixed_sumcheck_polynomial(embedding, b)
             };
             let c1 = *sum - c0.double() - c2;
 
@@ -211,16 +231,32 @@ impl<F: Field> Config<F> {
             mask_sum = univariate_evaluate(&univariate, r) - mask_rlc * *sum;
             prev_round_challenge = Some(r);
         }
-        if let Some(w) = prev_round_challenge {
-            // Final fold of the inputs (no polynomial computation).
-            a.fold_pair(b, w);
-        }
+        // Final fold of the inputs (no polynomial computation).
+        let a_folded = match (a_folded, prev_round_challenge) {
+            (Some(mut folded), Some(w)) => {
+                folded.fold_pair(b, w);
+                folded
+            }
+            (None, Some(w)) => {
+                // Single-round case: the only fold is the source → target one.
+                let folded = a.mixed_fold(embedding, w);
+                b.fold(w);
+                folded
+            }
+            // No rounds: nothing folds, but the caller still expects a
+            // target-field buffer.
+            (None, None) => Buffer::from(lift(embedding, a.to_slice())),
+            (Some(_), None) => unreachable!("folded buffer implies a prior challenge"),
+        };
 
         *sum = mask_sum + mask_rlc * *sum;
-        SumcheckOpening {
-            round_challenges,
-            mask_rlc,
-        }
+        (
+            a_folded,
+            SumcheckOpening {
+                round_challenges,
+                mask_rlc,
+            },
+        )
     }
 
     fn maybe_send_initial_mask_sum<H, R>(
@@ -364,6 +400,7 @@ mod tests {
     use crate::{
         algebra::{
             dot,
+            embedding::Identity,
             fields::{self, Field64},
             multilinear_extend, random_vector,
         },
@@ -415,16 +452,20 @@ mod tests {
         let masks = random_vector(&mut rng, config.mask_length() * config.num_rounds);
 
         // Prover
-        let mut vector = Buffer::from(initial_vector.as_slice());
+        let vector = Buffer::from(initial_vector.as_slice());
         let mut covector = Buffer::from(initial_covector.as_slice());
         let mut sum = initial_sum;
         let mut prover_state = ProverState::new_std(&ds);
-        let SumcheckOpening {
-            round_challenges: point,
-            mask_rlc,
-        } = config.prove(
+        let (
+            vector,
+            SumcheckOpening {
+                round_challenges: point,
+                mask_rlc,
+            },
+        ) = config.prove(
             &mut prover_state,
-            &mut vector,
+            &Identity::new(),
+            &vector,
             &mut covector,
             &mut sum,
             &masks,

--- a/src/protocols/whir/prover.rs
+++ b/src/protocols/whir/prover.rs
@@ -5,7 +5,10 @@ use tracing::instrument;
 
 use super::{Config, Witness};
 use crate::{
-    algebra::{embedding::Embedding, linear_form::LinearForm},
+    algebra::{
+        embedding::{Embedding, Identity},
+        linear_form::LinearForm,
+    },
     buffer::{Buffer, BufferMath, BufferOps},
     hash::Hash,
     protocols::{
@@ -179,9 +182,16 @@ impl<M: Embedding> Config<M> {
 
         // Run initial sumcheck on batched vectors with combined statement
         let mut folding_randomness = if has_constraints {
-            self.initial_sumcheck
-                .prove(prover_state, &mut vector, &mut covector, &mut the_sum, &[])
-                .round_challenges
+            let (folded, opening) = self.initial_sumcheck.prove(
+                prover_state,
+                &Identity::new(),
+                &vector,
+                &mut covector,
+                &mut the_sum,
+                &[],
+            );
+            vector = folded;
+            opening.round_challenges
         } else {
             // There are no constraints yet, so we can skip the sumcheck.
             // (If we did run it, all sumcheck vectors would be constant zero)
@@ -248,10 +258,16 @@ impl<M: Embedding> Config<M> {
             debug_assert_eq!(vector.dot(&covector), the_sum);
 
             // Run sumcheck for this round
-            folding_randomness = round_config
-                .sumcheck
-                .prove(prover_state, &mut vector, &mut covector, &mut the_sum, &[])
-                .round_challenges;
+            let (folded, opening) = round_config.sumcheck.prove(
+                prover_state,
+                &Identity::new(),
+                &vector,
+                &mut covector,
+                &mut the_sum,
+                &[],
+            );
+            vector = folded;
+            folding_randomness = opening.round_challenges;
 
             evaluation_point.extend(folding_randomness.iter().copied());
             debug_assert_eq!(vector.dot(&covector), the_sum);
@@ -284,10 +300,15 @@ impl<M: Embedding> Config<M> {
         }
 
         // Final sumcheck
-        let final_folding_randomness = self
-            .final_sumcheck
-            .prove(prover_state, &mut vector, &mut covector, &mut the_sum, &[])
-            .round_challenges;
+        let (_, opening) = self.final_sumcheck.prove(
+            prover_state,
+            &Identity::new(),
+            &vector,
+            &mut covector,
+            &mut the_sum,
+            &[],
+        );
+        let final_folding_randomness = opening.round_challenges;
         evaluation_point.extend(final_folding_randomness.iter().copied());
 
         FinalClaim {

--- a/src/protocols/whir/prover.rs
+++ b/src/protocols/whir/prover.rs
@@ -185,7 +185,7 @@ impl<M: Embedding> Config<M> {
             let (folded, opening) = self.initial_sumcheck.prove(
                 prover_state,
                 &Identity::new(),
-                &vector,
+                vector,
                 &mut covector,
                 &mut the_sum,
                 &[],
@@ -261,7 +261,7 @@ impl<M: Embedding> Config<M> {
             let (folded, opening) = round_config.sumcheck.prove(
                 prover_state,
                 &Identity::new(),
-                &vector,
+                vector,
                 &mut covector,
                 &mut the_sum,
                 &[],
@@ -303,7 +303,7 @@ impl<M: Embedding> Config<M> {
         let (_, opening) = self.final_sumcheck.prove(
             prover_state,
             &Identity::new(),
-            &vector,
+            vector,
             &mut covector,
             &mut the_sum,
             &[],

--- a/src/protocols/zook/commit.rs
+++ b/src/protocols/zook/commit.rs
@@ -31,8 +31,10 @@ pub struct CommittedWitness<M: Embedding> {
 #[derive(Clone, Debug)]
 pub(crate) enum CommittedState<M: Embedding> {
     /// Plan has ≥ 1 round; committed through `rounds[0].code_switch.source`.
+    /// The message stays in `M::Source`: the first round's sumcheck lifts it
+    /// into `M::Target` at its first fold.
     Round {
-        message: Vec<M::Target>,
+        message: Vec<M::Source>,
         irs_witness: IrsWitness<M::Source>,
     },
     /// Basecase-only plan; witness was lifted into `M::Target` first.
@@ -73,9 +75,8 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
         let state = if let Some(round) = self.first_round() {
             let witness_buffer = Buffer::from(witness);
             let irs_witness = round.code_switch().source().commit(ps, &[&witness_buffer]);
-            let message = lift(round.code_switch().source().embedding(), witness);
             CommittedState::Round {
-                message,
+                message: witness.to_vec(),
                 irs_witness,
             }
         } else {

--- a/src/protocols/zook/prover.rs
+++ b/src/protocols/zook/prover.rs
@@ -227,7 +227,7 @@ where
     let (message_buf, opening) = round.sumcheck().prove(
         ps,
         embedding,
-        &message_buf,
+        message_buf,
         &mut covector_buf,
         &mut sum,
         masker.sumcheck_blinding(),

--- a/src/protocols/zook/prover.rs
+++ b/src/protocols/zook/prover.rs
@@ -215,15 +215,17 @@ where
     // cs_fresh_padding is pre-sampled here because it does not depend on folding randomness.
     let mut masker = RoundMaskOracle::begin(round, ps);
 
-    // Sumcheck folds its buffers in place. Move the host-side round state into
-    // buffers, fold, and move the folded result back into the `Vec` state
-    // (which downstream steps resize/truncate/index directly). Both hops are
-    // zero-copy on the CPU backend.
-    let mut message_buf = Buffer::from(message);
+    // Sumcheck returns the folded message buffer (and folds the covector in
+    // place). Move the host-side round state into buffers, fold, and move the
+    // folded result back into the `Vec` state (which downstream steps
+    // resize/truncate/index directly). The hops are zero-copy on the CPU
+    // backend.
+    let message_buf = Buffer::from(message);
     let mut covector_buf = Buffer::from(covector);
-    let opening = round.sumcheck().prove(
+    let (message_buf, opening) = round.sumcheck().prove(
         ps,
-        &mut message_buf,
+        &Identity::new(),
+        &message_buf,
         &mut covector_buf,
         &mut sum,
         masker.sumcheck_blinding(),

--- a/src/protocols/zook/prover.rs
+++ b/src/protocols/zook/prover.rs
@@ -52,7 +52,7 @@ use crate::{
         embedding::{Embedding, Identity},
         geometric_sequence,
         linear_form::LinearForm,
-        random_vector, univariate_evaluate,
+        mixed_dot, random_vector, univariate_evaluate,
     },
     buffer::{Buffer, BufferOps},
     hash::Hash,
@@ -166,12 +166,13 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
     }
 }
 
-/// Per-round transient state: `message`/`covector`/`sum` in `M::Target`, the
-/// witness in `M::Source`. The code-switch turns the source witness into an
-/// `M::Target` one, so [`prove_round`] maps `ProverRoundState<M>` to
+/// Per-round transient state: `covector`/`sum` in `M::Target`, the message and
+/// witness in `M::Source`. The round's sumcheck lifts the message into
+/// `M::Target` at its first fold and the code-switch turns the source witness
+/// into an `M::Target` one, so [`prove_round`] maps `ProverRoundState<M>` to
 /// `ProverRoundState<Identity<M::Target>>`.
 struct ProverRoundState<M: Embedding> {
-    message: Vec<M::Target>,
+    message: Vec<M::Source>,
     irs_witness: IrsWitness<M::Source>,
     covector: Vec<M::Target>,
     sum: M::Target,
@@ -205,8 +206,9 @@ where
         mut sum,
     } = state;
 
+    let embedding = round.code_switch().source().embedding();
     debug_assert_eq!(
-        dot(&message, &covector),
+        mixed_dot(embedding, &covector, &message),
         sum,
         "prove_round entry: dot(message, covector) must equal sum"
     );
@@ -215,16 +217,16 @@ where
     // cs_fresh_padding is pre-sampled here because it does not depend on folding randomness.
     let mut masker = RoundMaskOracle::begin(round, ps);
 
-    // Sumcheck returns the folded message buffer (and folds the covector in
-    // place). Move the host-side round state into buffers, fold, and move the
-    // folded result back into the `Vec` state (which downstream steps
-    // resize/truncate/index directly). The hops are zero-copy on the CPU
-    // backend.
+    // Sumcheck lifts the source-field message into `M::Target` at its first
+    // fold and returns the folded buffer (the covector folds in place). Move
+    // the host-side round state into buffers, fold, and move the folded result
+    // back into the `Vec` state (which downstream steps resize/truncate/index
+    // directly). The hops are zero-copy on the CPU backend.
     let message_buf = Buffer::from(message);
     let mut covector_buf = Buffer::from(covector);
     let (message_buf, opening) = round.sumcheck().prove(
         ps,
-        &Identity::new(),
+        embedding,
         &message_buf,
         &mut covector_buf,
         &mut sum,


### PR DESCRIPTION
## Summary

For round-bearing plans, zook's commit currently materializes `lift(witness)` and round 0 runs its sumcheck entirely in the extension field, even though the committed data is base-field. This keeps the message in `M::Source` until the first sumcheck fold, so the largest binding runs as base x ext products and the full-size ext message allocation disappears.

### Changes

- **Buffer / algebra** : `mixed_sumcheck_polynomial` and `mixed_fold` join the existing `mixed_*` family on `BufferMath`. Both mirror `compute_sumcheck_polynomial` / `fold` exactly (including implicit zero-extension of non-power-of-two inputs) and are proptested equal to lift-then-operate over `Basefield<Field64_3>`.
- **Sumcheck** : `Config::prove` is now generic over an embedding: `a` lives in `M::Source`, crosses into the target field at the first fold, and is returned (the covector still folds in place). Same-field callers (basecase, whir, zook tail rounds) pass `Identity`, which monomorphizes to the previous code.
- **Zook** : `CommittedState::Round` and `ProverRoundState` hold the message as `Vec<M::Source>`; `prove_round` hands the round's own embedding to sumcheck (`Basefield` for round 0, `Identity` for tails). Verifier untouched.

The transcript is bit-identical to eager lifting, since the embedding is a ring homomorphism. `mixed_prove_matches_lifted_transcript` pins this down: byte-equal proofs and outputs for `prove(Basefield, message)` vs `prove(Identity, lift(message))` across arbitrary configs (Standard and ZK, masks fixed).

### Measured effect (N=2^20, `Basefield<Field64_3>`, ZK, blake3, rate 1/4, fold 3/3, 3 claims, M-series MacBook)

- Peak RSS: ~299 MB -> ~290 MB (the 24 MB ext message is replaced by the 8 MB base one; the rest of the peak is codewords and Merkle trees).
- Commit no longer allocates or writes the lifted message.
- Prove time: unchanged within noise (~0.18 s). The mixed primitives are 3-6x faster than their ext counterparts (~2.3 ms -> ~0.75 ms polynomial, ~2.8 ms -> ~0.43 ms fold at 2^20), but the whole round-0 message side is only ~5 ms of the prove, so this is a memory and structure win, not a latency one.

## Notes For Reviewers

- `prove`'s signature change is the reason basecase and whir call sites appear in the diff; those edits are mechanical (`Identity`, rebind the returned buffer).
- With `num_rounds == 0` the sumcheck performs no fold, so `prove` falls back to a plain lift to keep returning a target-field buffer. Zook only hits this through basecase-only plans, which lift at commit as before.
- The pre-fold source buffer is dropped without wiping. The eager path had the same exposure class (in-place `fold` frees the truncated half via `shrink_to_fit`), so this does not regress hiding, but a `wipe()` could be added if we want stricter prover memory hygiene.
- Cross-branch check (not in-repo): a fixed-seed Standard-mode roundtrip hashes to the same proof bytes on main and on this branch. ZK proofs are run-to-run nondeterministic (mask sampling uses the entropy-seeded prover RNG), which is why the in-repo equivalence test fixes the masks instead.

## Test plan

- `cargo test --release` : full suite green (257 passed), including the Basefield roundtrips that now exercise the mixed path against the unchanged verifier.
- New tests: `mixed_sumcheck_poly_matches_lifted`, `mixed_fold_matches_lifted` (algebra-level proptests, lengths 0..2^10 incl. non-powers-of-two), `mixed_prove_matches_lifted_transcript` (transcript identity, arbitrary configs).
- `cargo clippy --all-targets` clean.
