### PR TITLE
Zook: return the final evaluation point from `prove`

### DIFF
--- a/src/protocols/zook/mod.rs
+++ b/src/protocols/zook/mod.rs
@@ -59,11 +59,20 @@ impl<F: ark_ff::Field> FinalClaim<F> {
     }
 }
 
+/// Values derived by [`ProtocolConfig::prove`] from the prover transcript.
+#[derive(Clone, Debug)]
+pub struct ProverClaim<F: ark_ff::Field> {
+    /// Sumcheck challenges followed by the basecase evaluation points.
+    pub evaluation_point: Vec<F>,
+    /// Fiat-Shamir RLC coefficients for the input forms.
+    pub rlc_coefficients: Vec<F>,
+}
+
 #[cfg(test)]
 mod tests {
     use ark_std::rand::{rngs::StdRng, SeedableRng};
 
-    use super::ProtocolConfig;
+    use super::{FinalClaim, ProtocolConfig, ProverClaim};
     use crate::{
         algebra::{
             embedding::{Basefield, Embedding, Identity},
@@ -127,19 +136,21 @@ mod tests {
             .instance(&EMPTY)
     }
 
-    /// Build a witness, compute true evaluations, prove, and return the proof
-    /// along with the domain separator, forms, and values for further checks.
+    struct Proven {
+        proof: crate::transcript::Proof,
+        ds: DomainSeparator<'static, Empty>,
+        forms: Vec<MultilinearExtension<SmallF>>,
+        values: Vec<SmallF>,
+        prover_claim: ProverClaim<SmallF>,
+    }
+
+    /// Build a witness, compute its evaluations, and prove them.
     fn build_and_prove(
         config: &ProtocolConfig<SmallEmbed>,
         num_claims: usize,
         seed: u64,
         label: &str,
-    ) -> (
-        crate::transcript::Proof,
-        DomainSeparator<'static, Empty>,
-        Vec<MultilinearExtension<SmallF>>,
-        Vec<SmallF>,
-    ) {
+    ) -> Proven {
         let embedding = <SmallEmbed as Default>::default();
         let mut rng = StdRng::seed_from_u64(seed);
         let witness = Buffer::<SmallF>::random(&mut rng, config.tuning().vector_size);
@@ -160,10 +171,16 @@ mod tests {
         let ds = make_ds(label);
         let mut ps = ProverState::new_std(&ds);
         let committed = config.commit(&mut ps, witness);
-        config.prove(&mut ps, committed, &form_refs, &values);
+        let prover_claim = config.prove(&mut ps, committed, &form_refs, &values);
         let proof = ps.proof();
 
-        (proof, ds, forms, values)
+        Proven {
+            proof,
+            ds,
+            forms,
+            values,
+            prover_claim,
+        }
     }
 
     /// Run a full roundtrip: commit → prove → verify → FinalClaim::verify.
@@ -174,7 +191,13 @@ mod tests {
         seed: u64,
         label: &str,
     ) {
-        let (proof, ds, forms, values) = build_and_prove(config, num_claims, seed, label);
+        let Proven {
+            proof,
+            ds,
+            forms,
+            values,
+            prover_claim,
+        } = build_and_prove(config, num_claims, seed, label);
         let form_refs: Vec<&dyn LinearForm<SmallF>> =
             forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
 
@@ -184,7 +207,22 @@ mod tests {
             .verify(&mut vs, commitment, &form_refs, &values)
             .unwrap();
         claim.verify(&form_refs).expect("FinalClaim::verify failed");
+        assert_prover_claim_matches(&prover_claim, &claim);
         vs.check_eof().unwrap();
+    }
+
+    fn assert_prover_claim_matches<F: ark_ff::Field>(
+        prover_claim: &ProverClaim<F>,
+        claim: &FinalClaim<F>,
+    ) {
+        assert_eq!(
+            prover_claim.evaluation_point, claim.evaluation_point,
+            "prover and verifier evaluation points diverged"
+        );
+        assert_eq!(
+            prover_claim.rlc_coefficients, claim.rlc_coefficients,
+            "prover and verifier RLC coefficients diverged"
+        );
     }
 
     // ── Base-field embedding (witness over base prime field, claims over ext) ──
@@ -225,7 +263,7 @@ mod tests {
         let ds = make_ds(label);
         let mut ps = ProverState::new_std(&ds);
         let committed = config.commit(&mut ps, witness);
-        config.prove(&mut ps, committed, &form_refs, &values);
+        let prover_claim = config.prove(&mut ps, committed, &form_refs, &values);
         let proof = ps.proof();
 
         let mut vs = VerifierState::new_std(&ds, &proof);
@@ -234,6 +272,7 @@ mod tests {
             .verify(&mut vs, commitment, &form_refs, &values)
             .unwrap();
         claim.verify(&form_refs).expect("FinalClaim::verify failed");
+        assert_prover_claim_matches(&prover_claim, &claim);
         vs.check_eof().unwrap();
     }
 
@@ -380,8 +419,13 @@ mod tests {
             multi_round_tuning(),
         )
         .unwrap();
-        let (proof, ds, forms, true_values) =
-            build_and_prove(&config, 1, 10, "verify_rejects_wrong_evaluation_zk");
+        let Proven {
+            proof,
+            ds,
+            forms,
+            values: true_values,
+            ..
+        } = build_and_prove(&config, 1, 10, "verify_rejects_wrong_evaluation_zk");
 
         let form_refs: Vec<&dyn LinearForm<SmallF>> =
             forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
@@ -402,8 +446,13 @@ mod tests {
         let config =
             ProtocolConfig::<SmallEmbed>::derive(small_spec(Mode::Standard), multi_round_tuning())
                 .unwrap();
-        let (proof, ds, forms, true_values) =
-            build_and_prove(&config, 1, 11, "verify_rejects_wrong_evaluation_standard");
+        let Proven {
+            proof,
+            ds,
+            forms,
+            values: true_values,
+            ..
+        } = build_and_prove(&config, 1, 11, "verify_rejects_wrong_evaluation_standard");
 
         let form_refs: Vec<&dyn LinearForm<SmallF>> =
             forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
@@ -425,7 +474,13 @@ mod tests {
             multi_round_tuning(),
         )
         .unwrap();
-        let (proof, ds, forms, mut values) = build_and_prove(
+        let Proven {
+            proof,
+            ds,
+            forms,
+            mut values,
+            ..
+        } = build_and_prove(
             &config,
             3,
             12,
@@ -455,8 +510,13 @@ mod tests {
             multi_round_tuning(),
         )
         .unwrap();
-        let (proof, ds, forms, values) =
-            build_and_prove(&config, 1, 20, "final_claim_rejects_wrong_form");
+        let Proven {
+            proof,
+            ds,
+            forms,
+            values,
+            ..
+        } = build_and_prove(&config, 1, 20, "final_claim_rejects_wrong_form");
 
         let form_refs: Vec<&dyn LinearForm<SmallF>> =
             forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
@@ -486,8 +546,13 @@ mod tests {
             multi_round_tuning(),
         )
         .unwrap();
-        let (mut proof, ds, forms, values) =
-            build_and_prove(&config, 1, 30, "verify_rejects_tampered_proof");
+        let Proven {
+            mut proof,
+            ds,
+            forms,
+            values,
+            ..
+        } = build_and_prove(&config, 1, 30, "verify_rejects_tampered_proof");
 
         let form_refs: Vec<&dyn LinearForm<SmallF>> =
             forms.iter().map(|f| f as &dyn LinearForm<SmallF>).collect();
@@ -562,7 +627,7 @@ mod tests {
 
         let mut ps = ProverState::new_std(&ds);
         let committed = config.commit(&mut ps, witness);
-        config.prove(&mut ps, committed, &form_refs, &values);
+        let prover_claim = config.prove(&mut ps, committed, &form_refs, &values);
         let proof = ps.proof();
 
         let mut vs = VerifierState::new_std(&ds, &proof);
@@ -571,6 +636,7 @@ mod tests {
             .verify(&mut vs, commitment, &form_refs, &values)
             .unwrap();
         claim.verify(&form_refs).expect("FinalClaim::verify failed");
+        assert_prover_claim_matches(&prover_claim, &claim);
         vs.check_eof().unwrap();
     }
 

--- a/src/protocols/zook/prover.rs
+++ b/src/protocols/zook/prover.rs
@@ -63,7 +63,10 @@ use crate::{
         mask_proximity::Config as MaskProximityConfig,
         params::protocol_config::{MaskOracleConfig, ProtocolConfig, RoundConfig},
         sumcheck::{SumcheckMode, SumcheckOpening},
-        zook::commit::{CommittedState, CommittedWitness},
+        zook::{
+            commit::{CommittedState, CommittedWitness},
+            ProverClaim,
+        },
     },
     transcript::{
         codecs::U64, Codec, Decoding, DuplexSpongeInterface, ProverMessage, ProverState,
@@ -78,6 +81,7 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
     /// Round 0's code-switch folds the base witness (`IrsWitness<M::Source>`)
     /// into an ext IRS, so only it is embedding-aware; later rounds are ext→ext.
     /// Message, covector, and sum are in `M::Target` throughout.
+    /// Returns the transcript-derived evaluation point and RLC coefficients.
     #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::prove", fields(vector_size = self.tuning().vector_size, num_rounds = self.num_rounds(), num_claims = linear_forms.len())))]
     pub fn prove<H, R>(
         &self,
@@ -85,7 +89,8 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
         committed: CommittedWitness<M>,
         linear_forms: &[&dyn LinearForm<M::Target>],
         evaluations: &[M::Target],
-    ) where
+    ) -> ProverClaim<M::Target>
+    where
         M::Target: Field + Default + Zeroize + Codec<[H::U]>,
         Standard: Distribution<M::Target>,
         H: DuplexSpongeInterface,
@@ -122,14 +127,20 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
             .sum();
         let covector = Buffer::from(covector);
 
-        // Reduce to basecase inputs `(message, witness, covector, sum)`. The
-        // two arms differ only in how those are obtained.
-        let (message, basecase_witness, covector, sum) = match committed.state {
+        // Reduce to basecase inputs while retaining the round challenges.
+        let (message, basecase_witness, covector, sum, mut evaluation_point) = match committed.state
+        {
             // Basecase-only plan: use the committed witness directly.
             CommittedState::Basecase {
                 message,
                 irs_witness,
-            } => (message, irs_witness, covector, batched_evaluation),
+            } => (
+                message,
+                irs_witness,
+                covector,
+                batched_evaluation,
+                Vec::new(),
+            ),
             CommittedState::Round {
                 message,
                 irs_witness,
@@ -139,6 +150,7 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
                     irs_witness,
                     covector,
                     sum: batched_evaluation,
+                    all_round_challenges: Vec::new(),
                 };
                 let first = self
                     .first_round()
@@ -150,16 +162,34 @@ impl<M: Embedding + Default> ProtocolConfig<M> {
                 // After per-round reconciliation, state.sum is bound to
                 // dot(state.message, state.covector) — no extra transcript
                 // send needed entering basecase.
-                (state.message, state.irs_witness, state.covector, state.sum)
+                (
+                    state.message,
+                    state.irs_witness,
+                    state.covector,
+                    state.sum,
+                    state.all_round_challenges,
+                )
             }
         };
 
         // Standard mode (BasecaseMode::Standard) sends the full witness vector
         // and IRS randomness cleartext. Only call with Mode::ZeroKnowledge if
         // end-to-end hiding is required.
-        let _ = self
+        let basecase_opening = self
             .basecase()
             .prove(ps, message, &basecase_witness, covector, sum);
+
+        evaluation_point.extend(basecase_opening.evaluation_points);
+        debug_assert_eq!(
+            evaluation_point.len(),
+            self.tuning().vector_size.trailing_zeros() as usize,
+            "evaluation_point length must equal log2(vector_size)"
+        );
+
+        ProverClaim {
+            evaluation_point,
+            rlc_coefficients: claim_weights,
+        }
     }
 }
 
@@ -173,6 +203,8 @@ struct ProverRoundState<M: Embedding> {
     irs_witness: IrsWitness<M::Source>,
     covector: Buffer<M::Target>,
     sum: M::Target,
+    // Sumcheck challenges from completed rounds, in transcript order.
+    all_round_challenges: Vec<M::Target>,
 }
 
 #[cfg_attr(feature = "tracing", instrument(skip_all, name = "zook::prove_round", fields(msg_len = round.code_switch().source().message_length(), message_len = state.message.len())))]
@@ -201,6 +233,7 @@ where
         irs_witness,
         mut covector,
         mut sum,
+        mut all_round_challenges,
     } = state;
 
     let embedding = round.code_switch().source().embedding();
@@ -224,6 +257,7 @@ where
         &mut sum,
         masker.sumcheck_blinding(),
     );
+    all_round_challenges.extend_from_slice(&opening.round_challenges);
 
     // Build cs_mask = (folded_irs_masks ‖ cs_fresh_padding), commit its tree,
     // send mask_eval_sum cleartext, reconcile sum to the unmasked dot.
@@ -274,6 +308,7 @@ where
         irs_witness: cs_witness.target_witness,
         covector,
         sum,
+        all_round_challenges,
     }
 }
 


### PR DESCRIPTION
Stacked on #270 — review that first; this PR's diff is only the last commit.

## What

`ProtocolConfig::prove` currently returns `()` and discards everything the transcript derived, so a caller that wants to continue reasoning about the proof (e.g. wiring Zook into an outer protocol, or checking prover/verifier agreement in tests) has no way to get at the final evaluation point. This PR returns it.

`prove` now returns a `ProverClaim<F>`:

```rust
pub struct ProverClaim<F: ark_ff::Field> {
    /// Sumcheck challenges followed by the basecase evaluation points.
    pub evaluation_point: Vec<F>,
    /// Fiat-Shamir RLC coefficients for the input forms.
    pub rlc_coefficients: Vec<F>,
}
```

These are the prover-side mirror of the `FinalClaim` fields the verifier already returns.

## How

- `ProverRoundState` gains `all_round_challenges: Vec<M::Target>`, accumulating each round's sumcheck challenges in transcript order.
- After the rounds, the basecase opening's `evaluation_points` are appended, giving the full point in the same order the verifier reconstructs it.
- A `debug_assert` pins `evaluation_point.len() == log2(vector_size)`.
- The basecase opening was previously bound to `let _ =`; it is now used.

## Tests

- `build_and_prove` returns a `Proven` struct instead of a 4-tuple — the tuple was already 4 fields wide and this adds a 5th.
- Roundtrip tests assert the prover's `evaluation_point` and `rlc_coefficients` match the verifier's `FinalClaim`, so a divergence between the two sides fails loudly rather than silently.

`cargo test zook` → 21 passed. `cargo fmt --check` and `cargo clippy --all-targets` clean.

